### PR TITLE
gitf: GH-40: Collapse All label is incorrect

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1620,10 +1620,8 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
   const highHunkCount = hunks.filter((h) => h.significance === "high").length;
   const collapsedCount = collapsedHunks.size;
 
-  const collapseAllLow = () => {
-    setCollapsedHunks(new Set(
-      hunks.filter((h) => h.significance === "low").map((h) => h.index)
-    ));
+  const collapseAll = () => {
+    setCollapsedHunks(new Set(hunks.map((h) => h.index)));
   };
 
   const expandAll = () => {
@@ -1661,9 +1659,9 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
             </button>
           </>
         )}
-        {showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && hunks.some((h) => h.significance === "low") && (
-          <button className="hunk-toggle-all" onClick={collapseAllLow}>
-            Collapse low
+        {showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && (
+          <button className="hunk-toggle-all" onClick={collapseAll}>
+            Collapse all
           </button>
         )}
       </div>

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1655,13 +1655,13 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               {collapsedCount} {collapsedCount === 1 ? "hunk" : "hunks"} collapsed
             </span>
             <button className="hunk-toggle-all" onClick={expandAll}>
-              Expand all
+              Expand All
             </button>
           </>
         )}
         {showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && (
           <button className="hunk-toggle-all" onClick={collapseAll}>
-            Collapse all
+            Collapse All
           </button>
         )}
       </div>


### PR DESCRIPTION
Mission msn-b65f14

**Goal:** Implement GitHub issue 40: Collapse All label is incorrect

### Describe the bug

Should be "Collapse All" after expanding all hunks instead of "Collapse Low".



### Steps to reproduce

Expand the hunks, look with your eyes

### Expected behavior

Collapse All

### Screenshots

<img width="378" height="102" alt="Image" src="https://github.com/user-attachments/assets/bbb397f3-8215-4669-9cd8-655bea073f7c" />

### App version

01123

### OS

123123

Labels: bug

Issue: https://github.com/Besendorfer/relevant-reviews/issues/40


---
*There are countless ingredients that make up the human body and mind.* — Major Kusanagi, Ghost in the Shell
