### PR TITLE
feat(comments): add emoji reactions and inline reply/resolve

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -205,6 +205,16 @@ pub async fn toggle_thread_resolved(
 }
 
 #[command]
+pub async fn toggle_reaction(
+    comment_id: String,
+    content: String,
+    add: bool,
+) -> Result<(), String> {
+    let github = github_client();
+    github.toggle_reaction(&comment_id, &content, add).await
+}
+
+#[command]
 pub fn load_viewed_files(owner: String, repo: String, pr_number: u64) -> Option<ViewedFileState> {
     viewed_state::load_viewed_state(&owner, &repo, pr_number)
 }

--- a/app/src-tauri/src/github.rs
+++ b/app/src-tauri/src/github.rs
@@ -1,4 +1,4 @@
-use crate::types::{CheckRunInfo, CommentAuthor, MyReviewState, PrChecksStatus, PrFile, PrMetadata, ReviewComment, ReviewRequestItem, ReviewThread};
+use crate::types::{CheckRunInfo, CommentAuthor, MyReviewState, PrChecksStatus, PrFile, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::Client;
@@ -42,6 +42,37 @@ struct SearchPullRequest {
     merged_at: Option<String>,
 }
 
+fn parse_reaction_groups(c: &serde_json::Value) -> Vec<ReactionGroup> {
+    c.get("reactionGroups")
+        .and_then(|v| v.as_array())
+        .map(|groups| {
+            groups
+                .iter()
+                .filter_map(|g| {
+                    let content = g.get("content")?.as_str()?.to_string();
+                    let total_count = g
+                        .pointer("/users/totalCount")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u32;
+                    let viewer_has_reacted = g
+                        .get("viewerHasReacted")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if total_count > 0 || viewer_has_reacted {
+                        Some(ReactionGroup {
+                            content,
+                            total_count,
+                            viewer_has_reacted,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Parse a single review comment from a GraphQL JSON node.
 fn parse_review_comment(c: &serde_json::Value) -> Option<ReviewComment> {
     Some(ReviewComment {
@@ -62,6 +93,7 @@ fn parse_review_comment(c: &serde_json::Value) -> Option<ReviewComment> {
         created_at: c.get("createdAt")?.as_str()?.to_string(),
         updated_at: c.get("updatedAt")?.as_str()?.to_string(),
         url: c.get("url")?.as_str()?.to_string(),
+        reactions: parse_reaction_groups(c),
     })
 }
 
@@ -656,6 +688,11 @@ impl GithubClient {
                                             updatedAt
                                             url
                                             diffHunk
+                                            reactionGroups {{
+                                                content
+                                                viewerHasReacted
+                                                users {{ totalCount }}
+                                            }}
                                         }}
                                     }}
                                 }}
@@ -719,6 +756,11 @@ impl GithubClient {
                     createdAt
                     updatedAt
                     url
+                    reactionGroups {
+                        content
+                        viewerHasReacted
+                        users { totalCount }
+                    }
                 }
             }
         }"#;
@@ -788,6 +830,11 @@ impl GithubClient {
             }) {
                 pullRequestReviewComment {
                     id body author { login avatarUrl } createdAt updatedAt url
+                    reactionGroups {
+                        content
+                        viewerHasReacted
+                        users { totalCount }
+                    }
                 }
             }
         }"#;
@@ -852,6 +899,11 @@ impl GithubClient {
                     comments(first: 100) {{
                         nodes {{
                             id body author {{ login avatarUrl }} createdAt updatedAt url diffHunk
+                            reactionGroups {{
+                                content
+                                viewerHasReacted
+                                users {{ totalCount }}
+                            }}
                         }}
                     }}
                 }}
@@ -1000,6 +1052,34 @@ impl GithubClient {
 
             Ok(state)
         }
+    }
+
+    pub async fn toggle_reaction(
+        &self,
+        subject_id: &str,
+        content: &str,
+        add: bool,
+    ) -> Result<(), String> {
+        let mutation_name = if add { "addReaction" } else { "removeReaction" };
+
+        let query = format!(
+            r#"mutation($subjectId: ID!, $content: ReactionContent!) {{
+                {mutation_name}(input: {{ subjectId: $subjectId, content: $content }}) {{
+                    reaction {{ content }}
+                }}
+            }}"#
+        );
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": {
+                "subjectId": subject_id,
+                "content": content,
+            }
+        });
+
+        self.graphql_request(payload).await?;
+        Ok(())
     }
 
     pub async fn get_pull_request_id(

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ pub fn run() {
             commands::generate_review_body,
             commands::update_review_comment,
             commands::create_review_comment,
+            commands::toggle_reaction,
             commands::get_settings,
             commands::save_settings,
             commands::load_viewed_files,

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -157,6 +157,13 @@ pub struct CommentAuthor {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReactionGroup {
+    pub content: String,
+    pub total_count: u32,
+    pub viewer_has_reacted: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewComment {
     pub id: String,
     pub body: String,
@@ -164,6 +171,8 @@ pub struct ReviewComment {
     pub created_at: String,
     pub updated_at: String,
     pub url: String,
+    #[serde(default)]
+    pub reactions: Vec<ReactionGroup>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -495,6 +495,7 @@ function App() {
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
       url: "",
+      reactions: [],
     };
 
     const prevThreads = tab.commentThreads.threads;
@@ -615,6 +616,54 @@ function App() {
       );
     } catch {
       updateTab(activeTabId,(t) => ({
+        ...t,
+        commentThreads: { status: "loaded" as const, threads: prevThreads },
+      }));
+    }
+  }
+
+  async function handleToggleReaction(commentId: string, content: string) {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab || tab.commentThreads.status !== "loaded") return;
+
+    const prevThreads = tab.commentThreads.threads;
+
+    // Single pass: determine add vs remove and build optimistic update together
+    let willAdd = true;
+    const optimisticThreads = prevThreads.map((th) => {
+      if (!th.comments.some((c) => c.id === commentId)) return th;
+      return {
+        ...th,
+        comments: th.comments.map((c) => {
+          if (c.id !== commentId) return c;
+          const reactions = c.reactions ?? [];
+          const existing = reactions.find((r) => r.content === content);
+          const add = !(existing?.viewer_has_reacted);
+          willAdd = add;
+          if (add) {
+            if (existing) {
+              return { ...c, reactions: reactions.map((r) => r.content === content ? { ...r, total_count: r.total_count + 1, viewer_has_reacted: true } : r) };
+            }
+            return { ...c, reactions: [...reactions, { content, total_count: 1, viewer_has_reacted: true }] };
+          }
+          return {
+            ...c,
+            reactions: reactions
+              .map((r) => r.content === content ? { ...r, total_count: r.total_count - 1, viewer_has_reacted: false } : r)
+              .filter((r) => r.total_count > 0),
+          };
+        }),
+      };
+    });
+    updateTab(activeTabId, (t) => ({
+      ...t,
+      commentThreads: { status: "loaded" as const, threads: optimisticThreads },
+    }));
+
+    try {
+      await invoke("toggle_reaction", { commentId, content, add: willAdd });
+    } catch {
+      updateTab(activeTabId, (t) => ({
         ...t,
         commentThreads: { status: "loaded" as const, threads: prevThreads },
       }));
@@ -932,13 +981,14 @@ function App() {
                   onReply={handleReply}
                   onToggleResolved={handleToggleResolved}
                   onEditComment={handleEditComment}
+                  onToggleReaction={handleToggleReaction}
                   lang={activeTab.selectedCommentFile ? detectLanguage(activeTab.selectedCommentFile) : undefined}
                 />
               ) : (
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+              <DiffViewer key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
             ) : activeTab.manifest.summary ? (
               <div className="pr-summary">
                 <h3>PR Summary</h3>

--- a/app/src/components/CommentsViewer.tsx
+++ b/app/src/components/CommentsViewer.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import type { ReviewThread, ReviewComment } from "../types";
 import { timeAgo } from "../utils";
-import { CommentBodyRendered } from "./DiffViewer";
+import { CommentBodyRendered, ReactionBar } from "./DiffViewer";
 
 interface CommentsViewerProps {
   threads: ReviewThread[];
@@ -9,16 +9,19 @@ interface CommentsViewerProps {
   onReply: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved: (threadId: string, resolve: boolean) => void;
   onEditComment?: (commentId: string, body: string) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   lang?: string;
 }
 
 function CommentCard({
   comment,
   onEdit,
+  onToggleReaction,
   lang,
 }: {
   comment: ReviewComment;
   onEdit?: (commentId: string, body: string) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   lang?: string;
 }) {
   const [editing, setEditing] = useState(false);
@@ -67,7 +70,10 @@ function CommentCard({
           </div>
         </div>
       ) : (
-        <CommentBodyRendered body={comment.body} lang={lang} />
+        <>
+          <CommentBodyRendered body={comment.body} lang={lang} />
+          {onToggleReaction && <ReactionBar reactions={comment.reactions ?? []} commentId={comment.id} onToggleReaction={onToggleReaction} />}
+        </>
       )}
     </div>
   );
@@ -78,12 +84,14 @@ function ThreadCard({
   onReply,
   onToggleResolved,
   onEdit,
+  onToggleReaction,
   lang,
 }: {
   thread: ReviewThread;
   onReply: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved: (threadId: string, resolve: boolean) => void;
   onEdit?: (commentId: string, body: string) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   lang?: string;
 }) {
   const [hunkExpanded, setHunkExpanded] = useState(!thread.is_resolved);
@@ -142,7 +150,7 @@ function ThreadCard({
 
           <div className="thread-comments">
             {thread.comments.map((comment) => (
-              <CommentCard key={comment.id} comment={comment} onEdit={onEdit} lang={lang} />
+              <CommentCard key={comment.id} comment={comment} onEdit={onEdit} onToggleReaction={onToggleReaction} lang={lang} />
             ))}
           </div>
 
@@ -205,6 +213,7 @@ export function CommentsViewer({
   onReply,
   onToggleResolved,
   onEditComment,
+  onToggleReaction,
   lang,
 }: CommentsViewerProps) {
   if (!selectedFile) {
@@ -249,6 +258,7 @@ export function CommentsViewer({
             onReply={onReply}
             onToggleResolved={onToggleResolved}
             onEdit={onEditComment}
+            onToggleReaction={onToggleReaction}
             lang={lang}
           />
         ))}
@@ -259,6 +269,7 @@ export function CommentsViewer({
             onReply={onReply}
             onToggleResolved={onToggleResolved}
             onEdit={onEditComment}
+            onToggleReaction={onToggleReaction}
             lang={lang}
           />
         ))}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
-import type { FileDiff, DiffViewMode, Highlight, ReviewThread, ReviewComment, SearchMatch } from "../types";
+import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch } from "../types";
 import { timeAgo } from "../utils";
 
 const extToLang: Record<string, string> = {
@@ -100,6 +100,9 @@ interface DiffViewerProps {
   showAiNotes: boolean;
   onCreateComment?: (path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") => Promise<void>;
   onEditComment?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   reviewThreads?: ReviewThread[];
   searchMatches?: SearchMatch[];
   currentSearchMatch?: SearchMatch | null;
@@ -306,20 +309,119 @@ function EditableCommentBody({
   );
 }
 
+const REACTION_EMOJI: Record<string, string> = {
+  THUMBS_UP: "\uD83D\uDC4D",
+  THUMBS_DOWN: "\uD83D\uDC4E",
+  LAUGH: "\uD83D\uDE04",
+  HOORAY: "\uD83C\uDF89",
+  CONFUSED: "\uD83D\uDE15",
+  HEART: "\u2764\uFE0F",
+  ROCKET: "\uD83D\uDE80",
+  EYES: "\uD83D\uDC40",
+};
+
+const REACTION_CONTENTS = Object.keys(REACTION_EMOJI);
+
+export function ReactionBar({
+  reactions,
+  commentId,
+  onToggleReaction,
+}: {
+  reactions: ReactionGroup[];
+  commentId: string;
+  onToggleReaction: (commentId: string, content: string) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
+        setPickerOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [pickerOpen]);
+
+  return (
+    <div className="reaction-bar">
+      {reactions.map((r) => (
+        <button
+          key={r.content}
+          className={`reaction-pill ${r.viewer_has_reacted ? "reaction-pill-active" : ""}`}
+          onClick={() => onToggleReaction(commentId, r.content)}
+          title={r.content.toLowerCase().replace(/_/g, " ")}
+        >
+          {REACTION_EMOJI[r.content] ?? r.content} {r.total_count}
+        </button>
+      ))}
+      <div className="reaction-picker-wrapper" ref={pickerRef}>
+        <button
+          className="reaction-add-button"
+          onClick={() => setPickerOpen((v) => !v)}
+          title="Add reaction"
+        >
+          +
+        </button>
+        {pickerOpen && (
+          <div className="reaction-picker">
+            {REACTION_CONTENTS.map((content) => (
+              <button
+                key={content}
+                className="reaction-picker-item"
+                onClick={() => {
+                  onToggleReaction(commentId, content);
+                  setPickerOpen(false);
+                }}
+                title={content.toLowerCase().replace(/_/g, " ")}
+              >
+                {REACTION_EMOJI[content]}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function InlineThreadMarker({
   thread,
   colSpan,
   onEdit,
+  onReply,
+  onToggleResolved,
+  onToggleReaction,
   lang,
 }: {
   thread: ReviewThread;
   colSpan: number;
   onEdit?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   lang?: string;
 }) {
   const [collapsed, setCollapsed] = useState(thread.is_resolved);
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
   const isSingle = thread.comments.length === 1;
   const first = thread.comments[0];
+  const lastComment = thread.comments[thread.comments.length - 1];
+
+  function handleSubmitReply() {
+    if (!replyText.trim() || submitting || !onReply) return;
+    setSubmitting(true);
+    onReply(thread.id, lastComment.id, replyText.trim());
+    setReplyText("");
+    setReplyOpen(false);
+    setSubmitting(false);
+  }
+
+  const showActions = onReply || onToggleResolved;
 
   return (
     <tr className={`inline-thread-row ${thread.is_resolved ? "inline-thread-resolved" : ""}`}>
@@ -337,6 +439,7 @@ function InlineThreadMarker({
                 {thread.is_resolved && <span className="inline-thread-resolved-badge">Resolved</span>}
               </div>
               <EditableCommentBody comment={first} onEdit={onEdit} lang={lang} />
+              {onToggleReaction && <ReactionBar reactions={first?.reactions ?? []} commentId={first?.id} onToggleReaction={onToggleReaction} />}
             </div>
           ) : (
             // Multi-comment: collapsible header + comment list
@@ -370,11 +473,47 @@ function InlineThreadMarker({
                         <span className="comment-time">{timeAgo(comment.created_at)}</span>
                       </div>
                       <EditableCommentBody comment={comment} onEdit={onEdit} lang={lang} />
+                      {onToggleReaction && <ReactionBar reactions={comment.reactions ?? []} commentId={comment.id} onToggleReaction={onToggleReaction} />}
                     </div>
                   ))}
                 </div>
               )}
             </>
+          )}
+          {showActions && (isSingle || !collapsed) && (
+            <div className="thread-actions">
+              {onReply && (
+                replyOpen ? (
+                  <div className="thread-reply-form" style={{ flex: 1 }}>
+                    <textarea
+                      className="reply-textarea"
+                      value={replyText}
+                      onChange={(e) => setReplyText(e.target.value)}
+                      placeholder="Write a reply..."
+                      rows={3}
+                      autoFocus
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmitReply();
+                      }}
+                    />
+                    <div className="reply-actions">
+                      <button className="reply-cancel" onClick={() => { setReplyOpen(false); setReplyText(""); }}>Cancel</button>
+                      <button className="reply-submit" disabled={!replyText.trim() || submitting} onClick={handleSubmitReply}>Reply</button>
+                    </div>
+                  </div>
+                ) : (
+                  <button className="reply-open-button" onClick={() => setReplyOpen(true)}>Reply...</button>
+                )
+              )}
+              {onToggleResolved && (
+                <button
+                  className={`resolve-button ${thread.is_resolved ? "resolve-button-resolved" : ""}`}
+                  onClick={() => onToggleResolved(thread.id, !thread.is_resolved)}
+                >
+                  {thread.is_resolved ? "Unresolve" : "Resolve"}
+                </button>
+              )}
+            </div>
           )}
         </div>
       </td>
@@ -656,6 +795,9 @@ function UnifiedHunkLines({
   onCancelComment,
   reviewThreads,
   onEditComment,
+  onReply,
+  onToggleResolved,
+  onToggleReaction,
   onPostHighlightAsComment,
   lang,
 }: {
@@ -670,6 +812,9 @@ function UnifiedHunkLines({
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
   onEditComment?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   onPostHighlightAsComment?: (h: Highlight) => void;
   lang?: string;
 }) {
@@ -756,7 +901,7 @@ function UnifiedHunkLines({
               </td>
             </tr>
             {lineThreads.map((thread) => (
-              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} lang={lang} />
+              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} lang={lang} />
             ))}
             {isEndOfSelection && onSubmitComment && onCancelComment && (
               <InlineCommentForm
@@ -790,6 +935,9 @@ function UnifiedView({
   onCancelComment,
   reviewThreads,
   onEditComment,
+  onReply,
+  onToggleResolved,
+  onToggleReaction,
   onPostHighlightAsComment,
   lang,
 }: {
@@ -807,6 +955,9 @@ function UnifiedView({
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
   onEditComment?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   onPostHighlightAsComment?: (h: Highlight) => void;
   lang?: string;
 }) {
@@ -865,13 +1016,13 @@ function UnifiedView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -895,6 +1046,9 @@ function SplitHunkLines({
   onCancelComment,
   reviewThreads,
   onEditComment,
+  onReply,
+  onToggleResolved,
+  onToggleReaction,
   onPostHighlightAsComment,
   lang,
 }: {
@@ -909,6 +1063,9 @@ function SplitHunkLines({
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
   onEditComment?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   onPostHighlightAsComment?: (h: Highlight) => void;
   lang?: string;
 }) {
@@ -1006,7 +1163,7 @@ function SplitHunkLines({
               </td>
             </tr>
             {lineThreads.map((thread) => (
-              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} lang={lang} />
+              <InlineThreadMarker key={thread.id} thread={thread} colSpan={4} onEdit={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} lang={lang} />
             ))}
             {showForm && onSubmitComment && onCancelComment && (
               <InlineCommentForm
@@ -1040,6 +1197,9 @@ function SplitView({
   onCancelComment,
   reviewThreads,
   onEditComment,
+  onReply,
+  onToggleResolved,
+  onToggleReaction,
   onPostHighlightAsComment,
   lang,
 }: {
@@ -1057,6 +1217,9 @@ function SplitView({
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
   onEditComment?: (commentId: string, body: string) => void;
+  onReply?: (threadId: string, commentId: string, body: string) => void;
+  onToggleResolved?: (threadId: string, resolve: boolean) => void;
+  onToggleReaction?: (commentId: string, content: string) => void;
   onPostHighlightAsComment?: (h: Highlight) => void;
   lang?: string;
 }) {
@@ -1118,13 +1281,13 @@ function SplitView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -1136,7 +1299,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps) {
+export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   const diffContentRef = useRef<HTMLDivElement>(null);
@@ -1540,6 +1703,9 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               onCancelComment={handleCancelComment}
               reviewThreads={fileThreads}
               onEditComment={onEditComment}
+              onReply={onReply}
+              onToggleResolved={onToggleResolved}
+              onToggleReaction={onToggleReaction}
               onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined}
               lang={lang}
             />
@@ -1559,6 +1725,9 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               onCancelComment={handleCancelComment}
               reviewThreads={fileThreads}
               onEditComment={onEditComment}
+              onReply={onReply}
+              onToggleResolved={onToggleResolved}
+              onToggleReaction={onToggleReaction}
               onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined}
               lang={lang}
             />
@@ -1572,7 +1741,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
+              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
             </tbody>
           </table>
         )}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2777,6 +2777,102 @@ body {
   margin-top: 4px;
 }
 
+/* ─── Reactions ────────────────────────────────────────────────────────── */
+.reaction-bar {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+.reaction-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  line-height: 1.6;
+}
+
+.reaction-pill:hover {
+  border-color: var(--accent);
+}
+
+.reaction-pill-active {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+}
+
+.reaction-picker-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.reaction-add-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 22px;
+  border-radius: 10px;
+  border: 1px dashed var(--border);
+  background: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.thread-comment:hover .reaction-add-button,
+.inline-thread-single:hover .reaction-add-button,
+.inline-thread-comment:hover .reaction-add-button,
+.reaction-bar:hover .reaction-add-button {
+  opacity: 1;
+}
+
+.reaction-add-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.reaction-picker {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  z-index: 10;
+  white-space: nowrap;
+}
+
+.reaction-picker-item {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  line-height: 1.2;
+}
+
+.reaction-picker-item:hover {
+  background: var(--bg-secondary);
+}
+
 /* ─── Inline Comment (Diff View) ───────────────────────────────────────── */
 .line-comment-button {
   display: none;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -60,6 +60,12 @@ export interface CommentAuthor {
   avatar_url: string;
 }
 
+export interface ReactionGroup {
+  content: string;
+  total_count: number;
+  viewer_has_reacted: boolean;
+}
+
 export interface ReviewComment {
   id: string;
   body: string;
@@ -67,6 +73,7 @@ export interface ReviewComment {
   created_at: string;
   updated_at: string;
   url: string;
+  reactions: ReactionGroup[];
 }
 
 export interface ReviewThread {


### PR DESCRIPTION
## Summary
- Add emoji reaction support on review comments: display existing reactions as pills, toggle on/off via click, and add new reactions via a picker popover
- Add reply form and resolve/unresolve button to inline diff view comments (previously only available in the Comments sidebar)
- Fix single-comment resolved threads not showing action buttons in the inline diff view

Closes #31

## Changes

**Rust backend** (`src-tauri/src/`):
- `types.rs` — new `ReactionGroup` struct, `reactions` field on `ReviewComment`
- `github.rs` — `reactionGroups` in all comment GraphQL queries, `toggle_reaction` mutation, `parse_reaction_groups` parser
- `commands.rs` — `toggle_reaction` Tauri command
- `lib.rs` — register new command

**Frontend types** (`src/`):
- `types.ts` — `ReactionGroup` interface, updated `ReviewComment`

**React components** (`src/components/`):
- `DiffViewer.tsx` — `ReactionBar` component with click-outside dismiss, inline reply/resolve in `InlineThreadMarker`, prop threading for `onReply`/`onToggleResolved`/`onToggleReaction`
- `CommentsViewer.tsx` — wire `onToggleReaction` through `ThreadCard` and `CommentCard`
- `App.tsx` — `handleToggleReaction` with optimistic updates, pass new props to both viewers

**Styles** (`src/`):
- `styles.css` — reaction bar, pill, picker, and add-button styles

## Test Plan
- [ ] Open a PR with existing comments — verify reaction pills display with correct emoji and counts
- [ ] Click a reaction pill to toggle it on/off — verify optimistic update and GitHub sync
- [ ] Click the "+" button on a comment — verify picker opens, click outside dismisses it
- [ ] Select a reaction from the picker — verify it appears as a new pill
- [ ] On inline diff comments, verify "Reply..." button and "Resolve"/"Unresolve" button appear
- [ ] Reply to an inline comment — verify the reply appears in the thread
- [ ] Resolve/unresolve an inline thread — verify badge updates
- [ ] On a single-comment resolved thread in the diff view, verify action buttons are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)