### PR TITLE
feat(refresh): add auto-polling PR refresh with toast notifications

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use crate::bedrock::{region_from_arn, BedrockClient};
 use crate::config::{load_settings, resolve_github_token, save_settings_to_disk};
 use crate::fetch::fetch_pr_impl;
 use crate::github::GithubClient;
-use crate::types::{ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
+use crate::types::{PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use std::fs;
 use std::sync::Mutex;
 use tauri::{command, State};
@@ -45,6 +45,30 @@ pub fn get_initial_manifest_path(state: State<AppState>) -> Option<String> {
 pub async fn fetch_pr(app: tauri::AppHandle, pr_ref: String) -> Result<ReviewManifest, String> {
     let settings = load_settings();
     fetch_pr_impl(&pr_ref, &settings, &app).await
+}
+
+#[command]
+pub async fn check_pr_updates(
+    pr_url: String,
+    current_head_sha: String,
+    current_comment_count: u32,
+) -> Result<PrUpdateStatus, String> {
+    let github = github_client()?;
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    let (new_head_sha, new_comment_count) = github
+        .get_pr_status(&parsed.owner, &parsed.repo, parsed.number)
+        .await?;
+
+    let head_sha_changed = new_head_sha != current_head_sha;
+    let comment_count_changed = new_comment_count != current_comment_count;
+
+    Ok(PrUpdateStatus {
+        has_changes: head_sha_changed || comment_count_changed,
+        head_sha_changed,
+        comment_count_changed,
+        new_head_sha: if head_sha_changed { Some(new_head_sha) } else { None },
+        new_comment_count: if comment_count_changed { Some(new_comment_count) } else { None },
+    })
 }
 
 #[command]

--- a/app/src-tauri/src/github.rs
+++ b/app/src-tauri/src/github.rs
@@ -130,6 +130,53 @@ impl GithubClient {
         Ok(result)
     }
 
+    /// Lightweight check: returns (head_sha, review_comment_count) from a single REST call.
+    pub async fn get_pr_status(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<(String, u32), String> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/pulls/{}",
+            owner, repo, pr_number
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .header(AUTHORIZATION, format!("Bearer {}", self.token))
+            .header(USER_AGENT, "relevant-reviews")
+            .header(ACCEPT, "application/vnd.github.v3+json")
+            .send()
+            .await
+            .map_err(|e| format!("GitHub API request failed: {}", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("GitHub API error ({}): {}", status, body));
+        }
+
+        let json: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse PR status: {}", e))?;
+
+        let head_sha = json
+            .pointer("/head/sha")
+            .and_then(|v| v.as_str())
+            .ok_or("Missing head SHA in PR response")?
+            .to_string();
+
+        let comment_count = json
+            .get("review_comments")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        Ok((head_sha, comment_count))
+    }
+
     pub async fn get_pr_metadata(
         &self,
         owner: &str,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run() {
             commands::load_manifest,
             commands::get_initial_manifest_path,
             commands::fetch_pr,
+            commands::check_pr_updates,
             commands::fetch_review_requests,
             commands::fetch_review_comments,
             commands::reply_to_thread,

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -177,6 +177,15 @@ pub struct ReviewThread {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PrUpdateStatus {
+    pub has_changes: bool,
+    pub head_sha_changed: bool,
+    pub comment_count_changed: bool,
+    pub new_head_sha: Option<String>,
+    pub new_comment_count: Option<u32>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewRequestItem {
     pub owner: String,
     pub repo: String,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
@@ -11,7 +11,8 @@ import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
 import { SearchBar } from "./components/SearchBar";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch } from "./types";
+import { ToastContainer, createToast, type ToastData } from "./components/Toast";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus } from "./types";
 
 function App() {
   const nextTabId = useRef(1);
@@ -32,6 +33,15 @@ function App() {
   const [searchMatches, setSearchMatches] = useState<SearchMatch[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const addToast = useCallback((type: ToastData["type"], message: string) => {
+    setToasts((prev) => [...prev, createToast(type, message)]);
+  }, []);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
 
@@ -58,6 +68,8 @@ function App() {
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: hasGroups ? "groups" : "category",
+      isRefreshing: false,
+      lastCommentCount: 0,
     };
   }
 
@@ -134,18 +146,101 @@ function App() {
     setProgress(null);
   }
 
-  function updateActiveTab(updater: (tab: Tab) => Tab) {
-    setTabs((prev) =>
-      prev.map((t) => (t.id === activeTabId ? updater(t) : t))
-    );
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+  const loadingRef = useRef(loading);
+  loadingRef.current = loading;
+
+  function updateTab(tabId: string | null, updater: (tab: Tab) => Tab) {
+    setTabs((prev) => prev.map((t) => (t.id === tabId ? updater(t) : t)));
+  }
+
+  async function handleRefreshPr(tabId?: string) {
+    const targetId = tabId ?? activeTabId;
+    const tab = tabsRef.current.find((t) => t.id === targetId);
+    if (!tab || tab.isRefreshing || loadingRef.current) return;
+
+    updateTab(tab.id, (t) => ({ ...t, isRefreshing: true }));
+
+    try {
+      const newManifest = await invoke<ReviewManifest>("fetch_pr", {
+        prRef: tab.manifest.pr_url,
+      });
+
+      const parts: string[] = [];
+      if (newManifest.head_sha !== tab.manifest.head_sha) {
+        parts.push("new commits");
+      }
+      const oldPaths = new Set(tab.manifest.files.map((f) => f.path));
+      const newPaths = new Set(newManifest.files.map((f) => f.path));
+      const added = newManifest.files.filter((f) => !oldPaths.has(f.path));
+      const removed = tab.manifest.files.filter((f) => !newPaths.has(f.path));
+      if (added.length > 0) parts.push(`${added.length} file${added.length > 1 ? "s" : ""} added`);
+      if (removed.length > 0) parts.push(`${removed.length} file${removed.length > 1 ? "s" : ""} removed`);
+
+      const preservedViewed = new Set(
+        [...tab.viewedFiles].filter((p) => newPaths.has(p))
+      );
+
+      updateTab(tab.id, (t) => ({
+        ...t,
+        manifest: newManifest,
+        isRefreshing: false,
+        viewedFiles: preservedViewed,
+        selectedFile:
+          t.selectedFile && newPaths.has(t.selectedFile.path)
+            ? newManifest.files.find((f) => f.path === t.selectedFile!.path) ?? newManifest.files[0] ?? null
+            : newManifest.files[0] ?? null,
+        commentThreads: { status: "idle" },
+      }));
+
+      if (parts.length > 0) {
+        addToast("success", `PR updated: ${parts.join(", ")}`);
+      } else {
+        addToast("info", "PR refreshed — no changes detected");
+      }
+    } catch (err) {
+      updateTab(tab.id, (t) => ({ ...t, isRefreshing: false }));
+      addToast("error", `Refresh failed: ${String(err)}`);
+    }
+  }
+
+  async function handleRefreshComments(tabId: string) {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    if (!tab || tab.isRefreshing) return;
+
+    try {
+      const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
+        prUrl: tab.manifest.pr_url,
+      });
+
+      const oldCount =
+        tab.commentThreads.status === "loaded"
+          ? tab.commentThreads.threads.reduce((n, t) => n + t.comments.length, 0)
+          : 0;
+      const newCount = threads.reduce((n, t) => n + t.comments.length, 0);
+      const diff = newCount - oldCount;
+
+      updateTab(tabId, (t) => ({
+        ...t,
+        commentThreads: { status: "loaded", threads },
+        lastCommentCount: newCount,
+      }));
+
+      if (diff > 0) {
+        addToast("info", `${diff} new comment${diff > 1 ? "s" : ""} on PR #${tab.manifest.pr_number}`);
+      }
+    } catch {
+      // Poll will retry
+    }
   }
 
   function setSelectedFile(file: FileDiff) {
-    updateActiveTab((t) => ({ ...t, selectedFile: file }));
+    updateTab(activeTabId,(t) => ({ ...t, selectedFile: file }));
   }
 
   function toggleViewed(filePath: string) {
-    updateActiveTab((t) => {
+    updateTab(activeTabId,(t) => {
       const next = new Set(t.viewedFiles);
       if (next.has(filePath)) {
         next.delete(filePath);
@@ -157,7 +252,7 @@ function App() {
   }
 
   function handleViewChange(view: SidebarView) {
-    updateActiveTab((t) => ({ ...t, sidebarView: view }));
+    updateTab(activeTabId,(t) => ({ ...t, sidebarView: view }));
     if (view === "comments") {
       handleRequestComments();
     }
@@ -167,7 +262,7 @@ function App() {
     const tab = tabs.find((t) => t.id === activeTabId);
     if (!tab || tab.commentThreads.status === "loading" || tab.commentThreads.status === "loaded") return;
 
-    updateActiveTab((t) => ({ ...t, commentThreads: { status: "loading" } }));
+    updateTab(activeTabId,(t) => ({ ...t, commentThreads: { status: "loading" } }));
     try {
       const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
         prUrl: tab.manifest.pr_url,
@@ -186,7 +281,7 @@ function App() {
         )
       );
     } catch (err) {
-      updateActiveTab((t) => ({
+      updateTab(activeTabId,(t) => ({
         ...t,
         commentThreads: { status: "error", message: String(err) },
       }));
@@ -194,7 +289,7 @@ function App() {
   }
 
   function handleSelectCommentFile(path: string) {
-    updateActiveTab((t) => ({ ...t, selectedCommentFile: path }));
+    updateTab(activeTabId,(t) => ({ ...t, selectedCommentFile: path }));
   }
 
   async function handleReply(threadId: string, commentId: string, body: string) {
@@ -217,7 +312,7 @@ function App() {
         ? { ...t, comments: [...t.comments, optimisticComment] }
         : t
     );
-    updateActiveTab((t) => ({
+    updateTab(activeTabId,(t) => ({
       ...t,
       commentThreads: { status: "loaded", threads: optimisticThreads },
     }));
@@ -253,7 +348,7 @@ function App() {
       );
     } catch {
       // Revert on error
-      updateActiveTab((t) => ({
+      updateTab(activeTabId,(t) => ({
         ...t,
         commentThreads: { status: "loaded", threads: prevThreads },
       }));
@@ -270,7 +365,7 @@ function App() {
     const optimisticThreads = prevThreads.map((t) =>
       t.id === threadId ? { ...t, is_resolved: resolve } : t
     );
-    updateActiveTab((t) => ({
+    updateTab(activeTabId,(t) => ({
       ...t,
       commentThreads: { status: "loaded", threads: optimisticThreads },
     }));
@@ -279,7 +374,7 @@ function App() {
       await invoke<boolean>("toggle_thread_resolved", { threadId, resolve });
     } catch {
       // Revert on error
-      updateActiveTab((t) => ({
+      updateTab(activeTabId,(t) => ({
         ...t,
         commentThreads: { status: "loaded", threads: prevThreads },
       }));
@@ -299,7 +394,7 @@ function App() {
         c.id === commentId ? { ...c, body } : c
       ),
     }));
-    updateActiveTab((t) => ({
+    updateTab(activeTabId,(t) => ({
       ...t,
       commentThreads: { status: "loaded" as const, threads: optimisticThreads },
     }));
@@ -328,7 +423,7 @@ function App() {
         })
       );
     } catch {
-      updateActiveTab((t) => ({
+      updateTab(activeTabId,(t) => ({
         ...t,
         commentThreads: { status: "loaded" as const, threads: prevThreads },
       }));
@@ -350,7 +445,7 @@ function App() {
         const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
           prUrl: tab.manifest.pr_url,
         });
-        updateActiveTab((t) => ({
+        updateTab(activeTabId,(t) => ({
           ...t,
           commentThreads: { status: "loaded" as const, threads },
         }));
@@ -376,7 +471,7 @@ function App() {
       });
 
       // Add the new thread to the comment threads state
-      updateActiveTab((t) => {
+      updateTab(activeTabId,(t) => {
         if (t.commentThreads.status === "loaded") {
           return {
             ...t,
@@ -409,6 +504,34 @@ function App() {
       }
     }
   }
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const currentTabs = tabsRef.current;
+      if (loadingRef.current || currentTabs.length === 0) return;
+
+      const pollableTabs = currentTabs.filter((t) => !t.isRefreshing);
+      await Promise.allSettled(
+        pollableTabs.map(async (tab) => {
+          const status = await invoke<PrUpdateStatus>("check_pr_updates", {
+            prUrl: tab.manifest.pr_url,
+            currentHeadSha: tab.manifest.head_sha,
+            currentCommentCount: tab.lastCommentCount ?? 0,
+          });
+
+          if (!status.has_changes) return;
+
+          if (status.head_sha_changed) {
+            handleRefreshPr(tab.id);
+          } else if (status.comment_count_changed) {
+            handleRefreshComments(tab.id);
+          }
+        })
+      );
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleFileDrop(e: React.DragEvent) {
     e.preventDefault();
@@ -505,6 +628,8 @@ function App() {
         onToggleAiNotes={() => setShowAiNotes((v) => !v)}
         commentThreads={activeTab?.commentThreads}
         onSubmitReview={activeTab ? handleSubmitReview : undefined}
+        onRefresh={activeTab ? () => handleRefreshPr() : undefined}
+        isRefreshing={activeTab?.isRefreshing}
       />
       <SettingsModal
         open={settingsOpen}
@@ -570,6 +695,7 @@ function App() {
         </div>
         </>
       )}
+      <ToastContainer toasts={toasts} onDismiss={removeToast} />
     </div>
   );
 }

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -21,6 +21,8 @@ interface HeaderProps {
   onToggleAiNotes: () => void;
   commentThreads?: CommentThreadsState;
   onSubmitReview?: (event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) => Promise<void>;
+  onRefresh?: () => void;
+  isRefreshing?: boolean;
 }
 
 export function Header({
@@ -40,6 +42,8 @@ export function Header({
   onToggleAiNotes,
   commentThreads,
   onSubmitReview,
+  onRefresh,
+  isRefreshing,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -84,6 +88,17 @@ export function Header({
             <div className="progress-bar">
               <div className="progress-fill" style={{ width: `${progress}%` }} />
             </div>
+            {onRefresh && (
+              <button
+                className={`refresh-button${isRefreshing ? " refreshing" : ""}`}
+                onClick={onRefresh}
+                disabled={isRefreshing}
+                title={isRefreshing ? "Refreshing..." : "Refresh PR data"}
+              >
+                <span className="refresh-icon">&#x21bb;</span>
+                {isRefreshing ? "Refreshing" : "Refresh"}
+              </button>
+            )}
             {hasSummary && (
               <button
                 className="summary-toggle"

--- a/app/src/components/Toast.tsx
+++ b/app/src/components/Toast.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+
+export type ToastType = "info" | "success" | "error";
+
+export interface ToastData {
+  id: string;
+  type: ToastType;
+  message: string;
+}
+
+let nextToastId = 1;
+export function createToast(type: ToastType, message: string): ToastData {
+  return { id: String(nextToastId++), type, message };
+}
+
+function Toast({ toast, onDismiss }: { toast: ToastData; onDismiss: (id: string) => void }) {
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    timerRef.current = setTimeout(() => onDismiss(toast.id), 5000);
+    return () => clearTimeout(timerRef.current);
+  }, [toast.id, onDismiss]);
+
+  return (
+    <div className={`toast toast-${toast.type}`}>
+      <span className="toast-message">{toast.message}</span>
+      <button className="toast-dismiss" onClick={() => onDismiss(toast.id)}>
+        &times;
+      </button>
+    </div>
+  );
+}
+
+export function ToastContainer({
+  toasts,
+  onDismiss,
+}: {
+  toasts: ToastData[];
+  onDismiss: (id: string) => void;
+}) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="toast-container">
+      {toasts.map((t) => (
+        <Toast key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3026,3 +3026,116 @@ mark.search-highlight-current {
   outline-offset: 0;
   font-weight: 600;
 }
+
+/* ─── Toast Notifications ─────────────────────────────────────────────── */
+.toast-container {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 8px;
+  z-index: 9999;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+  animation: toast-slide-in 0.25s ease-out;
+  max-width: 400px;
+}
+
+.toast-success {
+  border-left: 3px solid var(--diff-add-text);
+}
+
+.toast-error {
+  border-left: 3px solid var(--diff-remove-text);
+}
+
+.toast-info {
+  border-left: 3px solid var(--accent);
+}
+
+.toast-message {
+  flex: 1;
+  line-height: 1.4;
+}
+
+.toast-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.toast-dismiss:hover {
+  color: var(--text-primary);
+}
+
+@keyframes toast-slide-in {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* ─── Refresh Button ──────────────────────────────────────────────────── */
+.refresh-button {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  padding: 3px 10px;
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.refresh-button:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.refresh-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.refresh-icon {
+  display: inline-block;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.refresh-button.refreshing .refresh-icon {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -99,6 +99,16 @@ export interface Tab {
   commentThreads: CommentThreadsState;
   selectedCommentFile: string | null;
   sidebarView: SidebarView;
+  isRefreshing?: boolean;
+  lastCommentCount?: number;
+}
+
+export interface PrUpdateStatus {
+  has_changes: boolean;
+  head_sha_changed: boolean;
+  comment_count_changed: boolean;
+  new_head_sha: string | null;
+  new_comment_count: number | null;
 }
 
 export interface SearchMatch {


### PR DESCRIPTION
## Summary
- Add 60-second background polling that detects new commits and comments on open PR tabs via a lightweight GitHub API check
- When the head SHA changes, automatically re-run the full 6-step pipeline including AI re-analysis; when only comments change, re-fetch just the review threads
- Add a manual "Refresh" button in the header toolbar for on-demand use
- Introduce a reusable toast notification system to surface change summaries (e.g. "PR updated: new commits, 2 files added")

## Changes

**Backend (Rust):**
- `src-tauri/src/github.rs` — new `get_pr_status()` lightweight REST method (head SHA + comment count)
- `src-tauri/src/commands.rs` — new `check_pr_updates` Tauri command
- `src-tauri/src/types.rs` — new `PrUpdateStatus` struct
- `src-tauri/src/lib.rs` — register new command

**Frontend (React/TypeScript):**
- `src/components/Toast.tsx` — new toast notification component (info/success/error, auto-dismiss 5s)
- `src/App.tsx` — refresh handlers, 60s polling via `setInterval` + `Promise.allSettled`, toast state
- `src/components/Header.tsx` — refresh button with spinning icon
- `src/types.ts` — `PrUpdateStatus` interface, `isRefreshing`/`lastCommentCount` on `Tab`
- `src/styles.css` — toast + refresh button styles

## Test Plan
- [ ] Open a PR tab, push a new commit to the PR branch, wait up to 60s — verify toast appears and files/diff update with AI re-analysis
- [ ] Open a PR tab, add a review comment on GitHub, wait up to 60s — verify toast shows new comment count and threads update without AI re-run
- [ ] Click the manual "Refresh" button — verify it triggers a full pipeline refresh with spinner and toast
- [ ] Open multiple PR tabs — verify polling checks all tabs concurrently
- [ ] Verify refresh preserves viewed-files progress and selected file

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)