### PR TITLE
feat: add step-by-step loading progress view for PR fetching

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -34,7 +34,7 @@ pub fn get_initial_manifest_path(state: State<AppState>) -> Option<String> {
 }
 
 #[command]
-pub async fn fetch_pr(pr_ref: String) -> Result<ReviewManifest, String> {
+pub async fn fetch_pr(app: tauri::AppHandle, pr_ref: String) -> Result<ReviewManifest, String> {
     let settings = load_settings();
-    fetch_pr_impl(&pr_ref, &settings).await
+    fetch_pr_impl(&pr_ref, &settings, &app).await
 }

--- a/app/src-tauri/src/fetch.rs
+++ b/app/src-tauri/src/fetch.rs
@@ -4,11 +4,32 @@ use crate::github::GithubClient;
 use crate::pr_parser::parse_pr_ref;
 use crate::prompts::{build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt};
 use crate::types::{
-    ChangeGroup, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, Settings,
+    ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, Settings,
 };
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::HashMap;
+use tauri::Emitter;
 
-pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewManifest, String> {
+fn emit_progress(
+    app: &tauri::AppHandle,
+    step: u8,
+    label: &str,
+    status: FetchStatus,
+    pr_title: Option<&str>,
+    files: Option<(u32, u32)>,
+) {
+    let _ = app.emit("fetch-progress", FetchProgress {
+        step,
+        total_steps: 6,
+        label: label.to_string(),
+        status,
+        pr_title: pr_title.map(|s| s.to_string()),
+        files_done: files.map(|(d, _)| d),
+        files_total: files.map(|(_, t)| t),
+    });
+}
+
+pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: &tauri::AppHandle) -> Result<ReviewManifest, String> {
     if settings.model.is_empty() {
         return Err("No model ARN configured. Set it in Settings.".to_string());
     }
@@ -19,11 +40,12 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     let github = GithubClient::new(token);
 
     // Step 1: Fetch PR metadata
+    emit_progress(app, 1, "Fetching PR metadata", FetchStatus::Running, None, None);
     let metadata = github
         .get_pr_metadata(&parsed.owner, &parsed.repo, parsed.number)
         .await?;
-
     let pr_title = metadata.title;
+    emit_progress(app, 1, "Fetching PR metadata", FetchStatus::Done, Some(&pr_title), None);
     let pr_url = metadata.html_url;
     let pr_number = metadata.number;
     let base_ref = metadata.base.ref_name;
@@ -32,6 +54,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     let head_sha = metadata.head.sha;
 
     // Step 2: Fetch PR file list and diff in parallel
+    emit_progress(app, 2, "Fetching files and diff", FetchStatus::Running, None, None);
     let (files_result, diff_result) = tokio::join!(
         github.get_pr_files(&parsed.owner, &parsed.repo, parsed.number),
         github.get_pr_diff(&parsed.owner, &parsed.repo, parsed.number),
@@ -39,6 +62,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
 
     let pr_files = files_result?;
     let full_diff = diff_result?;
+    emit_progress(app, 2, "Fetching files and diff", FetchStatus::Done, None, None);
 
     if pr_files.is_empty() {
         return Err("No changed files found in this PR.".to_string());
@@ -53,6 +77,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
         .collect();
 
     // Step 3: AI classification
+    emit_progress(app, 3, "Classifying files with AI", FetchStatus::Running, None, None);
     let region = region_from_arn(&settings.model)?;
     let bedrock = BedrockClient::new(&region, &settings.aws_profile).await?;
 
@@ -66,6 +91,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     let classification_json = extract_json_array(&classification_raw)?;
     let classifications: Vec<FileClassification> = serde_json::from_value(classification_json)
         .map_err(|e| format!("Failed to parse classification: {}", e))?;
+    emit_progress(app, 3, "Classifying files with AI", FetchStatus::Done, None, None);
 
     let relevant: Vec<&FileClassification> = classifications
         .iter()
@@ -88,6 +114,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     }
 
     // Step 4: AI highlight analysis + summary + grouping (parallel)
+    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
     let per_file_diff_map = build_per_file_diff_map(&full_diff);
     let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
     let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
@@ -95,11 +122,27 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     let summary_prompt = build_summary_prompt(&pr_title, &relevant);
     let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
 
-    let (highlights_raw, summary_raw, grouping_raw) = tokio::join!(
-        bedrock.invoke_model(&settings.model, &highlight_prompt),
-        bedrock.invoke_model(&settings.model, &summary_prompt),
-        bedrock.invoke_model(&settings.model, &grouping_prompt),
-    );
+    let mut ai_stream: FuturesUnordered<_> = [
+        ("highlights", bedrock.invoke_model(&settings.model, &highlight_prompt)),
+        ("summary", bedrock.invoke_model(&settings.model, &summary_prompt)),
+        ("grouping", bedrock.invoke_model(&settings.model, &grouping_prompt)),
+    ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
+
+    let mut highlights_raw = Err("not started".to_string());
+    let mut summary_raw = Err("not started".to_string());
+    let mut grouping_raw = Err("not started".to_string());
+    let mut ai_done: u32 = 0;
+    while let Some((name, result)) = ai_stream.next().await {
+        ai_done += 1;
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
+        match name {
+            "highlights" => highlights_raw = result,
+            "summary" => summary_raw = result,
+            "grouping" => grouping_raw = result,
+            _ => {}
+        }
+    }
+    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Done, None, None);
 
     let highlights_raw = highlights_raw.unwrap_or_else(|_| "[]".to_string());
 
@@ -133,6 +176,8 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
     }
 
     // Step 5: Fetch file contents for all relevant files concurrently
+    let files_total = relevant.len() as u32;
+    emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((0, files_total)));
     let content_futures: Vec<_> = relevant
         .iter()
         .map(|f| {
@@ -151,9 +196,19 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
             }
         })
         .collect();
-    let contents = futures::future::join_all(content_futures).await;
+
+    let mut stream: FuturesUnordered<_> = content_futures.into_iter().collect();
+    let mut contents = Vec::with_capacity(files_total as usize);
+    let mut files_done: u32 = 0;
+    while let Some(result) = stream.next().await {
+        files_done += 1;
+        emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((files_done, files_total)));
+        contents.push(result);
+    }
+    emit_progress(app, 5, "Fetching file contents", FetchStatus::Done, None, None);
 
     // Step 6: Build the manifest
+    emit_progress(app, 6, "Building review manifest", FetchStatus::Running, None, None);
     let mut file_diffs = Vec::new();
 
     for (path, base_result, head_result) in &contents {
@@ -196,6 +251,8 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings) -> Result<ReviewMa
             highlights: highlights_by_path.remove(path.as_str()).unwrap_or_default(),
         });
     }
+
+    emit_progress(app, 6, "Building review manifest", FetchStatus::Done, None, None);
 
     Ok(ReviewManifest {
         pr_title,

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -1,6 +1,27 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum FetchStatus {
+    Running,
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FetchProgress {
+    pub step: u8,
+    pub total_steps: u8,
+    pub label: String,
+    pub status: FetchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_done: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files_total: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Highlight {
     pub start_line: u64,
     pub end_line: u64,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
 import { DiffViewer } from "./components/DiffViewer";
 import { Header } from "./components/Header";
 import { PrOpener } from "./components/PrOpener";
+import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress } from "./types";
 
 function App() {
   const nextTabId = useRef(1);
@@ -16,6 +18,11 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [showOpener, setShowOpener] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingPrRef, setLoadingPrRef] = useState("");
+  const [loadingPrTitle, setLoadingPrTitle] = useState<string | null>(null);
+  const [progress, setProgress] = useState<FetchProgress | null>(null);
+  const [fileCounts, setFileCounts] = useState<Record<number, { done: number; total: number }>>({});
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
 
@@ -51,6 +58,54 @@ function App() {
     setActiveTabId(tab.id);
     setShowOpener(false);
     setError(null);
+  }
+
+  const unlistenRef = useRef<(() => void) | null>(null);
+
+  async function handleFetchStart(prRef: string) {
+    if (loading) return;
+    setLoading(true);
+    setLoadingPrRef(prRef);
+    setLoadingPrTitle(null);
+    setProgress(null);
+    setFileCounts({});
+    setError(null);
+
+    const unlisten = await listen<FetchProgress>("fetch-progress", (event) => {
+      setProgress(event.payload);
+      if (event.payload.pr_title) {
+        setLoadingPrTitle(event.payload.pr_title);
+      }
+      if (event.payload.files_total != null) {
+        setFileCounts((prev) => ({
+          ...prev,
+          [event.payload.step]: {
+            done: event.payload.files_done ?? 0,
+            total: event.payload.files_total!,
+          },
+        }));
+      }
+    });
+    unlistenRef.current = unlisten;
+
+    try {
+      const manifest = await invoke<ReviewManifest>("fetch_pr", { prRef });
+      handleManifestLoaded(manifest);
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      unlisten();
+      unlistenRef.current = null;
+      setLoading(false);
+      setProgress(null);
+    }
+  }
+
+  function handleFetchCancel() {
+    unlistenRef.current?.();
+    unlistenRef.current = null;
+    setLoading(false);
+    setProgress(null);
   }
 
   function updateActiveTab(updater: (tab: Tab) => Tab) {
@@ -128,14 +183,26 @@ function App() {
         onDrop={handleFileDrop}
       >
         <div className="empty-message">
-          <h1>Relevant Reviews</h1>
-          <p>
-            Drop a manifest JSON file here, or enter a PR URL below to start
-            a review.
-          </p>
-          <PrOpener onManifestLoaded={handleManifestLoaded} />
+          {loading ? (
+            <LoadingView
+              prRef={loadingPrRef}
+              prTitle={loadingPrTitle}
+              progress={progress}
+              fileCounts={fileCounts}
+              onCancel={handleFetchCancel}
+            />
+          ) : (
+            <>
+              <h1>Relevant Reviews</h1>
+              <p>
+                Drop a manifest JSON file here, or enter a PR URL below to start
+                a review.
+              </p>
+              <PrOpener onFetchStart={handleFetchStart} />
+            </>
+          )}
           <div style={{ display: "flex", gap: 8, marginTop: 16, justifyContent: "center" }}>
-            {tabs.length > 0 && (
+            {tabs.length > 0 && !loading && (
               <button
                 className="settings-button"
                 onClick={() => setShowOpener(false)}
@@ -143,12 +210,14 @@ function App() {
                 Cancel
               </button>
             )}
-            <button
-              className="settings-button"
-              onClick={() => setSettingsOpen(true)}
-            >
-              Settings
-            </button>
+            {!loading && (
+              <button
+                className="settings-button"
+                onClick={() => setSettingsOpen(true)}
+              >
+                Settings
+              </button>
+            )}
           </div>
         </div>
         <SettingsModal

--- a/app/src/components/LoadingView.tsx
+++ b/app/src/components/LoadingView.tsx
@@ -1,0 +1,93 @@
+import type { FetchProgress } from "../types";
+
+const STEP_LABELS = [
+  "Fetching PR metadata",
+  "Fetching files and diff",
+  "Classifying files with AI",
+  "Analyzing highlights, summary, and grouping",
+  "Fetching file contents",
+  "Building review manifest",
+];
+
+interface LoadingViewProps {
+  prRef: string;
+  prTitle: string | null;
+  progress: FetchProgress | null;
+  fileCounts: Record<number, { done: number; total: number }>;
+  onCancel: () => void;
+}
+
+export function LoadingView({ prRef, prTitle, progress, fileCounts, onCancel }: LoadingViewProps) {
+  const currentStep = progress?.step ?? 0;
+  const currentStatus = progress?.status ?? "running";
+
+  const completedSteps =
+    currentStatus === "done" ? currentStep : currentStep - 1;
+  const progressPercent = (completedSteps / 6) * 100;
+
+  return (
+    <div className="loading-view">
+      {prTitle ? (
+        <div className="loading-view-title">{prTitle}</div>
+      ) : (
+        <div className="loading-view-pr-ref">{prRef}</div>
+      )}
+      <div className="loading-view-body">
+      <div className="loading-view-steps">
+        {STEP_LABELS.map((label, i) => {
+          const stepNum = i + 1;
+          let status: "done" | "active" | "pending";
+          if (stepNum < currentStep) {
+            status = "done";
+          } else if (stepNum === currentStep) {
+            status = currentStatus === "done" ? "done" : "active";
+          } else {
+            status = "pending";
+          }
+
+          return (
+            <div key={stepNum} className={`loading-view-step loading-view-step-${status}`}>
+              <span className="loading-view-step-icon">
+                {status === "done" && (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <path
+                      d="M11.5 3.5L5.5 10L2.5 7"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                )}
+                {status === "active" && <span className="loading-view-spinner" />}
+                {status === "pending" && (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                    <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.5" />
+                  </svg>
+                )}
+              </span>
+              <span className="loading-view-step-label">
+                {label}
+                {fileCounts[stepNum] && (
+                  <span className="loading-view-file-count">
+                    {" "}{fileCounts[stepNum].done}/{fileCounts[stepNum].total}
+                  </span>
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="loading-view-progress">
+        <div
+          className="loading-view-progress-fill"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+      <button className="settings-button" onClick={onCancel} style={{ marginTop: 16 }}>
+        Cancel
+      </button>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/PrOpener.tsx
+++ b/app/src/components/PrOpener.tsx
@@ -1,33 +1,16 @@
 import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import type { ReviewManifest } from "../types";
 
 interface PrOpenerProps {
-  onManifestLoaded: (manifest: ReviewManifest) => void;
+  onFetchStart: (prRef: string) => void;
 }
 
-export function PrOpener({ onManifestLoaded }: PrOpenerProps) {
+export function PrOpener({ onFetchStart }: PrOpenerProps) {
   const [prRef, setPrRef] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!prRef.trim()) return;
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const manifest = await invoke<ReviewManifest>("fetch_pr", {
-        prRef: prRef.trim(),
-      });
-      onManifestLoaded(manifest);
-    } catch (err) {
-      setError(String(err));
-    } finally {
-      setLoading(false);
-    }
+    onFetchStart(prRef.trim());
   }
 
   return (
@@ -42,17 +25,15 @@ export function PrOpener({ onManifestLoaded }: PrOpenerProps) {
           value={prRef}
           onChange={(e) => setPrRef(e.target.value)}
           placeholder="PR URL or owner/repo#123 or just #123"
-          disabled={loading}
         />
         <button
           type="submit"
           className="pr-opener-button"
-          disabled={loading || !prRef.trim()}
+          disabled={!prRef.trim()}
         >
-          {loading ? "Fetching..." : "Open PR"}
+          Open PR
         </button>
       </form>
-      {error && <div className="pr-opener-error">{error}</div>}
     </div>
   );
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -911,6 +911,114 @@ body {
   font-family: var(--font-mono);
 }
 
+/* ─── Loading View ─────────────────────────────────────────────────────── */
+.loading-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.loading-view-body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 420px;
+  width: 100%;
+}
+
+.loading-view-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.loading-view-pr-ref {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent);
+  background: var(--bg-tertiary);
+  padding: 4px 12px;
+  border-radius: 6px;
+  margin-bottom: 24px;
+}
+
+.loading-view-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.loading-view-step {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  font-size: 13px;
+  border-radius: 4px;
+  transition: color 0.2s;
+}
+
+.loading-view-step-done {
+  color: var(--diff-add-text);
+}
+
+.loading-view-step-active {
+  color: var(--accent);
+}
+
+.loading-view-step-pending {
+  color: var(--text-muted);
+}
+
+.loading-view-step-icon {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.loading-view-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--bg-tertiary);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: loading-spin 0.6s linear infinite;
+}
+
+@keyframes loading-spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-view-file-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-left: 4px;
+}
+
+.loading-view-progress {
+  width: 100%;
+  height: 4px;
+  background: var(--bg-tertiary);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.loading-view-progress-fill {
+  height: 100%;
+  background: var(--diff-add-text);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
 /* ─── AI Highlights ────────────────────────────────────────────────────── */
 .highlight-count {
   font-size: 11px;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -43,6 +43,16 @@ export interface ReviewManifest {
   files: FileDiff[];
 }
 
+export interface FetchProgress {
+  step: number;
+  total_steps: number;
+  label: string;
+  status: "running" | "done";
+  pr_title?: string;
+  files_done?: number;
+  files_total?: number;
+}
+
 export type DiffViewMode = "split" | "unified";
 
 export interface Tab {


### PR DESCRIPTION
## Summary

- Adds a **LoadingView** component that shows real-time progress across all 6 backend fetch steps with animated spinners, checkmarks, and a progress bar
- Emits Tauri events from the Rust backend at each step boundary using a type-safe `FetchProgress` struct with `FetchStatus` enum
- Shows **file counters** on steps 4 (AI analysis: 1/3, 2/3, 3/3) and 5 (file content fetching: N/total) using `FuturesUnordered` for incremental tracking
- Displays the **PR title** (fetched from GitHub metadata) instead of the raw URL
- Simplifies `PrOpener` into a pure form component — all fetch logic moved to `App.tsx`
- Guards against event listener race conditions on rapid re-submit

<img width="540" height="403" alt="image" src="https://github.com/user-attachments/assets/f84e64f1-35ca-404b-bc89-a4262f8b9092" />

## Test plan

- [ ] Enter a PR URL and submit — verify loading view appears with all 6 steps
- [ ] Steps transition: pending → active (spinner) → done (checkmark)
- [ ] Progress bar fills incrementally
- [ ] PR title replaces the raw URL after step 1 completes
- [ ] File counters appear on steps 4 and 5
- [ ] Cancel button returns to the opener form
- [ ] Error case (bad PR URL) displays correctly
- [ ] Rapid double-click on submit does not register duplicate listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)