### PR TITLE
feat(settings): per-feature flags for AI/UI surfaces

### DIFF
--- a/app/src-tauri/src/config.rs
+++ b/app/src-tauri/src/config.rs
@@ -25,6 +25,10 @@ fn default_settings() -> Settings {
         show_hunk_significance: true,
         show_ai_notes: true,
         hunk_filter: "all".to_string(),
+        enable_ai_summary: true,
+        enable_change_groups: true,
+        enable_comments_view: true,
+        enable_checks_status: true,
     }
 }
 
@@ -48,6 +52,10 @@ pub fn load_settings() -> Settings {
     let mut show_hunk_significance = true;
     let mut show_ai_notes = true;
     let mut hunk_filter = "all".to_string();
+    let mut enable_ai_summary = true;
+    let mut enable_change_groups = true;
+    let mut enable_comments_view = true;
+    let mut enable_checks_status = true;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -68,6 +76,14 @@ pub fn load_settings() -> Settings {
             show_ai_notes = val == "true";
         } else if let Some(val) = line.strip_prefix("hunk_filter=") {
             hunk_filter = val.to_string();
+        } else if let Some(val) = line.strip_prefix("enable_ai_summary=") {
+            enable_ai_summary = val == "true";
+        } else if let Some(val) = line.strip_prefix("enable_change_groups=") {
+            enable_change_groups = val == "true";
+        } else if let Some(val) = line.strip_prefix("enable_comments_view=") {
+            enable_comments_view = val == "true";
+        } else if let Some(val) = line.strip_prefix("enable_checks_status=") {
+            enable_checks_status = val == "true";
         }
     }
 
@@ -81,6 +97,10 @@ pub fn load_settings() -> Settings {
         show_hunk_significance,
         show_ai_notes,
         hunk_filter,
+        enable_ai_summary,
+        enable_change_groups,
+        enable_comments_view,
+        enable_checks_status,
     }
 }
 
@@ -104,6 +124,10 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     content.push_str(&format!("show_hunk_significance={}\n", settings.show_hunk_significance));
     content.push_str(&format!("show_ai_notes={}\n", settings.show_ai_notes));
     content.push_str(&format!("hunk_filter={}\n", settings.hunk_filter));
+    content.push_str(&format!("enable_ai_summary={}\n", settings.enable_ai_summary));
+    content.push_str(&format!("enable_change_groups={}\n", settings.enable_change_groups));
+    content.push_str(&format!("enable_comments_view={}\n", settings.enable_comments_view));
+    content.push_str(&format!("enable_checks_status={}\n", settings.enable_checks_status));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/src/fetch.rs
+++ b/app/src-tauri/src/fetch.rs
@@ -120,35 +120,50 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: &tauri::AppHa
     }
 
     // Step 4: AI highlight analysis + summary + grouping (parallel)
-    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
+    // Each prompt is gated on a Settings flag — disabled prompts are skipped
+    // entirely to save AI cost and time.
     let per_file_diff_map = build_per_file_diff_map(&full_diff);
     let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
     let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
-
     let summary_prompt = build_summary_prompt(&pr_title, &relevant);
     let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
 
-    let mut ai_stream: FuturesUnordered<_> = [
-        ("highlights", ai.invoke(&highlight_prompt)),
-        ("summary", ai.invoke(&summary_prompt)),
-        ("grouping", ai.invoke(&grouping_prompt)),
-    ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
-
-    let mut highlights_raw = Err("not started".to_string());
-    let mut summary_raw = Err("not started".to_string());
-    let mut grouping_raw = Err("not started".to_string());
-    let mut ai_done: u32 = 0;
-    while let Some((name, result)) = ai_stream.next().await {
-        ai_done += 1;
-        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
-        match name {
-            "highlights" => highlights_raw = result,
-            "summary" => summary_raw = result,
-            "grouping" => grouping_raw = result,
-            _ => {}
-        }
+    let mut ai_futures = Vec::new();
+    if settings.show_ai_notes {
+        ai_futures.push(("highlights", ai.invoke(&highlight_prompt)));
     }
-    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Done, None, None);
+    if settings.enable_ai_summary {
+        ai_futures.push(("summary", ai.invoke(&summary_prompt)));
+    }
+    if settings.enable_change_groups {
+        ai_futures.push(("grouping", ai.invoke(&grouping_prompt)));
+    }
+
+    let mut highlights_raw: Result<String, String> = Ok("[]".to_string());
+    let mut summary_raw: Result<String, String> = Ok(String::new());
+    let mut grouping_raw: Result<String, String> = Ok("[]".to_string());
+
+    let total = ai_futures.len() as u32;
+    if total > 0 {
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, total)));
+        let mut ai_stream: FuturesUnordered<_> = ai_futures
+            .into_iter()
+            .map(|(name, fut)| async move { (name, fut.await) })
+            .collect();
+
+        let mut ai_done: u32 = 0;
+        while let Some((name, result)) = ai_stream.next().await {
+            ai_done += 1;
+            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, total)));
+            match name {
+                "highlights" => highlights_raw = result,
+                "summary" => summary_raw = result,
+                "grouping" => grouping_raw = result,
+                _ => {}
+            }
+        }
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Done, None, None);
+    }
 
     let highlights_raw = highlights_raw.unwrap_or_else(|_| "[]".to_string());
 

--- a/app/src-tauri/src/types.rs
+++ b/app/src-tauri/src/types.rs
@@ -99,6 +99,14 @@ pub struct Settings {
     pub show_ai_notes: bool,
     #[serde(default = "default_all")]
     pub hunk_filter: String,
+    #[serde(default = "default_true")]
+    pub enable_ai_summary: bool,
+    #[serde(default = "default_true")]
+    pub enable_change_groups: bool,
+    #[serde(default = "default_true")]
+    pub enable_comments_view: bool,
+    #[serde(default = "default_true")]
+    pub enable_checks_status: bool,
 }
 
 fn default_true() -> bool {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,6 +27,10 @@ function App() {
   const [showHunkSignificance, setShowHunkSignificance] = useState(true);
   const [showAiNotes, setShowAiNotes] = useState(true);
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
+  const [enableAiSummary, setEnableAiSummary] = useState(true);
+  const [enableChangeGroups, setEnableChangeGroups] = useState(true);
+  const [enableCommentsView, setEnableCommentsView] = useState(true);
+  const [enableChecksStatus, setEnableChecksStatus] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [showOpener, setShowOpener] = useState(false);
@@ -50,7 +54,15 @@ function App() {
 
   const handleSettingsClose = useCallback(() => {
     setSettingsOpen(false);
-    invoke<Settings>("get_settings").then((s) => { settingsRef.current = s; }).catch(() => {});
+    invoke<Settings>("get_settings").then((s) => {
+      settingsRef.current = s;
+      // Mirror feature-flag changes the user made inside the modal back into
+      // local state so the UI reflects them without an app reload.
+      setEnableAiSummary(s.enable_ai_summary ?? true);
+      setEnableChangeGroups(s.enable_change_groups ?? true);
+      setEnableCommentsView(s.enable_comments_view ?? true);
+      setEnableChecksStatus(s.enable_checks_status ?? true);
+    }).catch(() => {});
   }, []);
 
   const addToast = useCallback((type: ToastData["type"], message: string) => {
@@ -166,6 +178,10 @@ function App() {
         setShowHunkSignificance(settings.show_hunk_significance ?? true);
         setShowAiNotes(settings.show_ai_notes ?? true);
         setHunkFilter(settings.hunk_filter || "all");
+        setEnableAiSummary(settings.enable_ai_summary ?? true);
+        setEnableChangeGroups(settings.enable_change_groups ?? true);
+        setEnableCommentsView(settings.enable_comments_view ?? true);
+        setEnableChecksStatus(settings.enable_checks_status ?? true);
       } catch {
         // Use defaults on failure
       }
@@ -309,6 +325,7 @@ function App() {
   }
 
   async function fetchChecksStatus(tabId: string, prUrl: string) {
+    if (!enableChecksStatus) return;
     try {
       const [checks, dismissed] = await Promise.all([
         invoke<PrChecksStatus>("get_pr_checks", { prUrl }),
@@ -954,8 +971,12 @@ function App() {
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const enableChecksStatusRef = useRef(enableChecksStatus);
+  enableChecksStatusRef.current = enableChecksStatus;
+
   useEffect(() => {
     const interval = setInterval(async () => {
+      if (!enableChecksStatusRef.current) return;
       const currentTabs = tabsRef.current;
       if (loadingRef.current || currentTabs.length === 0) return;
 
@@ -1010,14 +1031,16 @@ function App() {
     const s = settingsRef.current;
     if (!s) return;
     if (s.view_mode === viewMode && s.show_hunk_significance === showHunkSignificance
-        && s.show_ai_notes === showAiNotes && s.hunk_filter === hunkFilter) return;
+        && s.show_ai_notes === showAiNotes && s.hunk_filter === hunkFilter
+        && s.enable_ai_summary === enableAiSummary && s.enable_change_groups === enableChangeGroups
+        && s.enable_comments_view === enableCommentsView && s.enable_checks_status === enableChecksStatus) return;
     const timer = setTimeout(() => {
-      const updated = { ...settingsRef.current!, view_mode: viewMode, show_hunk_significance: showHunkSignificance, show_ai_notes: showAiNotes, hunk_filter: hunkFilter };
+      const updated = { ...settingsRef.current!, view_mode: viewMode, show_hunk_significance: showHunkSignificance, show_ai_notes: showAiNotes, hunk_filter: hunkFilter, enable_ai_summary: enableAiSummary, enable_change_groups: enableChangeGroups, enable_comments_view: enableCommentsView, enable_checks_status: enableChecksStatus };
       settingsRef.current = updated;
       invoke("save_settings", { settings: updated }).catch(() => {});
     }, 500);
     return () => clearTimeout(timer);
-  }, [viewMode, showHunkSignificance, showAiNotes, hunkFilter]);
+  }, [viewMode, showHunkSignificance, showAiNotes, hunkFilter, enableAiSummary, enableChangeGroups, enableCommentsView, enableChecksStatus]);
 
   async function handleFileDrop(e: React.DragEvent) {
     e.preventDefault();
@@ -1184,6 +1207,8 @@ function App() {
             commentThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : []}
             selectedCommentFile={activeTab.selectedCommentFile}
             onSelectCommentFile={handleSelectCommentFile}
+            enableChangeGroups={enableChangeGroups}
+            enableCommentsView={enableCommentsView}
           />
           <div className="diff-pane">
             {activeTab.sidebarView === "comments" ? (

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -18,6 +18,8 @@ interface FileSidebarProps {
   commentThreads: ReviewThread[];
   selectedCommentFile: string | null;
   onSelectCommentFile: (path: string) => void;
+  enableChangeGroups: boolean;
+  enableCommentsView: boolean;
 }
 
 function getMaxHunkSignificance(file: FileDiff): string {
@@ -387,8 +389,10 @@ export function FileSidebar({
   commentThreads,
   selectedCommentFile,
   onSelectCommentFile,
+  enableChangeGroups,
+  enableCommentsView,
 }: FileSidebarProps) {
-  const hasGroups = changeGroups.length > 0;
+  const hasGroups = enableChangeGroups && changeGroups.length > 0;
   const prevHasGroups = useRef(hasGroups);
 
   useEffect(() => {
@@ -397,6 +401,12 @@ export function FileSidebar({
     }
     prevHasGroups.current = hasGroups;
   }, [hasGroups]);
+
+  // If the user disables a view they're currently looking at, snap back to a valid one.
+  useEffect(() => {
+    if (view === "comments" && !enableCommentsView) setView("category");
+    if (view === "groups" && !enableChangeGroups) setView("category");
+  }, [view, enableCommentsView, enableChangeGroups]);
 
   const criticalFiles = useMemo(() => {
     return files
@@ -506,13 +516,15 @@ export function FileSidebar({
                 Groups
               </button>
             )}
-            <button
-              className={view === "comments" ? "active" : ""}
-              onClick={() => setView("comments")}
-              title="Review comments"
-            >
-              Comments
-            </button>
+            {enableCommentsView && (
+              <button
+                className={view === "comments" ? "active" : ""}
+                onClick={() => setView("comments")}
+                title="Review comments"
+              >
+                Comments
+              </button>
+            )}
             <button
               className={view === "category" ? "active" : ""}
               onClick={() => setView("category")}

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -11,6 +11,32 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
+function FeatureToggle({
+  label,
+  hint,
+  checked,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <label className="feature-toggle">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className="feature-toggle-text">
+        <span className="feature-toggle-label">{label}</span>
+        <span className="feature-toggle-hint">{hint}</span>
+      </span>
+    </label>
+  );
+}
+
 export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [model, setModel] = useState("");
   const [githubToken, setGithubToken] = useState("");
@@ -18,6 +44,11 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [enableAiSummary, setEnableAiSummary] = useState(true);
+  const [enableChangeGroups, setEnableChangeGroups] = useState(true);
+  const [enableCommentsView, setEnableCommentsView] = useState(true);
+  const [enableChecksStatus, setEnableChecksStatus] = useState(true);
+  const [showAiNotes, setShowAiNotes] = useState(true);
 
   // Set href via DOM to bypass React's javascript: URL blocking
   const bookmarkletRef = useCallback((node: HTMLAnchorElement | null) => {
@@ -30,6 +61,11 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setModel(s.model);
         setGithubToken(s.github_token || "");
         setAwsProfile(s.aws_profile || "");
+        setEnableAiSummary(s.enable_ai_summary ?? true);
+        setEnableChangeGroups(s.enable_change_groups ?? true);
+        setEnableCommentsView(s.enable_comments_view ?? true);
+        setEnableChecksStatus(s.enable_checks_status ?? true);
+        setShowAiNotes(s.show_ai_notes ?? true);
         setCurrentSettings(s);
       });
       setSaved(false);
@@ -49,8 +85,12 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           filter_team: currentSettings?.filter_team ?? true,
           view_mode: currentSettings?.view_mode ?? "split",
           show_hunk_significance: currentSettings?.show_hunk_significance ?? true,
-          show_ai_notes: currentSettings?.show_ai_notes ?? true,
+          show_ai_notes: showAiNotes,
           hunk_filter: currentSettings?.hunk_filter ?? "all",
+          enable_ai_summary: enableAiSummary,
+          enable_change_groups: enableChangeGroups,
+          enable_comments_view: enableCommentsView,
+          enable_checks_status: enableChecksStatus,
         },
       });
       setSaved(true);
@@ -139,6 +179,44 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             placeholder="ghp_... or github_pat_..."
             spellCheck={false}
             autoComplete="off"
+          />
+
+          <div className="settings-divider" />
+          <h3 className="settings-section-title">Features</h3>
+          <p className="settings-hint">
+            Turn off features you don't use to declutter the UI. Items marked
+            <em> (skips AI work)</em> also avoid the related AI calls during
+            fetch, saving cost and time.
+          </p>
+          <FeatureToggle
+            label="AI highlights"
+            hint="Inline AI annotations on the diff. (skips AI work)"
+            checked={showAiNotes}
+            onChange={(v) => { setShowAiNotes(v); setSaved(false); }}
+          />
+          <FeatureToggle
+            label="AI summary"
+            hint="The PR-level summary shown when no file is selected. (skips AI work)"
+            checked={enableAiSummary}
+            onChange={(v) => { setEnableAiSummary(v); setSaved(false); }}
+          />
+          <FeatureToggle
+            label="Change groups"
+            hint="The Groups sidebar view that clusters related files. (skips AI work)"
+            checked={enableChangeGroups}
+            onChange={(v) => { setEnableChangeGroups(v); setSaved(false); }}
+          />
+          <FeatureToggle
+            label="Comments view"
+            hint="The Comments sidebar view and review-thread fetching."
+            checked={enableCommentsView}
+            onChange={(v) => { setEnableCommentsView(v); setSaved(false); }}
+          />
+          <FeatureToggle
+            label="CI checks status"
+            hint="The blocking modal and live polling for failing/pending checks."
+            checked={enableChecksStatus}
+            onChange={(v) => { setEnableChecksStatus(v); setSaved(false); }}
           />
 
           <div className="settings-divider" />

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1788,6 +1788,32 @@ body {
   color: var(--text-primary);
 }
 
+.feature-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 0;
+  cursor: pointer;
+}
+.feature-toggle input[type="checkbox"] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+.feature-toggle-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.feature-toggle-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+.feature-toggle-hint {
+  font-size: 12px;
+  color: var(--text-secondary, #888);
+}
+
 .bookmarklet-link {
   display: inline-block;
   padding: 6px 14px;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -139,6 +139,10 @@ export interface Settings {
   show_hunk_significance: boolean;
   show_ai_notes: boolean;
   hunk_filter: HunkSignificanceFilter;
+  enable_ai_summary: boolean;
+  enable_change_groups: boolean;
+  enable_comments_view: boolean;
+  enable_checks_status: boolean;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";


### PR DESCRIPTION
## Summary

Adds a Features section in Settings with toggles for each major feature. Flags off skip the related backend work where applicable, not just the UI rendering — saves AI cost and fetch time on big PRs.

## Flags

| Flag | UI effect when off | Backend effect when off |
|---|---|---|
| `show_ai_notes` (existing, now exposed) | Hide highlights | Skip highlights AI prompt |
| `enable_ai_summary` | Hide summary section | Skip summary AI prompt |
| `enable_change_groups` | Hide Groups sidebar view | Skip grouping AI prompt |
| `enable_comments_view` | Hide Comments sidebar view | Skip the on-demand `fetch_review_comments` (no comments view = no entry point) |
| `enable_checks_status` | Hide blocking modal + don't gate the submit button | Skip `get_pr_checks` initial fetch + 30s polling |

Dropped from the issue's draft: `deep_link_button` — the only in-app deep-link UI is the Settings → Browser Integration block itself, so hiding it would lock users out of re-enabling. Worth revisiting if/when there's a main-UI deep-link affordance.

## Touchpoints

- `types.rs` Settings struct, `config.rs` (default + load + save), `fetch.rs` (conditional AI futures)
- `types.ts` Settings, `App.tsx` (state + hydrate + persist + gate fetches + sidebar props), `SettingsModal.tsx` (Features section + FeatureToggle helper), `FileSidebar.tsx` (gate Groups/Comments tabs)
- All flags default `true` — upgrade is a no-op for existing users.

## Test plan

- [x] `cargo check` passes
- [x] `bun run build` (tsc + vite) passes
- [ ] Manual: open Settings → Features, toggle each flag off and on, confirm the corresponding section disappears/reappears
- [ ] Manual: with `enable_ai_summary` and `enable_change_groups` and `show_ai_notes` all off, fetch a fresh PR and confirm only file content + classification runs (no AI calls in the parallel block)
- [ ] Manual: with `enable_checks_status` off, verify the 30s polling stops and no blocking modal appears even on a red-CI PR
- [ ] Manual: with `enable_comments_view` off, the Comments sidebar tab disappears and `fetch_review_comments` is never called

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)