### PR TITLE
feat(sync): sync file reviewed state between RR and GitHub

### DIFF
--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -5,12 +5,14 @@ use crate::github::GithubClient;
 use crate::types::{MyReviewState, PrChecksStatus, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use crate::manifest_cache::{self, CachedPrInfo};
 use crate::viewed_state::{self, ViewedFileState};
+use std::collections::HashMap;
 use std::fs;
 use std::sync::Mutex;
 use tauri::{command, State};
 
 pub struct AppState {
     pub manifest_path: Mutex<Option<String>>,
+    pub pr_node_ids: Mutex<HashMap<String, String>>,
 }
 
 fn github_client() -> GithubClient {
@@ -212,6 +214,38 @@ pub async fn toggle_reaction(
 ) -> Result<(), String> {
     let github = github_client();
     github.toggle_reaction(&comment_id, &content, add).await
+}
+
+#[command]
+pub async fn sync_file_viewed_to_github(
+    state: State<'_, AppState>,
+    pr_url: String,
+    path: String,
+    viewed: bool,
+) -> Result<(), String> {
+    let cached = state.pr_node_ids.lock().unwrap().get(&pr_url).cloned();
+    let github = github_client();
+    let pr_node_id = match cached {
+        Some(id) => id,
+        None => {
+            let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+            let id = github
+                .get_pull_request_id(&parsed.owner, &parsed.repo, parsed.number)
+                .await?;
+            state.pr_node_ids.lock().unwrap().insert(pr_url, id.clone());
+            id
+        }
+    };
+    github.mark_file_viewed(&pr_node_id, &path, viewed).await
+}
+
+#[command]
+pub async fn fetch_gh_viewed_state(pr_url: String) -> Result<HashMap<String, String>, String> {
+    let github = github_client();
+    let parsed = crate::pr_parser::parse_pr_ref(&pr_url)?;
+    github
+        .get_files_viewed_state(&parsed.owner, &parsed.repo, parsed.number)
+        .await
 }
 
 #[command]

--- a/app/src-tauri/src/github.rs
+++ b/app/src-tauri/src/github.rs
@@ -1,4 +1,5 @@
 use crate::types::{CheckRunInfo, CommentAuthor, MyReviewState, PrChecksStatus, PrFile, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
+use std::collections::HashMap;
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
 use reqwest::Client;
@@ -1214,6 +1215,114 @@ impl GithubClient {
             overall_state,
             check_runs,
         })
+    }
+
+    /// Mark or unmark a file as viewed on a pull request.
+    pub async fn mark_file_viewed(
+        &self,
+        pull_request_id: &str,
+        path: &str,
+        viewed: bool,
+    ) -> Result<(), String> {
+        let mutation_name = if viewed {
+            "markFileAsViewed"
+        } else {
+            "unmarkFileAsViewed"
+        };
+
+        let query = format!(
+            r#"mutation($prId: ID!, $path: String!) {{
+                {mutation_name}(input: {{ pullRequestId: $prId, path: $path }}) {{
+                    pullRequest {{ id }}
+                }}
+            }}"#
+        );
+
+        let payload = serde_json::json!({
+            "query": query,
+            "variables": {
+                "prId": pull_request_id,
+                "path": path,
+            }
+        });
+
+        self.graphql_request(payload).await?;
+        Ok(())
+    }
+
+    /// Fetch the viewer's viewed state for all files in a pull request.
+    /// Returns a map of file path → "VIEWED" | "UNVIEWED" | "DISMISSED".
+    pub async fn get_files_viewed_state(
+        &self,
+        owner: &str,
+        repo: &str,
+        pr_number: u64,
+    ) -> Result<HashMap<String, String>, String> {
+        let mut all_files = HashMap::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let after_clause = match &cursor {
+                Some(c) => format!(", after: \"{}\"", c),
+                None => String::new(),
+            };
+
+            let query = format!(
+                r#"{{
+                    repository(owner: "{}", name: "{}") {{
+                        pullRequest(number: {}) {{
+                            files(first: 100{}) {{
+                                pageInfo {{ hasNextPage endCursor }}
+                                nodes {{
+                                    path
+                                    viewerViewedState
+                                }}
+                            }}
+                        }}
+                    }}
+                }}"#,
+                owner, repo, pr_number, after_clause
+            );
+
+            let body = serde_json::json!({ "query": query });
+            let result = self.graphql_request(body).await?;
+
+            let files_data = result
+                .pointer("/data/repository/pullRequest/files")
+                .ok_or("Missing files in response")?;
+
+            let nodes = files_data
+                .pointer("/nodes")
+                .and_then(|v| v.as_array())
+                .ok_or("Missing nodes in files")?;
+
+            for node in nodes {
+                let path = node.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                let state = node
+                    .get("viewerViewedState")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("UNVIEWED");
+                if !path.is_empty() {
+                    all_files.insert(path.to_string(), state.to_string());
+                }
+            }
+
+            let has_next = files_data
+                .pointer("/pageInfo/hasNextPage")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            if has_next {
+                cursor = files_data
+                    .pointer("/pageInfo/endCursor")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+            } else {
+                break;
+            }
+        }
+
+        Ok(all_files)
     }
 
     /// Get the current user's review state on a PR, including whether they've

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod types;
 mod viewed_state;
 
 use commands::AppState;
+use std::collections::HashMap;
 use std::env;
 use std::sync::Mutex;
 
@@ -26,6 +27,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .manage(AppState {
             manifest_path: Mutex::new(manifest_path),
+            pr_node_ids: Mutex::new(HashMap::new()),
         })
         .invoke_handler(tauri::generate_handler![
             commands::load_manifest,
@@ -44,6 +46,8 @@ pub fn run() {
             commands::toggle_reaction,
             commands::get_settings,
             commands::save_settings,
+            commands::sync_file_viewed_to_github,
+            commands::fetch_gh_viewed_state,
             commands::load_viewed_files,
             commands::save_viewed_files,
             commands::list_cached_prs,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -237,6 +237,7 @@ function App() {
     } catch {
       // Graceful degradation: if loading fails, start with empty state
     }
+    syncGhViewedState(tab.id, tab.manifest.pr_url, tab.manifest.files);
   }
 
   const unlistenRef = useRef<(() => void) | null>(null);
@@ -361,6 +362,7 @@ function App() {
       persistViewedState(refreshedTab);
       fetchMyReviewState(tab.id, newManifest.pr_url);
       fetchChecksStatus(tab.id, newManifest.pr_url);
+      syncGhViewedState(tab.id, newManifest.pr_url, newManifest.files);
 
       if (parts.length > 0) {
         addToast("success", `PR updated: ${parts.join(", ")}`);
@@ -408,24 +410,21 @@ function App() {
   }
 
   function toggleViewed(filePath: string) {
-    let tabToSave: Tab | null = null;
-    setTabs((prev) =>
-      prev.map((t) => {
-        if (t.id !== activeTabId) return t;
-        const nextViewed = new Set(t.viewedFiles);
-        const nextStale = new Set(t.staleViewedFiles);
-        if (nextViewed.has(filePath)) {
-          nextViewed.delete(filePath);
-        } else {
-          nextViewed.add(filePath);
-          nextStale.delete(filePath);
-        }
-        const updated = { ...t, viewedFiles: nextViewed, staleViewedFiles: nextStale };
-        tabToSave = updated;
-        return updated;
-      })
-    );
-    if (tabToSave) persistViewedState(tabToSave);
+    const tab = tabs.find((t) => t.id === activeTabId);
+    if (!tab) return;
+    const nowViewed = !tab.viewedFiles.has(filePath);
+    const nextViewed = new Set(tab.viewedFiles);
+    const nextStale = new Set(tab.staleViewedFiles);
+    if (nowViewed) {
+      nextViewed.add(filePath);
+      nextStale.delete(filePath);
+    } else {
+      nextViewed.delete(filePath);
+    }
+    const updated = { ...tab, viewedFiles: nextViewed, staleViewedFiles: nextStale };
+    updateTab(tab.id, () => updated);
+    persistViewedState(updated);
+    invoke("sync_file_viewed_to_github", { prUrl: tab.manifest.pr_url, path: filePath, viewed: nowViewed }).catch(() => {});
   }
 
   async function persistViewedState(tab: Tab) {
@@ -440,6 +439,44 @@ function App() {
       await invoke("save_viewed_files", { owner, repo, prNumber: number, state: { files } });
     } catch {
       // Non-critical: persistence failure shouldn't block UI
+    }
+  }
+
+  async function syncGhViewedState(tabId: string, prUrl: string, files: Array<{ path: string; diff_hash: string }>) {
+    try {
+      const ghState = await invoke<Record<string, string>>("fetch_gh_viewed_state", { prUrl });
+      const currentPaths = new Set(files.map((f) => f.path));
+
+      setTabs((prev) => {
+        const tab = prev.find((t) => t.id === tabId);
+        if (!tab) return prev;
+
+        const nextViewed = new Set(tab.viewedFiles);
+        const nextStale = new Set(tab.staleViewedFiles);
+        let changed = false;
+
+        for (const [path, state] of Object.entries(ghState)) {
+          if (!currentPaths.has(path)) continue;
+          if (state === "VIEWED" && !nextViewed.has(path) && !nextStale.has(path)) {
+            nextViewed.add(path);
+            changed = true;
+          } else if (state === "UNVIEWED" && nextViewed.has(path)) {
+            nextViewed.delete(path);
+            changed = true;
+          } else if (state === "DISMISSED" && nextViewed.has(path)) {
+            nextViewed.delete(path);
+            nextStale.add(path);
+            changed = true;
+          }
+        }
+
+        if (!changed) return prev;
+        const updated = { ...tab, viewedFiles: nextViewed, staleViewedFiles: nextStale };
+        persistViewedState(updated);
+        return prev.map((t) => (t.id === tabId ? updated : t));
+      });
+    } catch {
+      // GH sync is best-effort — skip on failure (no token, network error, etc.)
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds bidirectional sync of file "reviewed" state between Relevant Reviews and GitHub's "Viewed" file state on PRs
- **RR → GitHub:** Toggling a file's reviewed state in RR immediately calls `markFileAsViewed`/`unmarkFileAsViewed` via GitHub's GraphQL API
- **GitHub → RR:** On PR load and refresh, fetches `viewerViewedState` for all files and reconciles with local state (VIEWED, UNVIEWED, DISMISSED)
- PR node IDs are cached in-memory to avoid redundant API calls on repeated toggles

## Changes

**Rust backend (`app/src-tauri/src/`):**
- `github.rs` — added `mark_file_viewed` and `get_files_viewed_state` methods to `GithubClient`
- `commands.rs` — added `sync_file_viewed_to_github` and `fetch_gh_viewed_state` Tauri commands; added `pr_node_ids` cache to `AppState`
- `lib.rs` — registered new commands and initialized cache

**React frontend (`app/src/`):**
- `App.tsx` — added `syncGhViewedState` function called on load/refresh; updated `toggleViewed` to fire-and-forget sync to GitHub

## Test Plan
- [ ] Open a PR in RR, mark a file as reviewed, then check GitHub's "Files changed" tab — the file should show as "Viewed"
- [ ] Unmark the file in RR, verify it shows as unviewed on GitHub
- [ ] Mark a file as "Viewed" on GitHub's web UI, then refresh the PR in RR — the file should appear as reviewed
- [ ] Mark a file as "Viewed" on GitHub, push a new commit that changes that file, then refresh in RR — the file should appear as stale (DISMISSED)
- [ ] Verify sync degrades gracefully with no GitHub token configured (no errors, local state preserved)
- [ ] `cargo check` and `npm run build` pass cleanly

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)