### PR TITLE
fix: prevent single-hunk diffs from being collapsed

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -639,7 +639,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)
   const [collapsedHunks, setCollapsedHunks] = useState<Set<number>>(() => {
-    if (!showHunkSignificance) return new Set<number>();
+    if (!showHunkSignificance || hunks.length <= 1) return new Set<number>();
     return new Set(
       hunks.filter((h) => h.significance === "low").map((h) => h.index)
     );
@@ -705,7 +705,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
             </button>
           </>
         )}
-        {showHunkSignificance && collapsedCount === 0 && hunks.some((h) => h.significance === "low") && (
+        {showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && hunks.some((h) => h.significance === "low") && (
           <button className="hunk-toggle-all" onClick={collapseAllLow}>
             Collapse low
           </button>


### PR DESCRIPTION
## Summary
- Skip auto-collapsing low-significance hunks when a file has only one hunk, so the diff is always visible
- Hide the "Collapse low" button for single-hunk files since collapsing the only hunk provides no value

Closes #3

## Test plan
- [ ] Open a PR with a file that has a single low-significance hunk — verify the diff is displayed, not collapsed
- [ ] Open a PR with a file that has multiple hunks — verify low hunks are still collapsed by default
- [ ] Verify the "Collapse low" button does not appear for single-hunk files
- [ ] Verify the "Collapse low" button still appears for multi-hunk files with low-significance hunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)