### PR TITLE
feat(ui): consolidate toolbar actions into dropdown menu

### DIFF
--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
 import { SummaryParagraphs } from "./SummaryParagraphs";
@@ -115,6 +115,75 @@ export function Header({
             )}
           </div>
           <div className="header-right">
+            {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} />}
+            <ToolbarMenu
+              viewMode={viewMode}
+              onViewModeChange={onViewModeChange}
+              showHunkSignificance={showHunkSignificance}
+              onToggleHunkSignificance={onToggleHunkSignificance}
+              showAiNotes={showAiNotes}
+              onToggleAiNotes={onToggleAiNotes}
+              prUrl={manifest.pr_url}
+              onSettingsClick={onSettingsClick}
+            />
+          </div>
+        </div>
+      )}
+      {hasSummary && summaryExpanded && (
+        <div className="header-summary">
+          <SummaryParagraphs text={manifest!.summary} />
+        </div>
+      )}
+    </header>
+  );
+}
+
+function ToolbarMenu({
+  viewMode,
+  onViewModeChange,
+  showHunkSignificance,
+  onToggleHunkSignificance,
+  showAiNotes,
+  onToggleAiNotes,
+  prUrl,
+  onSettingsClick,
+}: {
+  viewMode: DiffViewMode;
+  onViewModeChange: (mode: DiffViewMode) => void;
+  showHunkSignificance: boolean;
+  onToggleHunkSignificance: () => void;
+  showAiNotes: boolean;
+  onToggleAiNotes: () => void;
+  prUrl: string;
+  onSettingsClick: () => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isOpen]);
+
+  return (
+    <div className="toolbar-menu-wrapper" ref={menuRef}>
+      <button
+        className="toolbar-menu-button"
+        onClick={() => setIsOpen((v) => !v)}
+        title="Menu"
+      >
+        ⋯
+      </button>
+      {isOpen && (
+        <div className="toolbar-menu-dropdown">
+          <div className="toolbar-menu-section">
+            <span className="toolbar-menu-label">View Mode</span>
             <div className="view-toggle">
               <button
                 className={viewMode === "split" ? "active" : ""}
@@ -129,43 +198,47 @@ export function Header({
                 Unified
               </button>
             </div>
-            <button
-              className={`significance-toggle ${showHunkSignificance ? "active" : ""}`}
-              onClick={onToggleHunkSignificance}
-              title={showHunkSignificance ? "Hide hunk significance scoring" : "Show hunk significance scoring"}
-            >
-              Significance {showHunkSignificance ? "ON" : "OFF"}
-            </button>
-            <button
-              className={`significance-toggle ${showAiNotes ? "active" : ""}`}
-              onClick={onToggleAiNotes}
-              title={showAiNotes ? "Hide AI highlight notes" : "Show AI highlight notes"}
-            >
-              AI Notes {showAiNotes ? "ON" : "OFF"}
-            </button>
-            <a
-              className="github-link"
-              href={manifest.pr_url}
-              onClick={(e) => {
-                e.preventDefault();
-                open(manifest.pr_url);
-              }}
-            >
-              View on GitHub
-            </a>
-            <button className="settings-button" onClick={onSettingsClick}>
-              Settings
-            </button>
-            {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} />}
           </div>
+          <div className="toolbar-menu-divider" />
+          <button
+            className="toolbar-menu-item"
+            onClick={onToggleHunkSignificance}
+          >
+            <span className={`toolbar-menu-check ${showHunkSignificance ? "visible" : ""}`}>✓</span>
+            Significance
+          </button>
+          <button
+            className="toolbar-menu-item"
+            onClick={onToggleAiNotes}
+          >
+            <span className={`toolbar-menu-check ${showAiNotes ? "visible" : ""}`}>✓</span>
+            AI Notes
+          </button>
+          <div className="toolbar-menu-divider" />
+          <button
+            className="toolbar-menu-item"
+            onClick={(e) => {
+              e.preventDefault();
+              open(prUrl);
+              setIsOpen(false);
+            }}
+          >
+            <span className="toolbar-menu-check" />
+            View on GitHub
+          </button>
+          <button
+            className="toolbar-menu-item"
+            onClick={() => {
+              onSettingsClick();
+              setIsOpen(false);
+            }}
+          >
+            <span className="toolbar-menu-check" />
+            Settings
+          </button>
         </div>
       )}
-      {hasSummary && summaryExpanded && (
-        <div className="header-summary">
-          <SummaryParagraphs text={manifest!.summary} />
-        </div>
-      )}
-    </header>
+    </div>
   );
 }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -262,6 +262,92 @@ body {
   flex-shrink: 0;
 }
 
+/* ─── Toolbar Dropdown Menu ────────────────────────────────────────────── */
+.toolbar-menu-wrapper {
+  position: relative;
+}
+
+.toolbar-menu-button {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  letter-spacing: 2px;
+}
+
+.toolbar-menu-button:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.toolbar-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  min-width: 220px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 0;
+  z-index: 50;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.toolbar-menu-section {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  gap: 12px;
+}
+
+.toolbar-menu-label {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.toolbar-menu-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+.toolbar-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 6px 12px;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  text-align: left;
+}
+
+.toolbar-menu-item:hover {
+  background: var(--bg-tertiary);
+}
+
+.toolbar-menu-check {
+  display: inline-block;
+  width: 16px;
+  color: transparent;
+  font-size: 12px;
+  flex-shrink: 0;
+}
+
+.toolbar-menu-check.visible {
+  color: var(--accent);
+}
+
 .view-toggle {
   display: flex;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Replaces inline toolbar items (view toggle, significance, AI notes, GitHub link, settings) with a three-dot (⋯) menu button that opens a dropdown
- "Finish Review" remains visible outside the menu as a primary action
- Toggle states (Significance, AI Notes) shown with checkmarks in the dropdown
- Dropdown closes on outside click; navigation items (GitHub, Settings) also close the menu

## Changes
- `app/src/components/Header.tsx` — extracted inline toolbar items into a new `ToolbarMenu` component with click-outside-to-close behavior
- `app/src/styles.css` — added `.toolbar-menu-*` styles for the dropdown menu, items, dividers, and checkmark indicators

## Test Plan
- [ ] Open a PR in the app and verify the ⋯ button appears in the header toolbar
- [ ] Click the menu button and confirm all options appear: View Mode (Split/Unified), Significance, AI Notes, View on GitHub, Settings
- [ ] Toggle Significance and AI Notes — checkmarks should appear/disappear and the menu should stay open
- [ ] Click "View on GitHub" — should open the PR URL and close the menu
- [ ] Click "Settings" — should open settings and close the menu
- [ ] Click outside the dropdown — should close the menu
- [ ] Verify "Finish Review" button remains visible outside the menu

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)