### PR TITLE
feat(review): disable finish review when already submitted

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -2,7 +2,7 @@ use crate::bedrock::{region_from_arn, BedrockClient};
 use crate::config::{load_settings, resolve_github_token, save_settings_to_disk};
 use crate::fetch::fetch_pr_impl;
 use crate::github::GithubClient;
-use crate::types::{PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
+use crate::types::{MyReviewState, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use crate::manifest_cache::{self, CachedPrInfo};
 use crate::viewed_state::{self, ViewedFileState};
 use std::fs;
@@ -139,6 +139,15 @@ pub async fn update_review_comment(
 ) -> Result<ReviewComment, String> {
     let github = github_client();
     github.update_review_comment(&comment_id, &body).await
+}
+
+#[command]
+pub async fn get_my_review_state(pr_url: String) -> Result<MyReviewState, String> {
+    let github = github_client();
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    github
+        .get_my_review_state(&parsed.owner, &parsed.repo, parsed.number)
+        .await
 }
 
 #[command]

--- a/app/src-tauri/src/github.rs
+++ b/app/src-tauri/src/github.rs
@@ -1,4 +1,4 @@
-use crate::types::{CommentAuthor, PrFile, PrMetadata, ReviewComment, ReviewRequestItem, ReviewThread};
+use crate::types::{CommentAuthor, MyReviewState, PrFile, PrMetadata, ReviewComment, ReviewRequestItem, ReviewThread};
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::Client;
@@ -89,6 +89,47 @@ fn parse_review_thread(node: &serde_json::Value) -> ReviewThread {
         diff_hunk,
         comments,
     }
+}
+
+/// Check whether `username` appears as a requested reviewer in a
+/// `reviewRequests { nodes { requestedReviewer { login } } }` JSON array.
+fn is_user_in_review_requests(nodes: &[serde_json::Value], username: &str) -> bool {
+    nodes.iter().any(|node| {
+        node.pointer("/requestedReviewer/login")
+            .and_then(|l| l.as_str())
+            .map(|l| l.eq_ignore_ascii_case(username))
+            .unwrap_or(false)
+    })
+}
+
+/// Determine the latest decisive review status for `username` from a
+/// `reviews { nodes { author { login } state } }` JSON array.
+/// Returns one of: "pending", "approved", "changes_requested", "dismissed", "commented".
+fn resolve_user_review_status(reviews: &[serde_json::Value], username: &str) -> String {
+    let mut status = "pending".to_string();
+    for review in reviews {
+        let author = review
+            .pointer("/author/login")
+            .and_then(|l| l.as_str())
+            .unwrap_or("");
+        if !author.eq_ignore_ascii_case(username) {
+            continue;
+        }
+        if let Some(state) = review.get("state").and_then(|s| s.as_str()) {
+            match state {
+                "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED" => {
+                    status = state.to_lowercase();
+                }
+                "COMMENTED" => {
+                    if status == "pending" {
+                        status = "commented".to_string();
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    status
 }
 
 impl GithubClient {
@@ -552,42 +593,12 @@ impl GithubClient {
                 None => continue,
             };
 
-            // Direct vs team: check if user is in requestedReviewer users
             if let Some(nodes) = pr.pointer("/reviewRequests/nodes").and_then(|v| v.as_array()) {
-                item.direct_request = nodes.iter().any(|node| {
-                    node.pointer("/requestedReviewer/login")
-                        .and_then(|l| l.as_str())
-                        .map(|l| l.eq_ignore_ascii_case(username))
-                        .unwrap_or(false)
-                });
+                item.direct_request = is_user_in_review_requests(nodes, username);
             }
 
-            // My review status: find latest decisive review by the user
             if let Some(reviews) = pr.pointer("/reviews/nodes").and_then(|v| v.as_array()) {
-                let mut status = "pending".to_string();
-                for review in reviews {
-                    let author = review
-                        .pointer("/author/login")
-                        .and_then(|l| l.as_str())
-                        .unwrap_or("");
-                    if !author.eq_ignore_ascii_case(username) {
-                        continue;
-                    }
-                    if let Some(state) = review.get("state").and_then(|s| s.as_str()) {
-                        match state {
-                            "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED" => {
-                                status = state.to_lowercase();
-                            }
-                            "COMMENTED" => {
-                                if status == "pending" {
-                                    status = "commented".to_string();
-                                }
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                item.my_review_status = status;
+                item.my_review_status = resolve_user_review_status(reviews, username);
             }
 
             // Unresolved thread count
@@ -1014,5 +1025,75 @@ impl GithubClient {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .ok_or_else(|| "Could not find PR node ID".to_string())
+    }
+
+    /// Get the current user's review state on a PR, including whether they've
+    /// been re-requested for review.
+    pub async fn get_my_review_state(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<MyReviewState, String> {
+        let query = format!(
+            r#"{{
+                viewer {{ login }}
+                repository(owner: "{}", name: "{}") {{
+                    pullRequest(number: {}) {{
+                        merged
+                        reviewRequests(first: 20) {{
+                            nodes {{
+                                requestedReviewer {{
+                                    ... on User {{ login }}
+                                }}
+                            }}
+                        }}
+                        reviews(last: 100) {{
+                            nodes {{
+                                author {{ login }}
+                                state
+                            }}
+                        }}
+                    }}
+                }}
+            }}"#,
+            owner, repo, pr_number
+        );
+
+        let result = self
+            .graphql_request(serde_json::json!({ "query": query }))
+            .await?;
+
+        let viewer_login = result
+            .pointer("/data/viewer/login")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        let pr = result
+            .pointer("/data/repository/pullRequest")
+            .ok_or("Could not find PR data")?;
+
+        let is_merged = pr
+            .get("merged")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let is_re_requested = pr
+            .pointer("/reviewRequests/nodes")
+            .and_then(|v| v.as_array())
+            .map(|nodes| is_user_in_review_requests(nodes, viewer_login))
+            .unwrap_or(false);
+
+        let status = pr
+            .pointer("/reviews/nodes")
+            .and_then(|v| v.as_array())
+            .map(|reviews| resolve_user_review_status(reviews, viewer_login))
+            .unwrap_or_else(|| "pending".to_string());
+
+        Ok(MyReviewState {
+            status,
+            is_re_requested,
+            is_merged,
+        })
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub fn run() {
             commands::fetch_review_comments,
             commands::reply_to_thread,
             commands::toggle_thread_resolved,
+            commands::get_my_review_state,
             commands::submit_review,
             commands::generate_review_body,
             commands::update_review_comment,

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -188,6 +188,13 @@ pub struct PrUpdateStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct MyReviewState {
+    pub status: String,
+    pub is_re_requested: bool,
+    pub is_merged: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewRequestItem {
     pub owner: String,
     pub repo: String,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,7 +12,7 @@ import { SettingsModal } from "./components/SettingsModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
 import { SearchBar } from "./components/SearchBar";
 import { ToastContainer, createToast, type ToastData } from "./components/Toast";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState } from "./types";
 import { parsePrUrl } from "./utils";
 
 function App() {
@@ -100,6 +100,16 @@ function App() {
     setShowOpener(false);
     setError(null);
     loadPersistedViewedState(tab);
+    fetchMyReviewState(tab.id, data.pr_url);
+  }
+
+  async function fetchMyReviewState(tabId: string, prUrl: string) {
+    try {
+      const state = await invoke<MyReviewState>("get_my_review_state", { prUrl });
+      updateTab(tabId, (t) => ({ ...t, myReviewState: state }));
+    } catch {
+      // Non-critical: if fetching fails, button stays enabled
+    }
   }
 
   function reconcileViewedFiles(
@@ -247,6 +257,7 @@ function App() {
 
       updateTab(tab.id, () => refreshedTab);
       persistViewedState(refreshedTab);
+      fetchMyReviewState(tab.id, newManifest.pr_url);
 
       if (parts.length > 0) {
         addToast("success", `PR updated: ${parts.join(", ")}`);
@@ -518,6 +529,22 @@ function App() {
         event,
         body,
       });
+
+      // Update review state immediately (submitting clears the review request)
+      const statusMap: Record<string, string> = {
+        APPROVE: "approved",
+        REQUEST_CHANGES: "changes_requested",
+        COMMENT: "commented",
+      };
+      updateTab(activeTabId, (t) => ({
+        ...t,
+        myReviewState: {
+          status: statusMap[event] as MyReviewState["status"],
+          is_re_requested: false,
+          is_merged: t.myReviewState?.is_merged ?? false,
+        },
+      }));
+
       // Re-fetch threads to update resolved states
       if (tab.commentThreads.status === "loaded") {
         const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
@@ -709,6 +736,7 @@ function App() {
         onSubmitReview={activeTab ? handleSubmitReview : undefined}
         onRefresh={activeTab ? () => handleRefreshPr() : undefined}
         isRefreshing={activeTab?.isRefreshing}
+        myReviewState={activeTab?.myReviewState}
       />
       <SettingsModal
         open={settingsOpen}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,8 +1,36 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import type { ReviewManifest, DiffViewMode, Tab, CommentThreadsState } from "../types";
+import type { ReviewManifest, DiffViewMode, Tab, CommentThreadsState, MyReviewState } from "../types";
+
+function useClickOutside(
+  ref: React.RefObject<HTMLElement | null>,
+  isActive: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!isActive) return;
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isActive, ref, onClose]);
+}
+
+const REVIEW_VERB: Record<string, string> = {
+  approved: "approved",
+  changes_requested: "requested changes on",
+  commented: "commented on",
+};
+
+const REVIEW_STATUS_SYMBOL: Record<string, string> = {
+  approved: "✓",
+  changes_requested: "✕",
+};
 
 interface HeaderProps {
   tabs: Tab[];
@@ -24,6 +52,7 @@ interface HeaderProps {
   onSubmitReview?: (event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) => Promise<void>;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  myReviewState?: MyReviewState;
 }
 
 export function Header({
@@ -46,6 +75,7 @@ export function Header({
   onSubmitReview,
   onRefresh,
   isRefreshing,
+  myReviewState,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -115,7 +145,7 @@ export function Header({
             )}
           </div>
           <div className="header-right">
-            {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} />}
+            {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} myReviewState={myReviewState} />}
             <ToolbarMenu
               viewMode={viewMode}
               onViewModeChange={onViewModeChange}
@@ -159,17 +189,8 @@ function ToolbarMenu({
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [isOpen]);
+  const closeMenu = useCallback(() => setIsOpen(false), []);
+  useClickOutside(menuRef, isOpen, closeMenu);
 
   return (
     <div className="toolbar-menu-wrapper" ref={menuRef}>
@@ -247,24 +268,42 @@ function ReviewSubmitButton({
   onSubmitReview,
   prTitle,
   prUrl,
+  myReviewState,
 }: {
   commentThreads?: CommentThreadsState;
   onSubmitReview: (event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT", body: string) => Promise<void>;
   prTitle: string;
   prUrl: string;
+  myReviewState?: MyReviewState;
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const [body, setBody] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [fetchedThreads, setFetchedThreads] = useState<import("../types").ReviewThread[] | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const closeDropdown = useCallback(() => setIsOpen(false), []);
+  useClickOutside(wrapperRef, isOpen, closeDropdown);
 
   // Use freshly fetched threads if available, otherwise fall back to prop
   const threads = fetchedThreads ?? (commentThreads?.status === "loaded" ? commentThreads.threads : []);
   const unresolvedThreads = threads.filter((t) => !t.is_resolved);
   const unresolvedCount = unresolvedThreads.length;
 
+  // Disable if the user has already submitted a review that hasn't been dismissed or re-requested
+  const hasSubmittedReview = myReviewState != null &&
+    myReviewState.status !== "pending" &&
+    myReviewState.status !== "dismissed" &&
+    !myReviewState.is_re_requested;
+
+  const isMerged = myReviewState?.is_merged ?? false;
+
+  const disabledTooltip = hasSubmittedReview
+    ? `You already ${REVIEW_VERB[myReviewState!.status] ?? "reviewed"} this PR`
+    : undefined;
+
   async function handleOpen() {
+    if (hasSubmittedReview) return;
     const wasOpen = isOpen;
     setIsOpen((v) => !v);
     if (wasOpen) return;
@@ -310,14 +349,19 @@ function ReviewSubmitButton({
   }
 
   return (
-    <div className="review-submit-wrapper">
+    <div className="review-submit-wrapper" ref={wrapperRef}>
       <button
-        className="review-submit-toggle"
+        className={`review-submit-toggle${hasSubmittedReview ? " review-submit-disabled" : ""}`}
         onClick={handleOpen}
+        disabled={hasSubmittedReview}
+        title={disabledTooltip}
       >
         Finish Review
-        {unresolvedCount > 0 && (
+        {unresolvedCount > 0 && !hasSubmittedReview && (
           <span className="review-submit-badge">{unresolvedCount}</span>
+        )}
+        {hasSubmittedReview && (
+          <span className="review-submit-status-badge">{REVIEW_STATUS_SYMBOL[myReviewState!.status] ?? "●"}</span>
         )}
       </button>
       {isOpen && (
@@ -344,22 +388,26 @@ function ReviewSubmitButton({
             >
               Comment
             </button>
-            <button
-              className="review-action-approve"
-              disabled={submitting || generating}
-              onClick={() => handleSubmit("APPROVE")}
-              title="Approve this pull request"
-            >
-              Approve
-            </button>
-            <button
-              className="review-action-request-changes"
-              disabled={submitting || generating}
-              onClick={() => handleSubmit("REQUEST_CHANGES")}
-              title="Request changes on this pull request"
-            >
-              Request Changes
-            </button>
+            {!isMerged && (
+              <>
+                <button
+                  className="review-action-approve"
+                  disabled={submitting || generating}
+                  onClick={() => handleSubmit("APPROVE")}
+                  title="Approve this pull request"
+                >
+                  Approve
+                </button>
+                <button
+                  className="review-action-request-changes"
+                  disabled={submitting || generating}
+                  onClick={() => handleSubmit("REQUEST_CHANGES")}
+                  title="Request changes on this pull request"
+                >
+                  Request Changes
+                </button>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2876,6 +2876,22 @@ body {
   cursor: not-allowed;
 }
 
+.review-submit-toggle.review-submit-disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.review-submit-toggle.review-submit-disabled:hover {
+  background: var(--bg-tertiary);
+}
+
+.review-submit-status-badge {
+  font-size: 10px;
+  opacity: 0.8;
+}
+
 /* ─── Comment Suggestion Block ─────────────────────────────────────────── */
 .comment-suggestion-block {
   margin: 6px 0;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -103,6 +103,7 @@ export interface Tab {
   sidebarView: SidebarView;
   isRefreshing?: boolean;
   lastCommentCount?: number;
+  myReviewState?: MyReviewState;
 }
 
 export interface PrUpdateStatus {
@@ -130,6 +131,12 @@ export interface Settings {
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";
+
+export interface MyReviewState {
+  status: ReviewStatus;
+  is_re_requested: boolean;
+  is_merged: boolean;
+}
 
 export interface ViewedFileState {
   files: Record<string, string>; // path -> diff_hash


### PR DESCRIPTION
## Summary
- Disable the "Finish Review" button when the current user has already submitted a review (approved, requested changes, or commented), unless the review was dismissed or re-requested
- On merged PRs, only the Comment action is shown (Approve and Request Changes are hidden)
- Clicking outside the "Finish Review" dropdown now dismisses it
- Extracts shared Rust helpers (`resolve_user_review_status`, `is_user_in_review_requests`) to eliminate duplication between `enrich_review_requests` and the new `get_my_review_state`

## Changes
**Rust backend:**
- `types.rs` — new `MyReviewState` struct (status, is_re_requested, is_merged)
- `github.rs` — `get_my_review_state` GraphQL method + extracted shared helpers
- `commands.rs` — new `get_my_review_state` Tauri command
- `lib.rs` — command registration

**React frontend:**
- `types.ts` — `MyReviewState` interface, added to `Tab`
- `App.tsx` — fetch review state on tab creation/refresh, optimistic update after submit
- `Header.tsx` — disable button logic, click-outside hook, merged PR handling, status badge
- `styles.css` — disabled button styling

## Test Plan
- [ ] Open a PR where you have already approved — verify "Finish Review" button is disabled with a ✓ badge and tooltip
- [ ] Open a PR where you requested changes — verify button is disabled with ✕ badge
- [ ] Open a PR where your review was dismissed — verify button remains enabled
- [ ] Open a PR where you were re-requested for review — verify button remains enabled
- [ ] Open a PR you haven't reviewed — verify button is enabled as normal
- [ ] Open a merged PR — verify only "Comment" action is shown (no Approve/Request Changes)
- [ ] Click "Finish Review" to open dropdown, then click outside — verify dropdown closes
- [ ] Submit a review — verify button becomes disabled immediately after submission
- [ ] Refresh a PR — verify review state updates correctly

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)