### PR TITLE
feat: review comments with inline threading, suggestions, and review submission

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1,13 +1,20 @@
+use crate::bedrock::{region_from_arn, BedrockClient};
 use crate::config::{load_settings, resolve_github_token, save_settings_to_disk};
 use crate::fetch::fetch_pr_impl;
 use crate::github::GithubClient;
-use crate::types::{ReviewManifest, ReviewRequestItem, Settings};
+use crate::types::{ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use std::fs;
 use std::sync::Mutex;
 use tauri::{command, State};
 
 pub struct AppState {
     pub manifest_path: Mutex<Option<String>>,
+}
+
+fn github_client() -> Result<GithubClient, String> {
+    let settings = load_settings();
+    let token = resolve_github_token(&settings)?;
+    Ok(GithubClient::new(token))
 }
 
 #[command]
@@ -45,11 +52,119 @@ pub async fn fetch_review_requests(
     cutoff_date: String,
     fetch_recent: bool,
 ) -> Result<Vec<ReviewRequestItem>, String> {
-    let settings = load_settings();
-    let token = resolve_github_token(&settings)?;
-    let github = GithubClient::new(token);
+    let github = github_client()?;
     let username = github.get_authenticated_user().await?;
     github
         .get_review_requests(&username, &cutoff_date, fetch_recent)
         .await
+}
+
+#[command]
+pub async fn fetch_review_comments(pr_url: String) -> Result<Vec<ReviewThread>, String> {
+    let github = github_client()?;
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    github.get_review_threads(&parsed.owner, &parsed.repo, parsed.number).await
+}
+
+#[command]
+pub async fn reply_to_thread(
+    pr_url: String,
+    comment_id: String,
+    body: String,
+) -> Result<ReviewComment, String> {
+    let github = github_client()?;
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    let pr_node_id = github.get_pull_request_id(&parsed.owner, &parsed.repo, parsed.number).await?;
+    github
+        .reply_to_review_thread(&pr_node_id, &comment_id, &body)
+        .await
+}
+
+#[command]
+pub async fn create_review_comment(
+    pr_url: String,
+    body: String,
+    path: String,
+    line: u64,
+    side: String,
+    start_line: Option<u64>,
+    start_side: Option<String>,
+) -> Result<ReviewThread, String> {
+    let github = github_client()?;
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    let pr_node_id = github.get_pull_request_id(&parsed.owner, &parsed.repo, parsed.number).await?;
+    github
+        .create_review_thread(
+            &pr_node_id,
+            &body,
+            &path,
+            line,
+            &side,
+            start_line,
+            start_side.as_deref(),
+        )
+        .await
+}
+
+#[command]
+pub async fn update_review_comment(
+    comment_id: String,
+    body: String,
+) -> Result<ReviewComment, String> {
+    let github = github_client()?;
+    github.update_review_comment(&comment_id, &body).await
+}
+
+#[command]
+pub async fn submit_review(
+    pr_url: String,
+    event: String,
+    body: String,
+) -> Result<String, String> {
+    let github = github_client()?;
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    github
+        .submit_review(&parsed.owner, &parsed.repo, parsed.number, &event, &body)
+        .await
+}
+
+#[command]
+pub async fn generate_review_body(
+    threads_json: String,
+    pr_title: String,
+    has_unresolved: bool,
+) -> Result<String, String> {
+    let settings = load_settings();
+    let region = region_from_arn(&settings.model)?;
+    let bedrock = BedrockClient::new(&region, &settings.aws_profile).await?;
+
+    let prompt = if has_unresolved {
+        format!(
+            r#"You are a code reviewer writing a brief review summary for a pull request titled "{}".
+
+Here are the unresolved review comment threads (JSON):
+{}
+
+Write a concise 1-3 sentence summary of the changes you're requesting. Focus on the key themes across the comments, not individual details. Write in first person as the reviewer. Do not use markdown. Do not include a greeting or sign-off."#,
+            pr_title, threads_json
+        )
+    } else {
+        format!(
+            r#"You are a code reviewer approving a pull request titled "{}".
+
+Write a short, fun, nerdy LGTM message (1-2 sentences). Be creative — reference sci-fi, programming culture, memes, or geek humor. Vary your style. Do not use markdown. Do not include a greeting or sign-off."#,
+            pr_title
+        )
+    };
+
+    bedrock.invoke_model(&settings.model, &prompt).await
+}
+
+#[command]
+pub async fn toggle_thread_resolved(
+    thread_id: String,
+    resolve: bool,
+) -> Result<bool, String> {
+    let github = github_client()?;
+    github.resolve_review_thread(&thread_id, resolve).await
 }

--- a/app/src-tauri/src/github.rs
+++ b/app/src-tauri/src/github.rs
@@ -1,4 +1,4 @@
-use crate::types::{PrFile, PrMetadata, ReviewRequestItem};
+use crate::types::{CommentAuthor, PrFile, PrMetadata, ReviewComment, ReviewRequestItem, ReviewThread};
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::Client;
@@ -42,6 +42,54 @@ struct SearchPullRequest {
     merged_at: Option<String>,
 }
 
+/// Parse a single review comment from a GraphQL JSON node.
+fn parse_review_comment(c: &serde_json::Value) -> Option<ReviewComment> {
+    Some(ReviewComment {
+        id: c.get("id")?.as_str()?.to_string(),
+        body: c.get("body")?.as_str()?.to_string(),
+        author: CommentAuthor {
+            login: c
+                .pointer("/author/login")
+                .and_then(|v| v.as_str())
+                .unwrap_or("ghost")
+                .to_string(),
+            avatar_url: c
+                .pointer("/author/avatarUrl")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+        },
+        created_at: c.get("createdAt")?.as_str()?.to_string(),
+        updated_at: c.get("updatedAt")?.as_str()?.to_string(),
+        url: c.get("url")?.as_str()?.to_string(),
+    })
+}
+
+/// Parse a review thread from a GraphQL JSON node.
+fn parse_review_thread(node: &serde_json::Value) -> ReviewThread {
+    let diff_hunk = node
+        .pointer("/comments/nodes/0/diffHunk")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let comments: Vec<ReviewComment> = node
+        .pointer("/comments/nodes")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(parse_review_comment).collect())
+        .unwrap_or_default();
+
+    ReviewThread {
+        id: node.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        is_resolved: node.get("isResolved").and_then(|v| v.as_bool()).unwrap_or(false),
+        is_outdated: node.get("isOutdated").and_then(|v| v.as_bool()).unwrap_or(false),
+        path: node.get("path").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+        line: node.get("line").and_then(|v| v.as_u64()),
+        original_line: node.get("originalLine").and_then(|v| v.as_u64()),
+        diff_hunk,
+        comments,
+    }
+}
 
 impl GithubClient {
     pub fn new(token: String) -> Self {
@@ -49,6 +97,37 @@ impl GithubClient {
             client: Client::new(),
             token,
         }
+    }
+
+    /// Send a GraphQL request and return the parsed JSON response.
+    /// Handles POST, headers, status check, and GraphQL-level error checking.
+    async fn graphql_request(&self, body: serde_json::Value) -> Result<serde_json::Value, String> {
+        let resp = self
+            .client
+            .post("https://api.github.com/graphql")
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(USER_AGENT, "relevant-reviews")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("GraphQL request failed: {}", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("GraphQL error ({}): {}", status, body));
+        }
+
+        let result: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse GraphQL response: {}", e))?;
+
+        if let Some(errors) = result.get("errors") {
+            return Err(format!("GraphQL errors: {}", errors));
+        }
+
+        Ok(result)
     }
 
     pub async fn get_pr_metadata(
@@ -328,11 +407,11 @@ impl GithubClient {
                 }
             }
 
-            let (owner, repo) = parse_owner_repo(&item.html_url)?;
+            let parsed = crate::pr_parser::parse_pr_ref(&item.html_url)?;
 
             items.push(ReviewRequestItem {
-                owner,
-                repo,
+                owner: parsed.owner,
+                repo: parsed.repo,
                 number: item.number,
                 title: item.title,
                 html_url: item.html_url,
@@ -397,26 +476,7 @@ impl GithubClient {
         let query = format!("{{ {} }}", query_parts.join("\n"));
         let body = serde_json::json!({ "query": query });
 
-        let resp = self
-            .client
-            .post("https://api.github.com/graphql")
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .header(USER_AGENT, "relevant-reviews")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| format!("GraphQL request failed: {}", e))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("GraphQL error ({}): {}", status, body));
-        }
-
-        let result: serde_json::Value = resp
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse GraphQL response: {}", e))?;
+        let result = self.graphql_request(body).await?;
 
         let data = match result.get("data") {
             Some(d) => d,
@@ -484,16 +544,413 @@ impl GithubClient {
 
         Ok(())
     }
-}
 
-fn parse_owner_repo(html_url: &str) -> Result<(String, String), String> {
-    // https://github.com/owner/repo/pull/123
-    let parts: Vec<&str> = html_url.split('/').collect();
-    if parts.len() >= 5 {
-        let owner = parts[parts.len() - 4].to_string();
-        let repo = parts[parts.len() - 3].to_string();
-        Ok((owner, repo))
-    } else {
-        Err(format!("Could not parse owner/repo from URL: {}", html_url))
+    pub async fn get_review_threads(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<Vec<ReviewThread>, String> {
+        let mut all_threads = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let after_clause = match &cursor {
+                Some(c) => format!(", after: \"{}\"", c),
+                None => String::new(),
+            };
+
+            let query = format!(
+                r#"{{
+                    repository(owner: "{}", name: "{}") {{
+                        pullRequest(number: {}) {{
+                            reviewThreads(first: 100{}) {{
+                                pageInfo {{ hasNextPage endCursor }}
+                                nodes {{
+                                    id
+                                    isResolved
+                                    isOutdated
+                                    path
+                                    line
+                                    originalLine
+                                    diffSide
+                                    comments(first: 100) {{
+                                        nodes {{
+                                            id
+                                            body
+                                            author {{ login avatarUrl }}
+                                            createdAt
+                                            updatedAt
+                                            url
+                                            diffHunk
+                                        }}
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}"#,
+                owner, repo, pr_number, after_clause
+            );
+
+            let body = serde_json::json!({ "query": query });
+            let result = self.graphql_request(body).await?;
+
+            let threads_data = result
+                .pointer("/data/repository/pullRequest/reviewThreads")
+                .ok_or("Missing reviewThreads in response")?;
+
+            let nodes = threads_data
+                .pointer("/nodes")
+                .and_then(|v| v.as_array())
+                .ok_or("Missing nodes in reviewThreads")?;
+
+            for node in nodes {
+                all_threads.push(parse_review_thread(node));
+            }
+
+            let has_next = threads_data
+                .pointer("/pageInfo/hasNextPage")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            if has_next {
+                cursor = threads_data
+                    .pointer("/pageInfo/endCursor")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        Ok(all_threads)
+    }
+
+    pub async fn reply_to_review_thread(
+        &self,
+        pull_request_id: &str,
+        comment_node_id: &str,
+        body: &str,
+    ) -> Result<ReviewComment, String> {
+        let query = r#"mutation($prId: ID!, $inReplyTo: ID!, $body: String!) {
+            addPullRequestReviewComment(input: {
+                pullRequestId: $prId,
+                inReplyTo: $inReplyTo,
+                body: $body
+            }) {
+                comment {
+                    id
+                    body
+                    author { login avatarUrl }
+                    createdAt
+                    updatedAt
+                    url
+                }
+            }
+        }"#;
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": {
+                "prId": pull_request_id,
+                "inReplyTo": comment_node_id,
+                "body": body,
+            }
+        });
+
+        let result = self.graphql_request(payload).await?;
+
+        let c = result
+            .pointer("/data/addPullRequestReviewComment/comment")
+            .ok_or("Missing comment in response")?;
+
+        parse_review_comment(c).ok_or_else(|| "Failed to parse comment from response".to_string())
+    }
+
+    pub async fn resolve_review_thread(
+        &self,
+        thread_id: &str,
+        resolve: bool,
+    ) -> Result<bool, String> {
+        let mutation_name = if resolve {
+            "resolveReviewThread"
+        } else {
+            "unresolveReviewThread"
+        };
+
+        let query = format!(
+            r#"mutation($threadId: ID!) {{
+                {}(input: {{ threadId: $threadId }}) {{
+                    thread {{ isResolved }}
+                }}
+            }}"#,
+            mutation_name
+        );
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": { "threadId": thread_id }
+        });
+
+        let result = self.graphql_request(payload).await?;
+
+        let is_resolved = result
+            .pointer(&format!("/data/{}/thread/isResolved", mutation_name))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(resolve);
+
+        Ok(is_resolved)
+    }
+
+    pub async fn update_review_comment(
+        &self,
+        comment_node_id: &str,
+        body: &str,
+    ) -> Result<ReviewComment, String> {
+        let query = r#"mutation($commentId: ID!, $body: String!) {
+            updatePullRequestReviewComment(input: {
+                pullRequestReviewCommentId: $commentId,
+                body: $body
+            }) {
+                pullRequestReviewComment {
+                    id body author { login avatarUrl } createdAt updatedAt url
+                }
+            }
+        }"#;
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": {
+                "commentId": comment_node_id,
+                "body": body,
+            }
+        });
+
+        let result = self.graphql_request(payload).await?;
+
+        let c = result
+            .pointer("/data/updatePullRequestReviewComment/pullRequestReviewComment")
+            .ok_or("Missing comment in response")?;
+
+        parse_review_comment(c).ok_or_else(|| "Failed to parse comment from response".to_string())
+    }
+
+    pub async fn create_review_thread(
+        &self,
+        pull_request_id: &str,
+        body: &str,
+        path: &str,
+        line: u64,
+        side: &str,
+        start_line: Option<u64>,
+        start_side: Option<&str>,
+    ) -> Result<ReviewThread, String> {
+        // Build mutation dynamically based on whether start_line is provided
+        let (vars_decl, input_extra) = if start_line.is_some() {
+            (
+                ", $startLine: Int!, $startSide: DiffSide!",
+                "\n                startLine: $startLine\n                startSide: $startSide",
+            )
+        } else {
+            ("", "")
+        };
+
+        let query = format!(
+            r#"mutation($prId: ID!, $body: String!, $path: String!, $line: Int!, $side: DiffSide!{vars_decl}) {{
+            addPullRequestReviewThread(input: {{
+                pullRequestId: $prId
+                body: $body
+                path: $path
+                line: $line
+                side: $side{input_extra}
+            }}) {{"#
+        );
+
+        let query = format!(
+            r#"{}
+                thread {{
+                    id
+                    isResolved
+                    isOutdated
+                    path
+                    line
+                    originalLine
+                    comments(first: 100) {{
+                        nodes {{
+                            id body author {{ login avatarUrl }} createdAt updatedAt url diffHunk
+                        }}
+                    }}
+                }}
+            }}
+        }}"#,
+            query
+        );
+
+        let mut variables = serde_json::json!({
+            "prId": pull_request_id,
+            "body": body,
+            "path": path,
+            "line": line,
+            "side": side,
+        });
+
+        if let (Some(sl), Some(ss)) = (start_line, start_side) {
+            variables["startLine"] = serde_json::json!(sl);
+            variables["startSide"] = serde_json::json!(ss);
+        }
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": variables,
+        });
+
+        let result = self.graphql_request(payload).await?;
+
+        let thread = result
+            .pointer("/data/addPullRequestReviewThread/thread")
+            .ok_or("Missing thread in response")?;
+
+        Ok(parse_review_thread(thread))
+    }
+
+    /// Submit a pending review, or create a new review with the given event.
+    /// `event` must be one of: APPROVE, REQUEST_CHANGES, COMMENT
+    pub async fn submit_review(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+        event: &str,
+        body: &str,
+    ) -> Result<String, String> {
+        // Find the viewer's pending review using the viewer query
+        let query = format!(
+            r#"{{
+                viewer {{ login }}
+                repository(owner: "{}", name: "{}") {{
+                    pullRequest(number: {}) {{
+                        id
+                        reviews(last: 10, states: PENDING) {{
+                            nodes {{ id author {{ login }} }}
+                        }}
+                    }}
+                }}
+            }}"#,
+            owner, repo, pr_number
+        );
+
+        let result = self.graphql_request(serde_json::json!({ "query": query })).await?;
+
+        let viewer_login = result
+            .pointer("/data/viewer/login")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let pr_id = result
+            .pointer("/data/repository/pullRequest/id")
+            .and_then(|v| v.as_str())
+            .ok_or("Could not find PR node ID")?
+            .to_string();
+
+        let pending_review_id = result
+            .pointer("/data/repository/pullRequest/reviews/nodes")
+            .and_then(|v| v.as_array())
+            .and_then(|nodes| {
+                nodes.iter().find(|n| {
+                    n.pointer("/author/login")
+                        .and_then(|l| l.as_str())
+                        .map(|l| l.eq_ignore_ascii_case(viewer_login))
+                        .unwrap_or(false)
+                })
+            })
+            .and_then(|n| n.get("id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        if let Some(review_id) = pending_review_id {
+            // Submit existing pending review
+            let mutation = r#"mutation($reviewId: ID!, $event: PullRequestReviewEvent!, $body: String) {
+                submitPullRequestReview(input: {
+                    pullRequestReviewId: $reviewId
+                    event: $event
+                    body: $body
+                }) {
+                    pullRequestReview { state }
+                }
+            }"#;
+
+            let payload = serde_json::json!({
+                "query": mutation,
+                "variables": {
+                    "reviewId": review_id,
+                    "event": event,
+                    "body": body,
+                }
+            });
+
+            let result = self.graphql_request(payload).await?;
+            let state = result
+                .pointer("/data/submitPullRequestReview/pullRequestReview/state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("UNKNOWN")
+                .to_string();
+
+            Ok(state)
+        } else {
+            // No pending review — create a new one directly
+            let mutation = r#"mutation($prId: ID!, $event: PullRequestReviewEvent!, $body: String) {
+                addPullRequestReview(input: {
+                    pullRequestId: $prId
+                    event: $event
+                    body: $body
+                }) {
+                    pullRequestReview { state }
+                }
+            }"#;
+
+            let payload = serde_json::json!({
+                "query": mutation,
+                "variables": {
+                    "prId": pr_id,
+                    "event": event,
+                    "body": body,
+                }
+            });
+
+            let result = self.graphql_request(payload).await?;
+            let state = result
+                .pointer("/data/addPullRequestReview/pullRequestReview/state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("UNKNOWN")
+                .to_string();
+
+            Ok(state)
+        }
+    }
+
+    pub async fn get_pull_request_id(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<String, String> {
+        let query = format!(
+            r#"{{
+                repository(owner: "{}", name: "{}") {{
+                    pullRequest(number: {}) {{ id }}
+                }}
+            }}"#,
+            owner, repo, pr_number
+        );
+
+        let body = serde_json::json!({ "query": query });
+        let result = self.graphql_request(body).await?;
+
+        result
+            .pointer("/data/repository/pullRequest/id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| "Could not find PR node ID".to_string())
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -26,6 +26,13 @@ pub fn run() {
             commands::get_initial_manifest_path,
             commands::fetch_pr,
             commands::fetch_review_requests,
+            commands::fetch_review_comments,
+            commands::reply_to_thread,
+            commands::toggle_thread_resolved,
+            commands::submit_review,
+            commands::generate_review_body,
+            commands::update_review_comment,
+            commands::create_review_comment,
             commands::get_settings,
             commands::save_settings,
         ])

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -149,6 +149,34 @@ pub struct PrFile {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CommentAuthor {
+    pub login: String,
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReviewComment {
+    pub id: String,
+    pub body: String,
+    pub author: CommentAuthor,
+    pub created_at: String,
+    pub updated_at: String,
+    pub url: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReviewThread {
+    pub id: String,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+    pub path: String,
+    pub line: Option<u64>,
+    pub original_line: Option<u64>,
+    pub diff_hunk: String,
+    pub comments: Vec<ReviewComment>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewRequestItem {
     pub owner: String,
     pub repo: String,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,14 +2,15 @@ import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
-import { DiffViewer } from "./components/DiffViewer";
+import { DiffViewer, detectLanguage } from "./components/DiffViewer";
+import { CommentsViewer } from "./components/CommentsViewer";
 import { Header } from "./components/Header";
 import { PrOpener } from "./components/PrOpener";
 import { ReviewRequestList } from "./components/ReviewRequestList";
 import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment } from "./types";
 
 function App() {
   const nextTabId = useRef(1);
@@ -31,11 +32,15 @@ function App() {
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
 
   function createTab(manifest: ReviewManifest): Tab {
+    const hasGroups = (manifest.change_groups ?? []).length > 0;
     return {
       id: String(nextTabId.current++),
       manifest,
       selectedFile: manifest.files.length > 0 ? manifest.files[0] : null,
       viewedFiles: new Set(),
+      commentThreads: { status: "idle" },
+      selectedCommentFile: null,
+      sidebarView: hasGroups ? "groups" : "category",
     };
   }
 
@@ -132,6 +137,246 @@ function App() {
       }
       return { ...t, viewedFiles: next };
     });
+  }
+
+  function handleViewChange(view: SidebarView) {
+    updateActiveTab((t) => ({ ...t, sidebarView: view }));
+    if (view === "comments") {
+      handleRequestComments();
+    }
+  }
+
+  async function handleRequestComments() {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || tab.commentThreads.status === "loading" || tab.commentThreads.status === "loaded") return;
+
+    updateActiveTab((t) => ({ ...t, commentThreads: { status: "loading" } }));
+    try {
+      const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
+        prUrl: tab.manifest.pr_url,
+      });
+      // Set first file with comments as selected if none selected
+      const firstFile = threads.length > 0 ? threads[0].path : null;
+      setTabs((prev) =>
+        prev.map((t) =>
+          t.id === activeTabId
+            ? {
+                ...t,
+                commentThreads: { status: "loaded", threads },
+                selectedCommentFile: t.selectedCommentFile ?? firstFile,
+              }
+            : t
+        )
+      );
+    } catch (err) {
+      updateActiveTab((t) => ({
+        ...t,
+        commentThreads: { status: "error", message: String(err) },
+      }));
+    }
+  }
+
+  function handleSelectCommentFile(path: string) {
+    updateActiveTab((t) => ({ ...t, selectedCommentFile: path }));
+  }
+
+  async function handleReply(threadId: string, commentId: string, body: string) {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || tab.commentThreads.status !== "loaded") return;
+
+    // Optimistic update: add a placeholder comment
+    const optimisticComment = {
+      id: `optimistic-${Date.now()}`,
+      body,
+      author: { login: "you", avatar_url: "" },
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      url: "",
+    };
+
+    const prevThreads = tab.commentThreads.threads;
+    const optimisticThreads = prevThreads.map((t) =>
+      t.id === threadId
+        ? { ...t, comments: [...t.comments, optimisticComment] }
+        : t
+    );
+    updateActiveTab((t) => ({
+      ...t,
+      commentThreads: { status: "loaded", threads: optimisticThreads },
+    }));
+
+    try {
+      const newComment = await invoke<ReviewComment>("reply_to_thread", {
+        prUrl: tab.manifest.pr_url,
+        commentId,
+        body,
+      });
+
+      // Replace optimistic comment with real one
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== activeTabId || t.commentThreads.status !== "loaded") return t;
+          return {
+            ...t,
+            commentThreads: {
+              status: "loaded",
+              threads: t.commentThreads.threads.map((th) =>
+                th.id === threadId
+                  ? {
+                      ...th,
+                      comments: th.comments.map((c) =>
+                        c.id === optimisticComment.id ? newComment : c
+                      ),
+                    }
+                  : th
+              ),
+            },
+          };
+        })
+      );
+    } catch {
+      // Revert on error
+      updateActiveTab((t) => ({
+        ...t,
+        commentThreads: { status: "loaded", threads: prevThreads },
+      }));
+    }
+  }
+
+  async function handleToggleResolved(threadId: string, resolve: boolean) {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || tab.commentThreads.status !== "loaded") return;
+
+    const prevThreads = tab.commentThreads.threads;
+
+    // Optimistic update
+    const optimisticThreads = prevThreads.map((t) =>
+      t.id === threadId ? { ...t, is_resolved: resolve } : t
+    );
+    updateActiveTab((t) => ({
+      ...t,
+      commentThreads: { status: "loaded", threads: optimisticThreads },
+    }));
+
+    try {
+      await invoke<boolean>("toggle_thread_resolved", { threadId, resolve });
+    } catch {
+      // Revert on error
+      updateActiveTab((t) => ({
+        ...t,
+        commentThreads: { status: "loaded", threads: prevThreads },
+      }));
+    }
+  }
+
+  async function handleEditComment(commentId: string, body: string) {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || tab.commentThreads.status !== "loaded") return;
+
+    const prevThreads = tab.commentThreads.threads;
+
+    // Optimistic update
+    const optimisticThreads = prevThreads.map((t) => ({
+      ...t,
+      comments: t.comments.map((c) =>
+        c.id === commentId ? { ...c, body } : c
+      ),
+    }));
+    updateActiveTab((t) => ({
+      ...t,
+      commentThreads: { status: "loaded" as const, threads: optimisticThreads },
+    }));
+
+    try {
+      const updated = await invoke<ReviewComment>("update_review_comment", {
+        commentId,
+        body,
+      });
+
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== activeTabId || t.commentThreads.status !== "loaded") return t;
+          return {
+            ...t,
+            commentThreads: {
+              status: "loaded" as const,
+              threads: t.commentThreads.threads.map((th) => ({
+                ...th,
+                comments: th.comments.map((c) =>
+                  c.id === commentId ? updated : c
+                ),
+              })),
+            },
+          };
+        })
+      );
+    } catch {
+      updateActiveTab((t) => ({
+        ...t,
+        commentThreads: { status: "loaded" as const, threads: prevThreads },
+      }));
+    }
+  }
+
+  async function handleSubmitReview(event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+
+    try {
+      await invoke<string>("submit_review", {
+        prUrl: tab.manifest.pr_url,
+        event,
+        body,
+      });
+      // Re-fetch threads to update resolved states
+      if (tab.commentThreads.status === "loaded") {
+        const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
+          prUrl: tab.manifest.pr_url,
+        });
+        updateActiveTab((t) => ({
+          ...t,
+          commentThreads: { status: "loaded" as const, threads },
+        }));
+      }
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  async function handleCreateComment(path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+
+    try {
+      const newThread = await invoke<ReviewThread>("create_review_comment", {
+        prUrl: tab.manifest.pr_url,
+        body,
+        path,
+        line: endLine,
+        side,
+        startLine: startLine ?? null,
+        startSide: startSide ?? null,
+      });
+
+      // Add the new thread to the comment threads state
+      updateActiveTab((t) => {
+        if (t.commentThreads.status === "loaded") {
+          return {
+            ...t,
+            commentThreads: {
+              status: "loaded",
+              threads: [...t.commentThreads.threads, newThread],
+            },
+          };
+        }
+        return {
+          ...t,
+          commentThreads: { status: "loaded", threads: [newThread] },
+        };
+      });
+    } catch (err) {
+      setError(String(err));
+    }
   }
 
   function closeTab(tabId: string) {
@@ -241,6 +486,8 @@ function App() {
         onToggleHunkSignificance={() => setShowHunkSignificance((v) => !v)}
         showAiNotes={showAiNotes}
         onToggleAiNotes={() => setShowAiNotes((v) => !v)}
+        commentThreads={activeTab?.commentThreads}
+        onSubmitReview={activeTab ? handleSubmitReview : undefined}
       />
       <SettingsModal
         open={settingsOpen}
@@ -258,10 +505,34 @@ function App() {
             showHunkSignificance={showHunkSignificance}
             hunkFilter={hunkFilter}
             onHunkFilterChange={setHunkFilter}
+            sidebarView={activeTab.sidebarView}
+            onViewChange={handleViewChange}
+            commentThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : []}
+            selectedCommentFile={activeTab.selectedCommentFile}
+            onSelectCommentFile={handleSelectCommentFile}
           />
           <div className="diff-pane">
-            {activeTab.selectedFile ? (
-              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} />
+            {activeTab.sidebarView === "comments" ? (
+              activeTab.commentThreads.status === "loading" ? (
+                <div className="no-file-selected">Loading review threads...</div>
+              ) : activeTab.commentThreads.status === "error" ? (
+                <div className="no-file-selected" style={{ color: "var(--diff-remove-text)" }}>
+                  {activeTab.commentThreads.message}
+                </div>
+              ) : activeTab.commentThreads.status === "loaded" ? (
+                <CommentsViewer
+                  threads={activeTab.commentThreads.threads}
+                  selectedFile={activeTab.selectedCommentFile}
+                  onReply={handleReply}
+                  onToggleResolved={handleToggleResolved}
+                  onEditComment={handleEditComment}
+                  lang={activeTab.selectedCommentFile ? detectLanguage(activeTab.selectedCommentFile) : undefined}
+                />
+              ) : (
+                <div className="no-file-selected">Switch to Comments tab to load threads</div>
+              )
+            ) : activeTab.selectedFile ? (
+              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} />
             ) : activeTab.manifest.summary ? (
               <div className="pr-summary">
                 <h3>PR Summary</h3>

--- a/app/src/components/CommentsViewer.tsx
+++ b/app/src/components/CommentsViewer.tsx
@@ -1,0 +1,268 @@
+import { useState, useMemo } from "react";
+import type { ReviewThread, ReviewComment } from "../types";
+import { timeAgo } from "../utils";
+import { CommentBodyRendered } from "./DiffViewer";
+
+interface CommentsViewerProps {
+  threads: ReviewThread[];
+  selectedFile: string | null;
+  onReply: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved: (threadId: string, resolve: boolean) => void;
+  onEditComment?: (commentId: string, body: string) => void;
+  lang?: string;
+}
+
+function CommentCard({
+  comment,
+  onEdit,
+  lang,
+}: {
+  comment: ReviewComment;
+  onEdit?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(comment.body);
+
+  function handleSave() {
+    if (!text.trim() || !onEdit) return;
+    onEdit(comment.id, text.trim());
+    setEditing(false);
+  }
+
+  return (
+    <div className="thread-comment">
+      <div className="comment-header">
+        {comment.author.avatar_url && (
+          <img
+            className="comment-avatar"
+            src={comment.author.avatar_url}
+            alt={comment.author.login}
+            width={20}
+            height={20}
+          />
+        )}
+        <span className="comment-author">@{comment.author.login}</span>
+        <span className="comment-time">{timeAgo(comment.created_at)}</span>
+        {onEdit && !editing && (
+          <button className="comment-edit-button" onClick={() => setEditing(true)}>Edit</button>
+        )}
+      </div>
+      {editing ? (
+        <div className="comment-edit-form">
+          <textarea
+            className="reply-textarea"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={Math.max(3, text.split("\n").length + 1)}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSave();
+              if (e.key === "Escape") { setText(comment.body); setEditing(false); }
+            }}
+          />
+          <div className="reply-actions">
+            <button className="reply-cancel" onClick={() => { setText(comment.body); setEditing(false); }}>Cancel</button>
+            <button className="reply-submit" disabled={!text.trim()} onClick={handleSave}>Save</button>
+          </div>
+        </div>
+      ) : (
+        <CommentBodyRendered body={comment.body} lang={lang} />
+      )}
+    </div>
+  );
+}
+
+function ThreadCard({
+  thread,
+  onReply,
+  onToggleResolved,
+  onEdit,
+  lang,
+}: {
+  thread: ReviewThread;
+  onReply: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved: (threadId: string, resolve: boolean) => void;
+  onEdit?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const [hunkExpanded, setHunkExpanded] = useState(!thread.is_resolved);
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [threadCollapsed, setThreadCollapsed] = useState(thread.is_resolved);
+
+  const lastComment = thread.comments[thread.comments.length - 1];
+
+  function handleSubmitReply() {
+    if (!replyText.trim() || submitting) return;
+    setSubmitting(true);
+    onReply(thread.id, lastComment.id, replyText.trim());
+    setReplyText("");
+    setReplyOpen(false);
+    setSubmitting(false);
+  }
+
+  const lineLabel = thread.line
+    ? `L${thread.line}`
+    : thread.original_line
+      ? `L${thread.original_line} (original)`
+      : "";
+
+  return (
+    <div className={`thread-card ${thread.is_resolved ? "thread-card-resolved" : ""}`}>
+      <div className="thread-card-header" onClick={() => setThreadCollapsed((v) => !v)}>
+        <span className={`collapse-chevron ${threadCollapsed ? "collapsed" : ""}`}>&#9662;</span>
+        <span className="thread-card-location">
+          {lineLabel}
+          {thread.is_outdated && <span className="thread-outdated-badge">outdated</span>}
+        </span>
+        <span className="thread-card-comment-count">
+          {thread.comments.length} comment{thread.comments.length !== 1 ? "s" : ""}
+        </span>
+        {thread.is_resolved && <span className="thread-resolved-badge">Resolved</span>}
+      </div>
+
+      {!threadCollapsed && (
+        <>
+          {thread.diff_hunk && (
+            <div className="thread-hunk-preview">
+              <button
+                className="thread-hunk-toggle"
+                onClick={() => setHunkExpanded((v) => !v)}
+              >
+                <span className={`collapse-chevron ${hunkExpanded ? "" : "collapsed"}`}>&#9662;</span>
+                Diff context
+              </button>
+              {hunkExpanded && (
+                <pre className="thread-hunk-code">{thread.diff_hunk}</pre>
+              )}
+            </div>
+          )}
+
+          <div className="thread-comments">
+            {thread.comments.map((comment) => (
+              <CommentCard key={comment.id} comment={comment} onEdit={onEdit} lang={lang} />
+            ))}
+          </div>
+
+          <div className="thread-actions">
+            {replyOpen ? (
+              <div className="thread-reply-form">
+                <textarea
+                  className="reply-textarea"
+                  value={replyText}
+                  onChange={(e) => setReplyText(e.target.value)}
+                  placeholder="Write a reply..."
+                  rows={3}
+                  autoFocus
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      handleSubmitReply();
+                    }
+                  }}
+                />
+                <div className="reply-actions">
+                  <button
+                    className="reply-cancel"
+                    onClick={() => {
+                      setReplyOpen(false);
+                      setReplyText("");
+                    }}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="reply-submit"
+                    disabled={!replyText.trim() || submitting}
+                    onClick={handleSubmitReply}
+                  >
+                    Reply
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button className="reply-open-button" onClick={() => setReplyOpen(true)}>
+                Reply...
+              </button>
+            )}
+            <button
+              className={`resolve-button ${thread.is_resolved ? "resolve-button-resolved" : ""}`}
+              onClick={() => onToggleResolved(thread.id, !thread.is_resolved)}
+            >
+              {thread.is_resolved ? "Unresolve" : "Resolve"}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function CommentsViewer({
+  threads,
+  selectedFile,
+  onReply,
+  onToggleResolved,
+  onEditComment,
+  lang,
+}: CommentsViewerProps) {
+  if (!selectedFile) {
+    return (
+      <div className="comments-viewer-empty">
+        Select a file from the Comments sidebar to view review threads
+      </div>
+    );
+  }
+
+  const { fileThreads, unresolvedThreads, resolvedThreads } = useMemo(() => {
+    const fileThreads = threads.filter((t) => t.path === selectedFile);
+    return {
+      fileThreads,
+      unresolvedThreads: fileThreads.filter((t) => !t.is_resolved),
+      resolvedThreads: fileThreads.filter((t) => t.is_resolved),
+    };
+  }, [threads, selectedFile]);
+
+  if (fileThreads.length === 0) {
+    return (
+      <div className="comments-viewer-empty">
+        No review threads for this file
+      </div>
+    );
+  }
+
+  return (
+    <div className="comments-viewer">
+      <div className="comments-viewer-header">
+        <span className="comments-viewer-path">{selectedFile}</span>
+        <span className="comments-viewer-summary">
+          {unresolvedThreads.length} unresolved
+          {resolvedThreads.length > 0 && `, ${resolvedThreads.length} resolved`}
+        </span>
+      </div>
+      <div className="comments-viewer-threads">
+        {unresolvedThreads.map((thread) => (
+          <ThreadCard
+            key={thread.id}
+            thread={thread}
+            onReply={onReply}
+            onToggleResolved={onToggleResolved}
+            onEdit={onEditComment}
+            lang={lang}
+          />
+        ))}
+        {resolvedThreads.map((thread) => (
+          <ThreadCard
+            key={thread.id}
+            thread={thread}
+            onReply={onReply}
+            onToggleResolved={onToggleResolved}
+            onEdit={onEditComment}
+            lang={lang}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1,7 +1,8 @@
-import { Fragment, useMemo, useState } from "react";
+import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
-import type { FileDiff, DiffViewMode, Highlight } from "../types";
+import type { FileDiff, DiffViewMode, Highlight, ReviewThread, ReviewComment } from "../types";
+import { timeAgo } from "../utils";
 
 const extToLang: Record<string, string> = {
   ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
@@ -15,7 +16,7 @@ const extToLang: Record<string, string> = {
   tf: "hcl", hcl: "hcl", graphql: "graphql", gql: "graphql",
 };
 
-function detectLanguage(filePath: string): string | undefined {
+export function detectLanguage(filePath: string): string | undefined {
   const name = filePath.split("/").pop()?.toLowerCase() ?? "";
   if (name === "dockerfile") return "dockerfile";
   const ext = name.split(".").pop() ?? "";
@@ -86,11 +87,296 @@ function splitHtmlByLines(html: string): string[] {
   return lines;
 }
 
+interface CommentingOn {
+  startLine: number;
+  endLine: number;
+  side: "LEFT" | "RIGHT";
+}
+
 interface DiffViewerProps {
   file: FileDiff;
   viewMode: DiffViewMode;
   showHunkSignificance: boolean;
   showAiNotes: boolean;
+  onCreateComment?: (path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") => Promise<void>;
+  onEditComment?: (commentId: string, body: string) => void;
+  reviewThreads?: ReviewThread[];
+}
+
+export const CommentBodyRendered = memo(function CommentBodyRendered({ body, lang }: { body: string; lang?: string }) {
+  // Split body into text and suggestion blocks
+  const parts = body.split(/(```suggestion\n[\s\S]*?\n```)/g);
+
+  if (parts.length === 1) {
+    // No suggestion blocks — render as plain pre-wrapped text
+    return <div className="comment-body">{body}</div>;
+  }
+
+  return (
+    <div className="comment-body">
+      {parts.map((part, i) => {
+        const match = part.match(/^```suggestion\n([\s\S]*?)\n```$/);
+        if (match) {
+          const suggestionCode = match[1];
+          const html = highlightCode(suggestionCode, lang);
+          return (
+            <div key={i} className="comment-suggestion-block">
+              <div className="suggestion-preview-header">
+                <span className="suggestion-preview-label">Suggestion</span>
+              </div>
+              <pre className="inline-comment-code suggestion-code-add" dangerouslySetInnerHTML={{ __html: html }} />
+            </div>
+          );
+        }
+        if (!part.trim()) return null;
+        return <span key={i}>{part}</span>;
+      })}
+    </div>
+  );
+});
+
+function highlightCode(code: string, lang: string | undefined): string {
+  if (!code) return "";
+  if (lang) {
+    try { return hljs.highlight(code, { language: lang }).value; } catch { /* fall through */ }
+  }
+  return escapeHtml(code);
+}
+
+function InlineCommentForm({
+  onSubmit,
+  onCancel,
+  colSpan,
+  codeSnippet,
+  lineRange,
+  lang,
+}: {
+  onSubmit: (body: string) => void;
+  onCancel: () => void;
+  colSpan: number;
+  codeSnippet?: string;
+  lineRange?: string;
+  lang?: string;
+}) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  function handleSubmit() {
+    if (!text.trim() || submitting) return;
+    setSubmitting(true);
+    onSubmit(text.trim());
+  }
+
+  function handleSuggest() {
+    if (!codeSnippet) return;
+    const suggestion = "```suggestion\n" + codeSnippet + "\n```\n";
+    setText(suggestion);
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (ta) {
+        const cursorPos = "```suggestion\n".length;
+        ta.focus();
+        ta.setSelectionRange(cursorPos, cursorPos + codeSnippet.length);
+      }
+    });
+  }
+
+  // Extract suggestion body from text for live preview
+  const suggestionMatch = text.match(/```suggestion\n([\s\S]*?)\n```/);
+  const suggestionBody = suggestionMatch?.[1];
+
+  const snippetHtml = codeSnippet ? highlightCode(codeSnippet, lang) : undefined;
+  const suggestionHtml = suggestionBody != null ? highlightCode(suggestionBody, lang) : undefined;
+
+  return (
+    <tr className="inline-comment-row">
+      <td colSpan={colSpan}>
+        <div className="inline-comment-form">
+          {snippetHtml && !suggestionBody && (
+            <div className="inline-comment-snippet">
+              {lineRange && <span className="inline-comment-line-range">{lineRange}</span>}
+              <pre className="inline-comment-code" dangerouslySetInnerHTML={{ __html: snippetHtml }} />
+            </div>
+          )}
+          {suggestionHtml != null && (
+            <div className="inline-comment-suggestion-preview">
+              <div className="suggestion-preview-header">
+                <span className="suggestion-preview-label">Suggestion</span>
+                {lineRange && <span className="inline-comment-line-range">{lineRange}</span>}
+              </div>
+              {snippetHtml && (
+                <div className="suggestion-preview-original">
+                  <pre className="inline-comment-code suggestion-code-remove" dangerouslySetInnerHTML={{ __html: snippetHtml }} />
+                </div>
+              )}
+              <div className="suggestion-preview-replacement">
+                <pre className="inline-comment-code suggestion-code-add" dangerouslySetInnerHTML={{ __html: suggestionHtml }} />
+              </div>
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            className="reply-textarea"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Add a review comment..."
+            rows={5}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                handleSubmit();
+              }
+              if (e.key === "Escape") {
+                onCancel();
+              }
+            }}
+          />
+          <div className="reply-actions">
+            {codeSnippet && (
+              <button className="suggest-button" onClick={handleSuggest} title="Insert a suggestion block with the selected code">
+                Suggest
+              </button>
+            )}
+            <button className="reply-cancel" onClick={onCancel}>Cancel</button>
+            <button
+              className="reply-submit"
+              disabled={!text.trim() || submitting}
+              onClick={handleSubmit}
+            >
+              Comment
+            </button>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function EditableCommentBody({
+  comment,
+  onEdit,
+  lang,
+}: {
+  comment: ReviewComment;
+  onEdit?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState(comment.body);
+
+  function handleSave() {
+    if (!text.trim() || !onEdit) return;
+    onEdit(comment.id, text.trim());
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div className="comment-edit-form">
+        <textarea
+          className="reply-textarea"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={Math.max(3, text.split("\n").length + 1)}
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSave();
+            if (e.key === "Escape") { setText(comment.body); setEditing(false); }
+          }}
+        />
+        <div className="reply-actions">
+          <button className="reply-cancel" onClick={() => { setText(comment.body); setEditing(false); }}>Cancel</button>
+          <button className="reply-submit" disabled={!text.trim()} onClick={handleSave}>Save</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="comment-body-wrapper">
+      <CommentBodyRendered body={comment.body} lang={lang} />
+      {onEdit && (
+        <button className="comment-edit-button" onClick={() => setEditing(true)}>Edit</button>
+      )}
+    </div>
+  );
+}
+
+function InlineThreadMarker({
+  thread,
+  colSpan,
+  onEdit,
+  lang,
+}: {
+  thread: ReviewThread;
+  colSpan: number;
+  onEdit?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const [collapsed, setCollapsed] = useState(thread.is_resolved);
+  const isSingle = thread.comments.length === 1;
+  const first = thread.comments[0];
+
+  return (
+    <tr className={`inline-thread-row ${thread.is_resolved ? "inline-thread-resolved" : ""}`}>
+      <td colSpan={colSpan}>
+        <div className="inline-thread">
+          {isSingle ? (
+            // Single comment: compact layout, no redundant header+body
+            <div className="inline-thread-single">
+              <div className="comment-header">
+                {first?.author.avatar_url && (
+                  <img className="comment-avatar" src={first.author.avatar_url} alt={first.author.login} width={18} height={18} />
+                )}
+                <span className="comment-author">@{first?.author.login}</span>
+                <span className="comment-time">{timeAgo(first?.created_at)}</span>
+                {thread.is_resolved && <span className="inline-thread-resolved-badge">Resolved</span>}
+              </div>
+              <EditableCommentBody comment={first} onEdit={onEdit} lang={lang} />
+            </div>
+          ) : (
+            // Multi-comment: collapsible header + comment list
+            <>
+              <div className="inline-thread-header" onClick={() => setCollapsed((v) => !v)}>
+                <span className={`collapse-chevron ${collapsed ? "collapsed" : ""}`}>&#9662;</span>
+                {first?.author.avatar_url && (
+                  <img className="comment-avatar" src={first.author.avatar_url} alt={first.author.login} width={16} height={16} />
+                )}
+                <span className="inline-thread-author">@{first?.author.login}</span>
+                <span className="inline-thread-preview">
+                  {collapsed ? first?.body.slice(0, 120) : ""}
+                </span>
+                <span className="inline-thread-meta">
+                  <span className="inline-thread-reply-count">
+                    {thread.comments.length} comments
+                  </span>
+                  {thread.is_resolved && <span className="inline-thread-resolved-badge">Resolved</span>}
+                  <span className="comment-time">{timeAgo(first?.created_at)}</span>
+                </span>
+              </div>
+              {!collapsed && (
+                <div className="inline-thread-comments">
+                  {thread.comments.map((comment) => (
+                    <div key={comment.id} className="inline-thread-comment">
+                      <div className="comment-header">
+                        {comment.author.avatar_url && (
+                          <img className="comment-avatar" src={comment.author.avatar_url} alt={comment.author.login} width={18} height={18} />
+                        )}
+                        <span className="comment-author">@{comment.author.login}</span>
+                        <span className="comment-time">{timeAgo(comment.created_at)}</span>
+                      </div>
+                      <EditableCommentBody comment={comment} onEdit={onEdit} lang={lang} />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
 }
 
 interface DiffLine {
@@ -332,15 +618,88 @@ function groupIntoHunks(
   return hunks;
 }
 
+function buildThreadsByLine(threads: ReviewThread[] | undefined): Map<number, ReviewThread[]> {
+  const map = new Map<number, ReviewThread[]>();
+  for (const t of threads ?? []) {
+    const line = t.line ?? t.original_line;
+    if (line == null) continue;
+    const arr = map.get(line);
+    if (arr) arr.push(t);
+    else map.set(line, [t]);
+  }
+  return map;
+}
+
 // ── Unified hunk rendering ───────────────────────────────────────────────
 
-function UnifiedHunkLines({ lines, highlights }: { lines: DiffLine[]; highlights: Highlight[] }) {
+function UnifiedHunkLines({
+  lines,
+  highlights,
+  commentingOn,
+  dragging,
+  onLineMouseDown,
+  onLineMouseEnter,
+  onLineMouseUp,
+  onSubmitComment,
+  onCancelComment,
+  reviewThreads,
+  onEditComment,
+  lang,
+}: {
+  lines: DiffLine[];
+  highlights: Highlight[];
+  commentingOn?: CommentingOn | null;
+  dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
+  onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseEnter?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseUp?: () => void;
+  onSubmitComment?: (body: string) => void;
+  onCancelComment?: () => void;
+  reviewThreads?: ReviewThread[];
+  onEditComment?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const threadsByLine = useMemo(() => buildThreadsByLine(reviewThreads), [reviewThreads]);
+
   return (
     <>
       {lines.map((line, idx) => {
         const lineNum = line.newLineNum ?? line.oldLineNum;
         const hl = getHighlightForLine(lineNum, highlights);
         const hlStart = isHighlightStart(lineNum, highlights);
+        const commentLine = line.type === "remove" ? line.oldLineNum : line.newLineNum;
+        const commentSide: "LEFT" | "RIGHT" = line.type === "remove" ? "LEFT" : "RIGHT";
+        const canComment = onLineMouseDown && line.type !== "header" && commentLine != null;
+        const isEndOfSelection =
+          commentingOn &&
+          commentingOn.endLine === commentLine &&
+          commentingOn.side === commentSide;
+        const isInSelection =
+          (commentingOn &&
+            commentingOn.side === commentSide &&
+            commentLine != null &&
+            commentLine >= commentingOn.startLine &&
+            commentLine <= commentingOn.endLine) ||
+          (dragging &&
+            dragging.side === commentSide &&
+            commentLine != null &&
+            commentLine >= Math.min(dragging.anchorLine, dragging.currentLine) &&
+            commentLine <= Math.max(dragging.anchorLine, dragging.currentLine));
+        const lineThreads = commentLine != null ? (threadsByLine.get(commentLine) ?? []) : [];
+        // Build code snippet for the comment form at end of selection
+        const codeSnippet = isEndOfSelection && commentingOn
+          ? lines
+              .filter((l) => {
+                const ln = l.type === "remove" ? l.oldLineNum : l.newLineNum;
+                return ln != null && ln >= commentingOn.startLine && ln <= commentingOn.endLine && l.type !== "header";
+              })
+              .map((l) => l.content)
+              .join("\n")
+          : undefined;
+        const lineRange = isEndOfSelection && commentingOn && commentingOn.startLine !== commentingOn.endLine
+          ? `L${commentingOn.startLine}-L${commentingOn.endLine}`
+          : undefined;
+
         return (
           <Fragment key={idx}>
             {hlStart && (
@@ -351,10 +710,30 @@ function UnifiedHunkLines({ lines, highlights }: { lines: DiffLine[]; highlights
               </tr>
             )}
             <tr
-              className={`diff-line diff-line-${line.type}${hl ? ` highlighted highlighted-${hl.severity}` : ""}`}
+              className={`diff-line diff-line-${line.type}${hl ? ` highlighted highlighted-${hl.severity}` : ""}${canComment ? " commentable-line" : ""}${isInSelection ? " line-selected" : ""}`}
             >
-              <td className="line-num">{line.oldLineNum ?? ""}</td>
-              <td className="line-num">{line.newLineNum ?? ""}</td>
+              <td
+                className="line-num"
+                onMouseDown={canComment && line.type !== "add" ? (e) => { e.preventDefault(); onLineMouseDown(commentLine!, commentSide); } : undefined}
+                onMouseEnter={canComment && onLineMouseEnter && line.type !== "add" ? () => onLineMouseEnter(commentLine!, commentSide) : undefined}
+                onMouseUp={canComment && onLineMouseUp && line.type !== "add" ? onLineMouseUp : undefined}
+              >
+                {line.oldLineNum ?? ""}
+                {canComment && line.type !== "add" && (
+                  <span className="line-comment-button">+</span>
+                )}
+              </td>
+              <td
+                className="line-num"
+                onMouseDown={canComment && line.type !== "remove" ? (e) => { e.preventDefault(); onLineMouseDown(commentLine!, commentSide); } : undefined}
+                onMouseEnter={canComment && onLineMouseEnter && line.type !== "remove" ? () => onLineMouseEnter(commentLine!, commentSide) : undefined}
+                onMouseUp={canComment && onLineMouseUp && line.type !== "remove" ? onLineMouseUp : undefined}
+              >
+                {line.newLineNum ?? ""}
+                {canComment && line.type !== "remove" && (
+                  <span className="line-comment-button">+</span>
+                )}
+              </td>
               <td className="line-prefix">
                 {line.type === "add" ? "+" : line.type === "remove" ? "-" : line.type === "header" ? "@@" : " "}
               </td>
@@ -362,6 +741,19 @@ function UnifiedHunkLines({ lines, highlights }: { lines: DiffLine[]; highlights
                 <pre dangerouslySetInnerHTML={{ __html: line.html }} />
               </td>
             </tr>
+            {lineThreads.map((thread) => (
+              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} lang={lang} />
+            ))}
+            {isEndOfSelection && onSubmitComment && onCancelComment && (
+              <InlineCommentForm
+                onSubmit={onSubmitComment}
+                onCancel={onCancelComment}
+                colSpan={4}
+                codeSnippet={codeSnippet}
+                lineRange={lineRange}
+                lang={lang}
+              />
+            )}
           </Fragment>
         );
       })}
@@ -375,12 +767,32 @@ function UnifiedView({
   collapsedHunks,
   onToggleHunk,
   showSignificance,
+  commentingOn,
+  dragging,
+  onLineMouseDown,
+  onLineMouseEnter,
+  onLineMouseUp,
+  onSubmitComment,
+  onCancelComment,
+  reviewThreads,
+  onEditComment,
+  lang,
 }: {
   hunks: Hunk[];
   highlights: Highlight[];
   collapsedHunks: Set<number>;
   onToggleHunk: (index: number) => void;
   showSignificance: boolean;
+  commentingOn?: CommentingOn | null;
+  dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
+  onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseEnter?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseUp?: () => void;
+  onSubmitComment?: (body: string) => void;
+  onCancelComment?: () => void;
+  reviewThreads?: ReviewThread[];
+  onEditComment?: (commentId: string, body: string) => void;
+  lang?: string;
 }) {
   return (
     <table className="diff-table unified">
@@ -437,13 +849,13 @@ function UnifiedView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} />
+                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} />
+                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -455,13 +867,83 @@ function UnifiedView({
 
 // ── Split hunk rendering ─────────────────────────────────────────────────
 
-function SplitHunkLines({ splitLines, highlights }: { splitLines: SplitLine[]; highlights: Highlight[] }) {
+function SplitHunkLines({
+  splitLines,
+  highlights,
+  commentingOn,
+  dragging,
+  onLineMouseDown,
+  onLineMouseEnter,
+  onLineMouseUp,
+  onSubmitComment,
+  onCancelComment,
+  reviewThreads,
+  onEditComment,
+  lang,
+}: {
+  splitLines: SplitLine[];
+  highlights: Highlight[];
+  commentingOn?: CommentingOn | null;
+  dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
+  onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseEnter?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseUp?: () => void;
+  onSubmitComment?: (body: string) => void;
+  onCancelComment?: () => void;
+  reviewThreads?: ReviewThread[];
+  onEditComment?: (commentId: string, body: string) => void;
+  lang?: string;
+}) {
+  const threadsByLine = useMemo(() => buildThreadsByLine(reviewThreads), [reviewThreads]);
+
   return (
     <>
       {splitLines.map((pair, idx) => {
         const rightLineNum = pair.right?.newLineNum ?? pair.right?.oldLineNum;
         const hl = getHighlightForLine(rightLineNum ?? null, highlights);
         const hlStart = isHighlightStart(rightLineNum ?? null, highlights);
+        const leftLine = pair.left?.oldLineNum ?? pair.left?.newLineNum ?? null;
+        const rightLine = pair.right?.newLineNum ?? pair.right?.oldLineNum ?? null;
+        const canCommentLeft = onLineMouseDown && pair.left && pair.left.type !== "header" && leftLine != null;
+        const canCommentRight = onLineMouseDown && pair.right && pair.right.type !== "header" && rightLine != null;
+        const leftSide: "LEFT" | "RIGHT" = pair.left?.type === "remove" ? "LEFT" : "RIGHT";
+        const rightSide: "LEFT" | "RIGHT" = "RIGHT";
+        const isEndLeft =
+          commentingOn && commentingOn.endLine === leftLine && commentingOn.side === leftSide;
+        const isEndRight =
+          commentingOn && commentingOn.endLine === rightLine && commentingOn.side === rightSide;
+        const showForm = isEndLeft || isEndRight;
+        // Build code snippet for the comment form at end of selection
+        const codeSnippet = showForm && commentingOn
+          ? splitLines
+              .map((p) => {
+                const dl = commentingOn.side === "LEFT" ? p.left : p.right;
+                if (!dl || dl.type === "header") return null;
+                const ln = dl.type === "remove" ? dl.oldLineNum : dl.newLineNum;
+                if (ln == null || ln < commentingOn.startLine || ln > commentingOn.endLine) return null;
+                return dl.content;
+              })
+              .filter((c): c is string => c !== null)
+              .join("\n")
+          : undefined;
+        const lineRange = showForm && commentingOn && commentingOn.startLine !== commentingOn.endLine
+          ? `L${commentingOn.startLine}-L${commentingOn.endLine}`
+          : undefined;
+
+        const isInSelection = (ln: number | null, side: "LEFT" | "RIGHT") => {
+          if (ln == null) return false;
+          if (commentingOn && commentingOn.side === side && ln >= commentingOn.startLine && ln <= commentingOn.endLine) return true;
+          if (dragging && dragging.side === side && ln >= Math.min(dragging.anchorLine, dragging.currentLine) && ln <= Math.max(dragging.anchorLine, dragging.currentLine)) return true;
+          return false;
+        };
+
+        // Collect threads for both sides, deduplicated
+        const leftThreads = leftLine != null ? (threadsByLine.get(leftLine) ?? []) : [];
+        const rightThreads = rightLine != null ? (threadsByLine.get(rightLine) ?? []) : [];
+        const lineThreads = rightLine === leftLine
+          ? leftThreads
+          : [...leftThreads, ...rightThreads.filter(t => !leftThreads.some(lt => lt.id === t.id))];
+
         return (
           <Fragment key={idx}>
             {hlStart && (
@@ -472,35 +954,52 @@ function SplitHunkLines({ splitLines, highlights }: { splitLines: SplitLine[]; h
               </tr>
             )}
             <tr
-              className={`diff-split-row${hl ? ` highlighted highlighted-${hl.severity}` : ""}`}
+              className={`diff-split-row${hl ? ` highlighted highlighted-${hl.severity}` : ""}${(canCommentLeft || canCommentRight) ? " commentable-line" : ""}`}
             >
               {/* Left side (base/old) */}
-              <td className="line-num left-num">
-                {pair.left?.oldLineNum ?? pair.left?.newLineNum ?? ""}
+              <td
+                className={`line-num left-num${isInSelection(leftLine, leftSide) ? " line-selected" : ""}`}
+                onMouseDown={canCommentLeft ? (e) => { e.preventDefault(); onLineMouseDown(leftLine!, leftSide); } : undefined}
+                onMouseEnter={canCommentLeft && onLineMouseEnter ? () => onLineMouseEnter(leftLine!, leftSide) : undefined}
+                onMouseUp={canCommentLeft && onLineMouseUp ? onLineMouseUp : undefined}
+              >
+                {leftLine ?? ""}
+                {canCommentLeft && <span className="line-comment-button">+</span>}
               </td>
               <td
-                className={`line-content left-content ${pair.left ? `diff-line-${pair.left.type}` : "empty-line"}`}
+                className={`line-content left-content ${pair.left ? `diff-line-${pair.left.type}` : "empty-line"}${isInSelection(leftLine, leftSide) ? " line-selected" : ""}`}
               >
-                <pre
-                  dangerouslySetInnerHTML={{
-                    __html: pair.left?.html ?? "",
-                  }}
-                />
+                <pre dangerouslySetInnerHTML={{ __html: pair.left?.html ?? "" }} />
               </td>
               {/* Right side (head/new) */}
-              <td className="line-num right-num">
-                {pair.right?.newLineNum ?? pair.right?.oldLineNum ?? ""}
+              <td
+                className={`line-num right-num${isInSelection(rightLine, rightSide) ? " line-selected" : ""}`}
+                onMouseDown={canCommentRight ? (e) => { e.preventDefault(); onLineMouseDown(rightLine!, rightSide); } : undefined}
+                onMouseEnter={canCommentRight && onLineMouseEnter ? () => onLineMouseEnter(rightLine!, rightSide) : undefined}
+                onMouseUp={canCommentRight && onLineMouseUp ? onLineMouseUp : undefined}
+              >
+                {rightLine ?? ""}
+                {canCommentRight && <span className="line-comment-button">+</span>}
               </td>
               <td
-                className={`line-content right-content ${pair.right ? `diff-line-${pair.right.type}` : "empty-line"}`}
+                className={`line-content right-content ${pair.right ? `diff-line-${pair.right.type}` : "empty-line"}${isInSelection(rightLine, rightSide) ? " line-selected" : ""}`}
               >
-                <pre
-                  dangerouslySetInnerHTML={{
-                    __html: pair.right?.html ?? "",
-                  }}
-                />
+                <pre dangerouslySetInnerHTML={{ __html: pair.right?.html ?? "" }} />
               </td>
             </tr>
+            {lineThreads.map((thread) => (
+              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} lang={lang} />
+            ))}
+            {showForm && onSubmitComment && onCancelComment && (
+              <InlineCommentForm
+                onSubmit={onSubmitComment}
+                onCancel={onCancelComment}
+                colSpan={4}
+                codeSnippet={codeSnippet}
+                lineRange={lineRange}
+                lang={lang}
+              />
+            )}
           </Fragment>
         );
       })}
@@ -514,12 +1013,32 @@ function SplitView({
   collapsedHunks,
   onToggleHunk,
   showSignificance,
+  commentingOn,
+  dragging,
+  onLineMouseDown,
+  onLineMouseEnter,
+  onLineMouseUp,
+  onSubmitComment,
+  onCancelComment,
+  reviewThreads,
+  onEditComment,
+  lang,
 }: {
   hunks: Hunk[];
   highlights: Highlight[];
   collapsedHunks: Set<number>;
   onToggleHunk: (index: number) => void;
   showSignificance: boolean;
+  commentingOn?: CommentingOn | null;
+  dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
+  onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseEnter?: (line: number, side: "LEFT" | "RIGHT") => void;
+  onLineMouseUp?: () => void;
+  onSubmitComment?: (body: string) => void;
+  onCancelComment?: () => void;
+  reviewThreads?: ReviewThread[];
+  onEditComment?: (commentId: string, body: string) => void;
+  lang?: string;
 }) {
   return (
     <table className="diff-table split">
@@ -579,13 +1098,13 @@ function SplitView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <SplitHunkLines splitLines={splitLines} highlights={highlights} />
+                        <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <SplitHunkLines splitLines={splitLines} highlights={highlights} />
+                <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -597,9 +1116,59 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }: DiffViewerProps) {
+export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, reviewThreads }: DiffViewerProps) {
+  const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
+  const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
+
+  function handleLineMouseDown(line: number, side: "LEFT" | "RIGHT") {
+    setDragging({ anchorLine: line, side, currentLine: line });
+    setCommentingOn(null);
+  }
+
+  function handleLineMouseEnter(line: number, side: "LEFT" | "RIGHT") {
+    if (!dragging || dragging.side !== side) return;
+    setDragging((d) => d ? { ...d, currentLine: line } : null);
+  }
+
+  function handleLineMouseUp() {
+    if (!dragging) return;
+    const startLine = Math.min(dragging.anchorLine, dragging.currentLine);
+    const endLine = Math.max(dragging.anchorLine, dragging.currentLine);
+    setCommentingOn({ startLine, endLine, side: dragging.side });
+    setDragging(null);
+  }
+
+  function handleSubmitComment(body: string) {
+    if (!commentingOn || !onCreateComment) return;
+    const isRange = commentingOn.startLine !== commentingOn.endLine;
+    onCreateComment(
+      file.path,
+      commentingOn.endLine,
+      commentingOn.side,
+      body,
+      isRange ? commentingOn.startLine : undefined,
+      isRange ? commentingOn.side : undefined,
+    );
+    setCommentingOn(null);
+  }
+
+  function handleCancelComment() {
+    setCommentingOn(null);
+    setDragging(null);
+  }
+
+  useEffect(() => {
+    if (!dragging) return;
+    function onMouseUp() {
+      handleLineMouseUp();
+    }
+    document.addEventListener("mouseup", onMouseUp);
+    return () => document.removeEventListener("mouseup", onMouseUp);
+  }, [dragging]);
+
+  const lang = useMemo(() => detectLanguage(file.path), [file.path]);
+
   const { hunks, diffLines, useHunkView } = useMemo(() => {
-    const lang = detectLanguage(file.path);
     const hunkScores = file.hunk_scores ?? [];
     const hasUnifiedDiff = file.unified_diff && file.unified_diff.length > 0;
 
@@ -656,6 +1225,11 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
       return next;
     });
   };
+
+  const fileThreads = useMemo(
+    () => (reviewThreads ?? []).filter((t) => t.path === file.path),
+    [reviewThreads, file.path]
+  );
 
   const highlights = showAiNotes ? (file.highlights ?? []) : [];
   const isCritical =
@@ -731,6 +1305,16 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
               collapsedHunks={collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
+              commentingOn={commentingOn}
+              dragging={dragging}
+              onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined}
+              onLineMouseEnter={handleLineMouseEnter}
+              onLineMouseUp={handleLineMouseUp}
+              onSubmitComment={handleSubmitComment}
+              onCancelComment={handleCancelComment}
+              reviewThreads={fileThreads}
+              onEditComment={onEditComment}
+              lang={lang}
             />
           ) : (
             <SplitView
@@ -739,6 +1323,16 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
               collapsedHunks={collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
+              commentingOn={commentingOn}
+              dragging={dragging}
+              onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined}
+              onLineMouseEnter={handleLineMouseEnter}
+              onLineMouseUp={handleLineMouseUp}
+              onSubmitComment={handleSubmitComment}
+              onCancelComment={handleCancelComment}
+              reviewThreads={fileThreads}
+              onEditComment={onEditComment}
+              lang={lang}
             />
           )
         ) : (
@@ -750,7 +1344,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes }
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={diffLines} highlights={highlights} />
+              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} lang={lang} />
             </tbody>
           </table>
         )}

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { FileDiff, RiskLevel, ChangeGroup, HunkSignificanceFilter } from "../types";
-
-type SidebarView = "category" | "groups" | "tree";
+import type { FileDiff, RiskLevel, ChangeGroup, HunkSignificanceFilter, SidebarView, ReviewThread } from "../types";
 
 interface FileSidebarProps {
   files: FileDiff[];
@@ -13,6 +11,11 @@ interface FileSidebarProps {
   showHunkSignificance: boolean;
   hunkFilter: HunkSignificanceFilter;
   onHunkFilterChange: (filter: HunkSignificanceFilter) => void;
+  sidebarView: SidebarView;
+  onViewChange: (view: SidebarView) => void;
+  commentThreads: ReviewThread[];
+  selectedCommentFile: string | null;
+  onSelectCommentFile: (path: string) => void;
 }
 
 function getMaxHunkSignificance(file: FileDiff): string {
@@ -309,6 +312,72 @@ function TreeFolder({
   );
 }
 
+/* ─── Comment file list ──────────────────────────────────────────────────── */
+
+function CommentFileList({
+  threads,
+  selectedFile,
+  onSelectFile,
+}: {
+  threads: ReviewThread[];
+  selectedFile: string | null;
+  onSelectFile: (path: string) => void;
+}) {
+  const fileMap = useMemo(() => {
+    const map = new Map<string, { total: number; unresolved: number }>();
+    for (const t of threads) {
+      const entry = map.get(t.path) ?? { total: 0, unresolved: 0 };
+      entry.total++;
+      if (!t.is_resolved) entry.unresolved++;
+      map.set(t.path, entry);
+    }
+    // Sort: files with unresolved threads first, then alphabetical
+    const sorted = [...map.entries()].sort((a, b) => {
+      if (a[1].unresolved > 0 && b[1].unresolved === 0) return -1;
+      if (a[1].unresolved === 0 && b[1].unresolved > 0) return 1;
+      return a[0].localeCompare(b[0]);
+    });
+    return sorted;
+  }, [threads]);
+
+  if (threads.length === 0) {
+    return (
+      <div className="comment-file-list-empty">
+        No review threads on this PR
+      </div>
+    );
+  }
+
+  return (
+    <div className="comment-file-list">
+      {fileMap.map(([path, counts]) => {
+        const fileName = getFileName(path);
+        const dirHint = path.split("/").slice(-2, -1)[0] || "";
+        return (
+          <button
+            key={path}
+            className={`comment-file-item ${selectedFile === path ? "selected" : ""}`}
+            onClick={() => onSelectFile(path)}
+            title={path}
+          >
+            <span className="file-name">{fileName}</span>
+            <span className="file-path-hint">{dirHint}</span>
+            {counts.unresolved > 0 ? (
+              <span className="unresolved-badge">
+                {counts.unresolved}
+              </span>
+            ) : (
+              <span className="comment-count-badge">
+                {counts.total}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 /* ─── Main component ────────────────────────────────────────────────────── */
 
 export function FileSidebar({
@@ -321,13 +390,16 @@ export function FileSidebar({
   showHunkSignificance,
   hunkFilter,
   onHunkFilterChange,
+  sidebarView: view,
+  onViewChange: setView,
+  commentThreads,
+  selectedCommentFile,
+  onSelectCommentFile,
 }: FileSidebarProps) {
   const hasGroups = changeGroups.length > 0;
-  const [view, setView] = useState<SidebarView>(hasGroups ? "groups" : "category");
   const prevHasGroups = useRef(hasGroups);
 
   useEffect(() => {
-    // Only auto-switch when groups first arrive, not on every tab switch
     if (hasGroups && !prevHasGroups.current) {
       setView("groups");
     }
@@ -429,34 +501,44 @@ export function FileSidebar({
   return (
     <aside className="file-sidebar">
       <div className="sidebar-header">
-        <span>
-          Files ({viewedCount}/{totalCount} viewed)
-        </span>
-        <div className="sidebar-view-toggle">
-          {hasGroups && (
+        <div className="sidebar-header-top">
+          <span className="sidebar-title">Files</span>
+          <div className="sidebar-view-toggle">
+            {hasGroups && (
+              <button
+                className={view === "groups" ? "active" : ""}
+                onClick={() => setView("groups")}
+                title="Group by logical change"
+              >
+                Groups
+              </button>
+            )}
             <button
-              className={view === "groups" ? "active" : ""}
-              onClick={() => setView("groups")}
-              title="Group by logical change"
+              className={view === "comments" ? "active" : ""}
+              onClick={() => setView("comments")}
+              title="Review comments"
             >
-              Groups
+              Comments
             </button>
-          )}
-          <button
-            className={view === "category" ? "active" : ""}
-            onClick={() => setView("category")}
-            title="Group by category"
-          >
-            Category
-          </button>
-          <button
-            className={view === "tree" ? "active" : ""}
-            onClick={() => setView("tree")}
-            title="File tree"
-          >
-            Tree
-          </button>
+            <button
+              className={view === "category" ? "active" : ""}
+              onClick={() => setView("category")}
+              title="Group by category"
+            >
+              Category
+            </button>
+            <button
+              className={view === "tree" ? "active" : ""}
+              onClick={() => setView("tree")}
+              title="File tree"
+            >
+              Tree
+            </button>
+          </div>
         </div>
+        <span className="sidebar-file-count">
+          {viewedCount}/{totalCount} viewed
+        </span>
       </div>
       {viewedCount > 0 && (
         <button
@@ -484,7 +566,13 @@ export function FileSidebar({
         </div>
       )}
       <nav className="file-list">
-        {view === "groups" ? (
+        {view === "comments" ? (
+          <CommentFileList
+            threads={commentThreads}
+            selectedFile={selectedCommentFile}
+            onSelectFile={onSelectCommentFile}
+          />
+        ) : view === "groups" ? (
           <>
             {changeGroups.map((group, idx) => {
               const groupKey = `group:${idx}`;

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import type { ReviewManifest, DiffViewMode, Tab } from "../types";
+import type { ReviewManifest, DiffViewMode, Tab, CommentThreadsState } from "../types";
 
 interface HeaderProps {
   tabs: Tab[];
@@ -18,6 +19,8 @@ interface HeaderProps {
   onToggleHunkSignificance: () => void;
   showAiNotes: boolean;
   onToggleAiNotes: () => void;
+  commentThreads?: CommentThreadsState;
+  onSubmitReview?: (event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) => Promise<void>;
 }
 
 export function Header({
@@ -35,6 +38,8 @@ export function Header({
   onToggleHunkSignificance,
   showAiNotes,
   onToggleAiNotes,
+  commentThreads,
+  onSubmitReview,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -131,6 +136,7 @@ export function Header({
             <button className="settings-button" onClick={onSettingsClick}>
               Settings
             </button>
+            {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} />}
           </div>
         </div>
       )}
@@ -140,5 +146,130 @@ export function Header({
         </div>
       )}
     </header>
+  );
+}
+
+function ReviewSubmitButton({
+  commentThreads,
+  onSubmitReview,
+  prTitle,
+  prUrl,
+}: {
+  commentThreads?: CommentThreadsState;
+  onSubmitReview: (event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) => Promise<void>;
+  prTitle: string;
+  prUrl: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [body, setBody] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [fetchedThreads, setFetchedThreads] = useState<import("../types").ReviewThread[] | null>(null);
+
+  // Use freshly fetched threads if available, otherwise fall back to prop
+  const threads = fetchedThreads ?? (commentThreads?.status === "loaded" ? commentThreads.threads : []);
+  const unresolvedThreads = threads.filter((t) => !t.is_resolved);
+  const unresolvedCount = unresolvedThreads.length;
+
+  async function handleOpen() {
+    const wasOpen = isOpen;
+    setIsOpen((v) => !v);
+    if (wasOpen) return;
+
+    setGenerating(true);
+    try {
+      // Always fetch fresh threads from GitHub to get accurate state
+      const freshThreads = await invoke<import("../types").ReviewThread[]>("fetch_review_comments", { prUrl });
+      setFetchedThreads(freshThreads);
+
+      const unresolved = freshThreads.filter((t) => !t.is_resolved);
+
+      const threadsJson = unresolved.length > 0
+        ? JSON.stringify(unresolved.map((t) => ({
+            path: t.path,
+            line: t.line,
+            comments: t.comments.map((c) => ({ author: c.author.login, body: c.body })),
+          })))
+        : "[]";
+
+      const generated = await invoke<string>("generate_review_body", {
+        threadsJson,
+        prTitle,
+        hasUnresolved: unresolved.length > 0,
+      });
+      setBody(generated);
+    } catch {
+      // Silently fail — user can type manually
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function handleSubmit(event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT") {
+    setSubmitting(true);
+    try {
+      await onSubmitReview(event, body);
+      setBody("");
+      setIsOpen(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="review-submit-wrapper">
+      <button
+        className="review-submit-toggle"
+        onClick={handleOpen}
+      >
+        Finish Review
+        {unresolvedCount > 0 && (
+          <span className="review-submit-badge">{unresolvedCount}</span>
+        )}
+      </button>
+      {isOpen && (
+        <div className="review-submit-dropdown">
+          <textarea
+            className="review-submit-body"
+            value={generating ? "Generating..." : body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder="Leave a comment with your review (optional)"
+            rows={3}
+            disabled={generating}
+          />
+          {unresolvedCount > 0 && (
+            <div className="review-submit-warning">
+              {unresolvedCount} unresolved {unresolvedCount === 1 ? "thread" : "threads"}
+            </div>
+          )}
+          <div className="review-submit-actions">
+            <button
+              className="review-action-comment"
+              disabled={submitting || generating}
+              onClick={() => handleSubmit("COMMENT")}
+              title="Submit review without explicit approval or change request"
+            >
+              Comment
+            </button>
+            <button
+              className="review-action-approve"
+              disabled={submitting || generating}
+              onClick={() => handleSubmit("APPROVE")}
+              title="Approve this pull request"
+            >
+              Approve
+            </button>
+            <button
+              className="review-action-request-changes"
+              disabled={submitting || generating}
+              onClick={() => handleSubmit("REQUEST_CHANGES")}
+              title="Request changes on this pull request"
+            >
+              Request Changes
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -315,15 +315,29 @@ body {
 }
 
 .sidebar-header {
-  padding: 12px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text-secondary);
+  padding: 10px 16px 8px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
   display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-header-top {
+  display: flex;
   align-items: center;
   justify-content: space-between;
+}
+
+.sidebar-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.sidebar-file-count {
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 .sidebar-view-toggle {
@@ -1915,4 +1929,822 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--border);
+}
+
+/* ─── Comments Viewer ──────────────────────────────────────────────────── */
+.comments-viewer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.comments-viewer-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.comments-viewer-path {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.comments-viewer-summary {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-left: auto;
+}
+
+.comments-viewer-threads {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comments-viewer-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+/* ─── Thread Card ──────────────────────────────────────────────────────── */
+.thread-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.thread-card-resolved {
+  opacity: 0.6;
+}
+
+.thread-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.thread-card-header:hover {
+  background: var(--border);
+}
+
+.thread-card-location {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-primary);
+}
+
+.thread-card-comment-count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.thread-outdated-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--risk-medium-bg);
+  color: var(--risk-medium);
+  margin-left: 6px;
+}
+
+.thread-resolved-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: var(--diff-add-bg);
+  color: var(--diff-add-text);
+}
+
+/* ─── Thread Hunk Preview ──────────────────────────────────────────────── */
+.thread-hunk-preview {
+  border-bottom: 1px solid var(--border);
+}
+
+.thread-hunk-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.thread-hunk-toggle:hover {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+.thread-hunk-code {
+  margin: 0;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* ─── Thread Comments ──────────────────────────────────────────────────── */
+.thread-comments {
+  display: flex;
+  flex-direction: column;
+}
+
+.thread-comment {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.thread-comment:last-child {
+  border-bottom: none;
+}
+
+.comment-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.comment-avatar {
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.comment-author {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.comment-time {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.comment-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ─── Thread Actions ───────────────────────────────────────────────────── */
+.thread-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
+}
+
+.reply-open-button {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-muted);
+  padding: 4px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.reply-open-button:hover {
+  color: var(--text-secondary);
+  border-color: var(--text-muted);
+}
+
+.resolve-button {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--diff-add-text);
+  border-radius: 6px;
+  color: var(--diff-add-text);
+  padding: 4px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.resolve-button:hover {
+  background: var(--diff-add-bg);
+}
+
+.resolve-button-resolved {
+  border-color: var(--text-muted);
+  color: var(--text-muted);
+}
+
+.resolve-button-resolved:hover {
+  background: var(--bg-tertiary);
+}
+
+/* ─── Reply Form ───────────────────────────────────────────────────────── */
+.thread-reply-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+}
+
+.reply-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  resize: vertical;
+  outline: none;
+  min-height: 60px;
+}
+
+.reply-textarea:focus {
+  border-color: var(--accent);
+}
+
+.reply-textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.reply-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.suggest-button {
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: var(--accent);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  margin-right: auto;
+}
+
+.suggest-button:hover {
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.reply-cancel {
+  padding: 4px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.reply-cancel:hover {
+  color: var(--text-primary);
+}
+
+.reply-submit {
+  padding: 4px 12px;
+  background: var(--accent);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.reply-submit:hover:not(:disabled) {
+  background: #79c0ff;
+}
+
+.reply-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ─── Comment File List (sidebar) ──────────────────────────────────────── */
+.comment-file-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.comment-file-list-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.comment-file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 16px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.comment-file-item .file-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.comment-file-item .file-path-hint {
+  margin-left: 0;
+  width: 48px;
+  text-align: right;
+}
+
+.comment-file-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.comment-file-item.selected {
+  background: rgba(88, 166, 255, 0.15);
+}
+
+.comment-count-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* ─── Inline Review Threads (Diff View) ────────────────────────────────── */
+.inline-thread-row td {
+  padding: 0;
+}
+
+.inline-thread {
+  border-left: 3px solid var(--accent);
+  background: rgba(88, 166, 255, 0.06);
+  margin: 0;
+}
+
+.inline-thread-resolved .inline-thread {
+  border-left-color: var(--diff-add-text);
+  background: rgba(63, 185, 80, 0.04);
+  opacity: 0.6;
+}
+
+.inline-thread-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+}
+
+.inline-thread-header:hover {
+  background: rgba(88, 166, 255, 0.1);
+}
+
+.inline-thread-author {
+  font-weight: 600;
+  color: var(--text-primary);
+  flex-shrink: 0;
+}
+
+.inline-thread-preview {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.inline-thread-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.inline-thread-reply-count {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.inline-thread-resolved-badge {
+  font-size: 10px;
+  font-weight: 600;
+  padding: 0 6px;
+  border-radius: 8px;
+  background: var(--diff-add-bg);
+  color: var(--diff-add-text);
+}
+
+.inline-thread-single {
+  padding: 8px 12px;
+}
+
+.inline-thread-comments {
+  border-top: 1px solid var(--border);
+}
+
+.inline-thread-comment {
+  padding: 8px 12px 8px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.inline-thread-comment:last-child {
+  border-bottom: none;
+}
+
+.comment-body-wrapper {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.comment-body-wrapper .comment-body {
+  flex: 1;
+}
+
+.comment-edit-button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  padding: 0;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.inline-thread-single:hover .comment-edit-button,
+.inline-thread-comment:hover .comment-edit-button,
+.thread-comment:hover .comment-edit-button {
+  opacity: 1;
+}
+
+.comment-edit-button:hover {
+  color: var(--accent);
+}
+
+.comment-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+/* ─── Inline Comment (Diff View) ───────────────────────────────────────── */
+.line-comment-button {
+  display: none;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.commentable-line:hover .line-comment-button {
+  display: block;
+}
+
+.inline-comment-row td {
+  padding: 0;
+}
+
+.inline-comment-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--bg-secondary);
+  border-top: 1px solid var(--accent);
+  border-bottom: 1px solid var(--accent);
+}
+
+.inline-comment-snippet {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.inline-comment-line-range {
+  display: block;
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.inline-comment-code {
+  margin: 0;
+  padding: 8px 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+/* ─── Suggestion Preview ───────────────────────────────────────────────── */
+.inline-comment-suggestion-preview {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.suggestion-preview-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  background: var(--bg-tertiary);
+  border-bottom: 1px solid var(--border);
+}
+
+.suggestion-preview-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.suggestion-preview-original {
+  border-bottom: 1px solid var(--border);
+}
+
+.suggestion-code-remove {
+  background: var(--diff-remove-bg) !important;
+  border-left: 3px solid var(--diff-remove-text);
+}
+
+.suggestion-code-add {
+  background: var(--diff-add-bg) !important;
+  border-left: 3px solid var(--diff-add-text);
+}
+
+/* ─── Review Submit ────────────────────────────────────────────────────── */
+.review-submit-wrapper {
+  position: relative;
+}
+
+.review-submit-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background: var(--diff-add-text);
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.review-submit-toggle:hover {
+  background: #2ea043;
+}
+
+.review-submit-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+.review-submit-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  width: 340px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 50;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.review-submit-body {
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  resize: vertical;
+  outline: none;
+  min-height: 60px;
+}
+
+.review-submit-body:focus {
+  border-color: var(--accent);
+}
+
+.review-submit-body::placeholder {
+  color: var(--text-muted);
+}
+
+.review-submit-warning {
+  font-size: 12px;
+  color: var(--risk-high);
+  background: var(--risk-high-bg);
+  padding: 4px 10px;
+  border-radius: 4px;
+}
+
+.review-submit-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.review-action-comment {
+  flex: 1;
+  padding: 6px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.review-action-comment:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.review-action-approve {
+  flex: 1;
+  padding: 6px 8px;
+  background: var(--diff-add-bg);
+  border: 1px solid var(--diff-add-text);
+  border-radius: 6px;
+  color: var(--diff-add-text);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.review-action-approve:hover {
+  background: var(--diff-add-text);
+  color: #fff;
+}
+
+.review-action-request-changes {
+  flex: 1;
+  padding: 6px 8px;
+  background: var(--diff-remove-bg);
+  border: 1px solid var(--diff-remove-text);
+  border-radius: 6px;
+  color: var(--diff-remove-text);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.review-action-request-changes:hover {
+  background: var(--diff-remove-text);
+  color: #fff;
+}
+
+.review-action-comment:disabled,
+.review-action-approve:disabled,
+.review-action-request-changes:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ─── Comment Suggestion Block ─────────────────────────────────────────── */
+.comment-suggestion-block {
+  margin: 6px 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.comment-suggestion-block .suggestion-preview-header {
+  padding: 4px 10px;
+}
+
+.comment-suggestion-block .inline-comment-code {
+  margin: 0;
+}
+
+/* ─── Line Selection (drag) ────────────────────────────────────────────── */
+.line-selected {
+  background: rgba(88, 166, 255, 0.12) !important;
+}
+
+.line-num {
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+}
+
+.unresolved-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--risk-high-bg);
+  color: var(--risk-high);
+  flex-shrink: 0;
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -54,6 +54,39 @@ export interface FetchProgress {
   files_total?: number;
 }
 
+export interface CommentAuthor {
+  login: string;
+  avatar_url: string;
+}
+
+export interface ReviewComment {
+  id: string;
+  body: string;
+  author: CommentAuthor;
+  created_at: string;
+  updated_at: string;
+  url: string;
+}
+
+export interface ReviewThread {
+  id: string;
+  is_resolved: boolean;
+  is_outdated: boolean;
+  path: string;
+  line: number | null;
+  original_line: number | null;
+  diff_hunk: string;
+  comments: ReviewComment[];
+}
+
+export type CommentThreadsState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "loaded"; threads: ReviewThread[] }
+  | { status: "error"; message: string };
+
+export type SidebarView = "groups" | "comments" | "category" | "tree";
+
 export type DiffViewMode = "split" | "unified";
 
 export type HunkSignificanceFilter = "all" | "high" | "medium" | "low";
@@ -63,6 +96,9 @@ export interface Tab {
   manifest: ReviewManifest;
   selectedFile: FileDiff | null;
   viewedFiles: Set<string>;
+  commentThreads: CommentThreadsState;
+  selectedCommentFile: string | null;
+  sidebarView: SidebarView;
 }
 
 export interface Settings {

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,0 +1,14 @@
+export function timeAgo(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const seconds = Math.floor((now - then) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}


### PR DESCRIPTION
## Summary

> **Note:** This PR is based on #7 (review requests list). Merge that first.

- **Comments tab** in sidebar with file-level thread counts, unresolved badges, and sorted file list
- **CommentsViewer** pane showing threaded conversations with reply, edit, resolve/unresolve
- **Inline review threads** in the diff view — single-comment threads render compactly, multi-comment threads are collapsible
- **Inline comment creation** — click a line number for single-line, drag across lines for multi-line range selection with code snippet preview
- **GitHub suggestion blocks** — "Suggest" button pre-fills ` ```suggestion ` fence with selected code; live syntax-highlighted diff preview (original vs replacement) updates as you type
- **Edit comments** — inline edit with auto-sizing textarea, Cmd+Enter to save
- **Finish Review** dropdown — Approve / Request Changes / Comment with AI-generated review body (change summary for unresolved threads, nerdy LGTM for clean PRs)
- **GraphQL backend** for all comment operations: fetch threads, reply, create thread (single/multi-line), edit, resolve/unresolve, submit review

## Test plan

- [ ] Open a PR with existing review comments — verify threads appear in Comments tab and inline in diff
- [ ] Click a line number to add a single-line comment — verify it posts to GitHub
- [ ] Drag across multiple lines — verify range selection highlights, code snippet appears, and suggestion button works
- [ ] Click Suggest, edit the code, verify live preview shows red/green diff with syntax highlighting
- [ ] Edit an existing comment — verify save updates both inline and Comments tab
- [ ] Resolve/unresolve a thread from both views
- [ ] Click Finish Review with unresolved threads — verify AI summarizes requested changes
- [ ] Click Finish Review with no unresolved threads — verify AI generates nerdy LGTM
- [ ] Submit review with each action type (Comment, Approve, Request Changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)