### PR TITLE
feat: add local and global find with word highlighting

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
@@ -10,7 +10,8 @@ import { ReviewRequestList } from "./components/ReviewRequestList";
 import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment } from "./types";
+import { SearchBar } from "./components/SearchBar";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch } from "./types";
 
 function App() {
   const nextTabId = useRef(1);
@@ -28,8 +29,24 @@ function App() {
   const [loadingPrTitle, setLoadingPrTitle] = useState<string | null>(null);
   const [progress, setProgress] = useState<FetchProgress | null>(null);
   const [fileCounts, setFileCounts] = useState<Record<number, { done: number; total: number }>>({});
+  const [searchMatches, setSearchMatches] = useState<SearchMatch[]>([]);
+  const [searchCurrentIndex, setSearchCurrentIndex] = useState(0);
+  const [searchQuery, setSearchQuery] = useState("");
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+
+  const selectedFilePath = activeTab?.selectedFile?.path ?? null;
+  const fileSearchMatches = useMemo(
+    () => searchMatches.filter((m) => m.filePath === selectedFilePath),
+    [searchMatches, selectedFilePath]
+  );
+  const currentSearchMatch = useMemo(
+    () => {
+      const m = searchMatches[searchCurrentIndex];
+      return m?.filePath === selectedFilePath ? m : null;
+    },
+    [searchMatches, searchCurrentIndex, selectedFilePath]
+  );
 
   function createTab(manifest: ReviewManifest): Tab {
     const hasGroups = (manifest.change_groups ?? []).length > 0;
@@ -494,6 +511,14 @@ function App() {
         onClose={() => setSettingsOpen(false)}
       />
       {activeTab && (
+        <>
+        <SearchBar
+          files={activeTab.manifest.files}
+          selectedFile={activeTab.selectedFile}
+          onSelectFile={setSelectedFile}
+          onHighlightMatches={(matches, idx, q) => { setSearchMatches(matches); setSearchCurrentIndex(idx); setSearchQuery(q); }}
+          onClearHighlights={() => { setSearchMatches([]); setSearchCurrentIndex(0); setSearchQuery(""); }}
+        />
         <div className="main-content">
           <FileSidebar
             files={activeTab.manifest.files}
@@ -532,7 +557,7 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} />
+              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
             ) : activeTab.manifest.summary ? (
               <div className="pr-summary">
                 <h3>PR Summary</h3>
@@ -543,6 +568,7 @@ function App() {
             )}
           </div>
         </div>
+        </>
       )}
     </div>
   );

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
-import type { FileDiff, DiffViewMode, Highlight, ReviewThread, ReviewComment } from "../types";
+import type { FileDiff, DiffViewMode, Highlight, ReviewThread, ReviewComment, SearchMatch } from "../types";
 import { timeAgo } from "../utils";
 
 const extToLang: Record<string, string> = {
@@ -101,6 +101,9 @@ interface DiffViewerProps {
   onCreateComment?: (path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") => Promise<void>;
   onEditComment?: (commentId: string, body: string) => void;
   reviewThreads?: ReviewThread[];
+  searchMatches?: SearchMatch[];
+  currentSearchMatch?: SearchMatch | null;
+  searchQuery?: string;
 }
 
 export const CommentBodyRendered = memo(function CommentBodyRendered({ body, lang }: { body: string; lang?: string }) {
@@ -1133,9 +1136,10 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, reviewThreads }: DiffViewerProps) {
+export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
+  const diffContentRef = useRef<HTMLDivElement>(null);
 
   function handleLineMouseDown(line: number, side: "LEFT" | "RIGHT") {
     setDragging({ anchorLine: line, side, currentLine: line });
@@ -1266,6 +1270,188 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
   const isCritical =
     file.risk_level === "critical" || file.risk_level === "high";
 
+  // Track original collapsed state so we can restore it when search ends
+  const preSearchCollapsed = useRef<Set<number> | null>(null);
+  const collapsedHunksRef = useRef(collapsedHunks);
+  collapsedHunksRef.current = collapsedHunks;
+
+  // Expand collapsed hunks that contain search matches; restore when search clears
+  useEffect(() => {
+    const hasSearch = searchQuery && searchMatches && searchMatches.length > 0;
+
+    if (!hasSearch) {
+      // Search ended — restore original collapsed state if we saved one
+      if (preSearchCollapsed.current !== null) {
+        setCollapsedHunks(preSearchCollapsed.current);
+        preSearchCollapsed.current = null;
+      }
+      return;
+    }
+
+    // Save original collapsed state before we start expanding
+    if (preSearchCollapsed.current === null) {
+      preSearchCollapsed.current = new Set(collapsedHunksRef.current);
+    }
+
+    // Find which hunk indices contain search match line numbers
+    const matchLineNums = new Set(searchMatches!.map((m) => m.lineNumber));
+    const hunksToExpand = new Set<number>();
+    for (const hunk of hunks) {
+      for (const line of hunk.lines) {
+        const ln = line.newLineNum ?? line.oldLineNum;
+        if (ln != null && matchLineNums.has(ln)) {
+          hunksToExpand.add(hunk.index);
+          break;
+        }
+      }
+    }
+
+    if (hunksToExpand.size === 0) return;
+
+    setCollapsedHunks((prev) => {
+      const next = new Set(prev);
+      for (const idx of hunksToExpand) {
+        next.delete(idx);
+      }
+      if (next.size === prev.size) return prev;
+      return next;
+    });
+  }, [searchQuery, searchMatches, hunks]);
+
+  // Apply word-level search highlights into the DOM (marks all matches)
+  useEffect(() => {
+    const container = diffContentRef.current;
+    if (!container) return;
+
+    function clearMarks() {
+      container!.querySelectorAll("mark.search-highlight, mark.search-highlight-current").forEach((el) => {
+        const parent = el.parentNode;
+        if (parent) {
+          parent.replaceChild(document.createTextNode(el.textContent || ""), el);
+          parent.normalize();
+        }
+      });
+      container!.querySelectorAll(".search-match-line").forEach((el) => {
+        el.classList.remove("search-match-line");
+      });
+    }
+
+    clearMarks();
+
+    if (!searchQuery || !searchMatches || searchMatches.length === 0) return;
+
+    const query = searchQuery.toLowerCase();
+
+    const pres = container.querySelectorAll<HTMLElement>(".line-content pre");
+    for (const pre of pres) {
+      const row = pre.closest("tr");
+      if (!row) continue;
+
+      const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+      const textNodes: Text[] = [];
+      let node: Node | null;
+      while ((node = walker.nextNode())) {
+        textNodes.push(node as Text);
+      }
+
+      let hasMatch = false;
+      let charOffset = 0;
+
+      // Get the line number for this row (used as data attribute on marks)
+      const lineNumCells = row.querySelectorAll<HTMLElement>(".line-num");
+      let lineNum: number | null = null;
+      for (const cell of lineNumCells) {
+        const text = cell.textContent?.trim();
+        if (text && /^\d+$/.test(text)) {
+          lineNum = parseInt(text, 10);
+          break;
+        }
+      }
+
+      for (const textNode of textNodes) {
+        const text = textNode.textContent || "";
+        const textLower = text.toLowerCase();
+        const parts: (string | { text: string; offset: number })[] = [];
+        let lastEnd = 0;
+        let searchStart = 0;
+
+        while (true) {
+          const idx = textLower.indexOf(query, searchStart);
+          if (idx === -1) break;
+          if (idx > lastEnd) parts.push(text.slice(lastEnd, idx));
+          parts.push({ text: text.slice(idx, idx + query.length), offset: charOffset + idx });
+          lastEnd = idx + query.length;
+          searchStart = idx + 1;
+          hasMatch = true;
+        }
+
+        charOffset += text.length;
+        if (parts.length === 0) continue;
+        if (lastEnd < text.length) parts.push(text.slice(lastEnd));
+
+        const frag = document.createDocumentFragment();
+        for (const part of parts) {
+          if (typeof part === "string") {
+            frag.appendChild(document.createTextNode(part));
+          } else {
+            const mark = document.createElement("mark");
+            mark.className = "search-highlight";
+            mark.dataset.line = String(lineNum ?? "");
+            mark.dataset.offset = String(part.offset);
+            mark.textContent = part.text;
+            frag.appendChild(mark);
+          }
+        }
+        textNode.parentNode!.replaceChild(frag, textNode);
+      }
+
+      if (hasMatch) row.classList.add("search-match-line");
+    }
+
+    return clearMarks;
+  }, [searchMatches, searchQuery, file.path]);
+
+  // Update which mark is the "current" one (lightweight — just swaps classes)
+  useEffect(() => {
+    const container = diffContentRef.current;
+    if (!container) return;
+
+    // Clear previous current mark
+    const prev = container.querySelector("mark.search-highlight-current");
+    if (prev) {
+      prev.className = "search-highlight";
+      prev.closest("tr")?.classList.remove("search-current-line");
+    }
+
+    if (!currentMatchInFile) return;
+
+    // Find the mark matching the current search match by data attributes
+    const marks = container.querySelectorAll<HTMLElement>("mark.search-highlight");
+    for (const mark of marks) {
+      if (
+        mark.dataset.line === String(currentMatchInFile.lineNumber) &&
+        mark.dataset.offset === String(currentMatchInFile.matchStart)
+      ) {
+        mark.className = "search-highlight-current";
+        mark.closest("tr")?.classList.add("search-current-line");
+        mark.scrollIntoView({ block: "center", behavior: "smooth" });
+        return;
+      }
+    }
+
+    // Fallback: scroll to the row by line number
+    const allLineNums = container.querySelectorAll<HTMLElement>(".line-num");
+    for (const el of allLineNums) {
+      if (el.textContent?.trim() === String(currentMatchInFile.lineNumber)) {
+        const row = el.closest("tr");
+        if (row) {
+          row.scrollIntoView({ block: "center", behavior: "smooth" });
+          break;
+        }
+      }
+    }
+  }, [currentMatchInFile]);
+
   const highHunkCount = hunks.filter((h) => h.significance === "high").length;
   const collapsedCount = collapsedHunks.size;
 
@@ -1336,7 +1522,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
           ))}
         </div>
       )}
-      <div className="diff-content">
+      <div className="diff-content" ref={diffContentRef}>
         {useHunkView ? (
           viewMode === "unified" || file.diff_type !== "modified" ? (
             <UnifiedView

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { FileDiff, RiskLevel, ChangeGroup, HunkSignificanceFilter, SidebarView, ReviewThread } from "../types";
+import { getFileName } from "../utils";
 
 interface FileSidebarProps {
   files: FileDiff[];
@@ -33,10 +34,6 @@ function fileMatchesHunkFilter(file: FileDiff, filter: HunkSignificanceFilter): 
   if (filter === "medium") return max === "high" || max === "medium";
   // "low" means show all (including low-only) — same as "all"
   return true;
-}
-
-function getFileName(path: string): string {
-  return path.split("/").pop() || path;
 }
 
 function getDiffTypeIcon(diffType: string): string {

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { FileDiff, SearchMatch } from "../types";
+import { getFileName } from "../utils";
+
+type SearchMode = "local" | "global";
+
+interface SearchBarProps {
+  files: FileDiff[];
+  selectedFile: FileDiff | null;
+  onSelectFile: (file: FileDiff) => void;
+  onHighlightMatches: (matches: SearchMatch[], currentIndex: number, query: string) => void;
+  onClearHighlights: () => void;
+}
+
+function searchInContent(
+  content: string,
+  query: string,
+  filePath: string,
+): SearchMatch[] {
+  if (!content || !query) return [];
+  const lower = query.toLowerCase();
+  const lines = content.split("\n");
+  const matches: SearchMatch[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const lineLower = line.toLowerCase();
+    let start = 0;
+    while (true) {
+      const idx = lineLower.indexOf(lower, start);
+      if (idx === -1) break;
+      matches.push({
+        filePath,
+        lineNumber: i + 1,
+        lineContent: line,
+        matchStart: idx,
+        matchLength: query.length,
+      });
+      start = idx + 1;
+    }
+  }
+  return matches;
+}
+
+function dedupeMatches(matches: SearchMatch[]): SearchMatch[] {
+  const seen = new Set<string>();
+  return matches.filter((m) => {
+    const key = `${m.filePath}:${m.lineNumber}:${m.matchStart}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function SearchBar({
+  files,
+  selectedFile,
+  onSelectFile,
+  onHighlightMatches,
+  onClearHighlights,
+}: SearchBarProps) {
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<SearchMode>("local");
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const resultsRef = useRef<HTMLDivElement>(null);
+
+  // Debounce the query for global search (local stays instant)
+  useEffect(() => {
+    if (mode === "local") {
+      setDebouncedQuery(query);
+      return;
+    }
+    const timer = setTimeout(() => setDebouncedQuery(query), 150);
+    return () => clearTimeout(timer);
+  }, [query, mode]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+    setDebouncedQuery("");
+    setCurrentIndex(0);
+    onClearHighlights();
+  }, [onClearHighlights]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Cmd+F = local find, Cmd+Shift+F = global find
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        const newMode = e.shiftKey ? "global" : "local";
+        if (open && mode === newMode) {
+          // Already open in the same mode — just focus
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        } else {
+          setMode(newMode);
+          setOpen(true);
+          setCurrentIndex(0);
+          // If switching modes, keep the query
+        }
+        setTimeout(() => {
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        }, 0);
+      }
+      if (e.key === "Escape" && open) {
+        e.preventDefault();
+        close();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, mode, close]);
+
+  // Compute matches — local uses instant query, global uses debounced
+  const effectiveQuery = mode === "local" ? query : debouncedQuery;
+  const allMatches = useMemo(() => {
+    if (!effectiveQuery) return [];
+    if (mode === "global" && effectiveQuery.length < 2) return [];
+    if (mode === "local") {
+      if (!selectedFile) return [];
+      return dedupeMatches([
+        ...searchInContent(selectedFile.head_content, effectiveQuery, selectedFile.path),
+        ...searchInContent(selectedFile.base_content, effectiveQuery, selectedFile.path),
+      ]);
+    } else {
+      const MAX_GLOBAL_MATCHES = 1000;
+      const matches: SearchMatch[] = [];
+      for (const file of files) {
+        matches.push(...dedupeMatches([
+          ...searchInContent(file.head_content, effectiveQuery, file.path),
+          ...searchInContent(file.base_content, effectiveQuery, file.path),
+        ]));
+        if (matches.length >= MAX_GLOBAL_MATCHES) {
+          return matches.slice(0, MAX_GLOBAL_MATCHES);
+        }
+      }
+      return matches;
+    }
+  }, [effectiveQuery, mode, selectedFile, files]);
+
+  // Group by file for global results
+  const groupedResults = useMemo(() => {
+    if (mode !== "global") return null;
+    const groups = new Map<string, SearchMatch[]>();
+    for (const m of allMatches) {
+      const arr = groups.get(m.filePath);
+      if (arr) arr.push(m);
+      else groups.set(m.filePath, [m]);
+    }
+    return groups;
+  }, [allMatches, mode]);
+
+  // Clamp current index
+  useEffect(() => {
+    if (currentIndex >= allMatches.length) {
+      setCurrentIndex(Math.max(0, allMatches.length - 1));
+    }
+  }, [allMatches.length, currentIndex]);
+
+  // Notify parent of highlights
+  useEffect(() => {
+    if (!open || allMatches.length === 0) {
+      onClearHighlights();
+      return;
+    }
+    onHighlightMatches(allMatches, currentIndex, effectiveQuery);
+  }, [allMatches, currentIndex, open]);
+
+  function goNext() {
+    if (allMatches.length === 0) return;
+    const next = (currentIndex + 1) % allMatches.length;
+    setCurrentIndex(next);
+    navigateToMatch(next);
+  }
+
+  function goPrev() {
+    if (allMatches.length === 0) return;
+    const prev = (currentIndex - 1 + allMatches.length) % allMatches.length;
+    setCurrentIndex(prev);
+    navigateToMatch(prev);
+  }
+
+  function navigateToMatch(index: number) {
+    const match = allMatches[index];
+    if (!match) return;
+    // If global mode, switch to the matched file
+    if (mode === "global") {
+      const file = files.find((f) => f.path === match.filePath);
+      if (file && file.path !== selectedFile?.path) {
+        onSelectFile(file);
+      }
+    }
+  }
+
+  function handleResultClick(match: SearchMatch, index: number) {
+    setCurrentIndex(index);
+    const file = files.find((f) => f.path === match.filePath);
+    if (file) {
+      onSelectFile(file);
+    }
+    onHighlightMatches(allMatches, index, effectiveQuery);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) goPrev();
+      else goNext();
+    }
+  }
+
+  // Scroll active result into view
+  useEffect(() => {
+    if (mode !== "global" || !resultsRef.current) return;
+    const active = resultsRef.current.querySelector(".search-result-item.active");
+    if (active) {
+      active.scrollIntoView({ block: "nearest" });
+    }
+  }, [currentIndex, mode]);
+
+  if (!open) return null;
+
+  // Compute a flat index for global results to map back to allMatches index
+  let globalFlatIndex = 0;
+
+  return (
+    <div className={`search-bar ${mode}`}>
+      <div className="search-bar-input-row">
+        <div className="search-mode-toggle">
+          <button
+            className={mode === "local" ? "active" : ""}
+            onClick={() => { setMode("local"); setCurrentIndex(0); }}
+            title="Find in current file (Cmd+F)"
+          >
+            File
+          </button>
+          <button
+            className={mode === "global" ? "active" : ""}
+            onClick={() => { setMode("global"); setCurrentIndex(0); }}
+            title="Find in all files (Cmd+Shift+F)"
+          >
+            All Files
+          </button>
+        </div>
+        <input
+          ref={inputRef}
+          className="search-input"
+          type="text"
+          value={query}
+          onChange={(e) => { setQuery(e.target.value); setCurrentIndex(0); }}
+          onKeyDown={handleKeyDown}
+          placeholder={mode === "local" ? "Find in file..." : "Find in all files..."}
+          autoFocus
+        />
+        <span className="search-count">
+          {query
+            ? allMatches.length > 0
+              ? `${currentIndex + 1}/${allMatches.length}`
+              : "No results"
+            : ""}
+        </span>
+        <button className="search-nav-btn" onClick={goPrev} disabled={allMatches.length === 0} title="Previous (Shift+Enter)">
+          &#9650;
+        </button>
+        <button className="search-nav-btn" onClick={goNext} disabled={allMatches.length === 0} title="Next (Enter)">
+          &#9660;
+        </button>
+        <button className="search-close-btn" onClick={close} title="Close (Esc)">
+          &times;
+        </button>
+      </div>
+      {mode === "global" && query && groupedResults && (
+        <div className="search-results-panel" ref={resultsRef}>
+          {groupedResults.size === 0 ? (
+            <div className="search-no-results">No matches found</div>
+          ) : (
+            Array.from(groupedResults.entries()).map(([filePath, matches]) => {
+              const startIdx = globalFlatIndex;
+              globalFlatIndex += matches.length;
+              return (
+                <div key={filePath} className="search-result-group">
+                  <div className="search-result-file">
+                    <span className="search-result-filename">{getFileName(filePath)}</span>
+                    <span className="search-result-filepath">{filePath}</span>
+                    <span className="search-result-file-count">{matches.length}</span>
+                  </div>
+                  {matches.map((match, i) => {
+                    const flatIdx = startIdx + i;
+                    const isActive = flatIdx === currentIndex;
+                    // Build highlighted line preview
+                    const before = match.lineContent.slice(0, match.matchStart);
+                    const matched = match.lineContent.slice(match.matchStart, match.matchStart + match.matchLength);
+                    const after = match.lineContent.slice(match.matchStart + match.matchLength);
+                    return (
+                      <button
+                        key={`${match.lineNumber}-${match.matchStart}`}
+                        className={`search-result-item ${isActive ? "active" : ""}`}
+                        onClick={() => handleResultClick(match, flatIdx)}
+                      >
+                        <span className="search-result-line-num">L{match.lineNumber}</span>
+                        <span className="search-result-line-text">
+                          <span>{truncateLeft(before, 40)}</span>
+                          <mark>{matched}</mark>
+                          <span>{truncateRight(after, 60)}</span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function truncateLeft(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return "..." + s.slice(s.length - maxLen);
+}
+
+function truncateRight(s: string, maxLen: number): string {
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen) + "...";
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2774,3 +2774,255 @@ body {
   color: var(--risk-high);
   flex-shrink: 0;
 }
+
+/* ─── Search Bar ────────────────────────────────────────────────────────── */
+.search-bar {
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+
+.search-bar-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+}
+
+.search-mode-toggle {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.search-mode-toggle button {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 4px 10px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.search-mode-toggle button:hover {
+  background: var(--bg-tertiary);
+}
+
+.search-mode-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.search-input {
+  flex: 1;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  padding: 5px 10px;
+  outline: none;
+  min-width: 0;
+}
+
+.search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.search-input::placeholder {
+  color: var(--text-muted);
+}
+
+.search-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  min-width: 70px;
+  text-align: center;
+}
+
+.search-nav-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  font-size: 10px;
+  width: 26px;
+  height: 26px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+
+.search-nav-btn:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.search-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.search-close-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 18px;
+  cursor: pointer;
+  padding: 2px 6px;
+  line-height: 1;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+
+.search-close-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+/* ─── Search Results Panel (Global) ─────────────────────────────────────── */
+.search-results-panel {
+  max-height: 300px;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+  background: var(--bg-primary);
+}
+
+.search-no-results {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.search-result-group {
+  border-bottom: 1px solid var(--border);
+}
+
+.search-result-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: var(--bg-secondary);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.search-result-filename {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.search-result-filepath {
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.search-result-file-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.search-result-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px 4px 24px;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  transition: background 0.1s;
+}
+
+.search-result-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.search-result-item.active {
+  background: rgba(88, 166, 255, 0.12);
+}
+
+.search-result-line-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 40px;
+  flex-shrink: 0;
+}
+
+.search-result-line-text {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--text-secondary);
+}
+
+.search-result-line-text mark {
+  background: rgba(227, 179, 65, 0.35);
+  color: #e3b341;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+/* ─── Search Match Highlighting (Diff View) ─────────────────────────────── */
+.search-match-line {
+  background: rgba(227, 179, 65, 0.06) !important;
+}
+
+.search-current-line {
+  background: rgba(227, 179, 65, 0.12) !important;
+}
+
+mark.search-highlight {
+  background: rgba(227, 179, 65, 0.35);
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+  outline: 1px solid rgba(227, 179, 65, 0.25);
+  outline-offset: 0;
+}
+
+mark.search-highlight-current {
+  background: rgba(227, 179, 65, 0.65);
+  color: #1c1c1e;
+  border-radius: 2px;
+  padding: 0 1px;
+  outline: 2px solid rgba(227, 179, 65, 0.8);
+  outline-offset: 0;
+  font-weight: 600;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -101,6 +101,14 @@ export interface Tab {
   sidebarView: SidebarView;
 }
 
+export interface SearchMatch {
+  filePath: string;
+  lineNumber: number;
+  lineContent: string;
+  matchStart: number;
+  matchLength: number;
+}
+
 export interface Settings {
   model: string;
   github_token: string;

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,3 +1,7 @@
+export function getFileName(path: string): string {
+  return path.split("/").pop() || path;
+}
+
 export function timeAgo(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();


### PR DESCRIPTION
## Summary
- Add a search bar with local file find (Cmd+F) and global all-files find (Cmd+Shift+F)
- Word-level highlighting in the diff view with distinct "current match" styling
- Global results panel grouped by file with line previews and click-to-navigate
- Auto-expand collapsed hunks containing matches, restore on search close
- Performance: debounced global search, memoized filtering, split DOM effects, 2-char min for global, 1000-match cap

## Screenshot

<img width="2559" height="950" alt="image" src="https://github.com/user-attachments/assets/bf7a7f7b-cf66-4aba-924f-5bdfc195c31e" />

## Test plan
- [ ] Open a PR with multiple files, press Cmd+F and search for a term — verify matches highlight in the current file
- [ ] Press Enter/Shift+Enter to navigate between matches — verify smooth scrolling and current match styling
- [ ] Press Cmd+Shift+F to switch to global search — verify results panel shows grouped matches across files
- [ ] Click a global result — verify it navigates to the correct file and highlights the match
- [ ] Search for a term inside a collapsed hunk — verify the hunk expands; close search and verify it re-collapses
- [ ] Press Escape to close search — verify all highlights are cleared
- [ ] Type a single character in global mode — verify no search runs (2-char minimum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)