### PR TITLE
feat(cli): syntax-highlighted diffs with AI-highlight annotations [#79 Level 1]

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -570,6 +570,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1354,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2586,6 +2606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,6 +2683,7 @@ dependencies = [
  "clap",
  "marrow-core",
  "serde_json",
+ "syntect",
  "tokio",
 ]
 
@@ -4693,6 +4720,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6641,6 +6689,15 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/app/src-tauri/crates/cli/Cargo.toml
+++ b/app/src-tauri/crates/cli/Cargo.toml
@@ -14,3 +14,6 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1"
 chrono = "0.4"
+# fancy-regex backend = pure Rust, no oniguruma/C dependency (keeps the CLI
+# easy to cross-compile and `cargo install`).
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -5,14 +5,28 @@
 //! `fetch.rs`, `config.rs` — so it proves how much of the app is already
 //! frontend-agnostic. No webview, no Tauri runtime: just the core + stdout.
 
+use std::collections::HashMap;
 use std::io::{IsTerminal, Write};
+use std::sync::OnceLock;
 
-use clap::{Parser, Subcommand};
+use clap::{Parser, Subcommand, ValueEnum};
+use syntect::easy::HighlightLines;
+use syntect::highlighting::{Theme, ThemeSet};
+use syntect::parsing::{SyntaxReference, SyntaxSet};
+use syntect::util::as_24_bit_terminal_escaped;
 
 use marrow_core::config::{load_settings, resolve_github_token};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
-use marrow_core::types::{FetchProgress, FetchStatus, ReviewManifest, ReviewThread};
+use marrow_core::types::{FetchProgress, FetchStatus, FileDiff, Highlight, ReviewManifest, ReviewThread};
+
+/// When to colorize output. `auto` = colorize only when stdout is a terminal.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum ColorWhen {
+    Auto,
+    Always,
+    Never,
+}
 
 #[derive(Parser)]
 #[command(
@@ -28,6 +42,10 @@ struct Cli {
     /// approve, …). Required when stdin is not a terminal.
     #[arg(short = 'y', long, global = true)]
     yes: bool,
+
+    /// When to colorize output: auto (TTY only), always, or never.
+    #[arg(long, value_enum, default_value_t = ColorWhen::Auto, global = true)]
+    color: ColorWhen,
 }
 
 #[derive(Subcommand)]
@@ -138,6 +156,12 @@ enum Command {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let use_color = match cli.color {
+        ColorWhen::Always => true,
+        ColorWhen::Never => false,
+        ColorWhen::Auto => std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none(),
+    };
+    let _ = COLOR.set(use_color);
     if let Err(e) = run(cli.command, cli.yes).await {
         eprintln!("{}", paint(&format!("error: {e}"), RED));
         std::process::exit(1);
@@ -358,40 +382,172 @@ fn print_manifest(m: &ReviewManifest, show_diffs: bool) {
                 println!("        {}", paint(&line, DIM));
             }
         }
-        for h in &f.highlights {
-            let sev = match h.severity.as_str() {
-                "high" | "warning" => RED,
-                "medium" => YELLOW,
-                _ => CYAN,
-            };
-            let loc = if h.start_line == h.end_line {
-                format!("L{}", h.start_line)
-            } else {
-                format!("L{}-{}", h.start_line, h.end_line)
-            };
-            println!("        {} {} {}", paint("▸", sev), paint(&loc, sev), h.comment);
+        // When showing diffs, highlights are rendered inline in the diff, so
+        // skip the summary list to avoid duplication.
+        if !show_diffs {
+            for h in &f.highlights {
+                let sev = severity_color(&h.severity);
+                let loc = if h.start_line == h.end_line {
+                    format!("L{}", h.start_line)
+                } else {
+                    format!("L{}-{}", h.start_line, h.end_line)
+                };
+                println!("        {} {} {}", paint("▸", sev), paint(&loc, sev), h.comment);
+            }
         }
         if show_diffs && !f.unified_diff.is_empty() {
             println!();
-            print_diff(&f.unified_diff);
+            render_file_diff(f);
             println!();
         }
     }
     println!();
 }
 
-fn print_diff(diff: &str) {
-    for line in diff.lines() {
-        let colored = if line.starts_with("@@") {
-            paint(line, CYAN)
-        } else if line.starts_with('+') {
-            paint(line, GREEN)
-        } else if line.starts_with('-') {
-            paint(line, RED)
-        } else {
-            line.to_string()
+// ── diff rendering (syntect highlighting + AI-highlight annotations) ─────────
+
+fn severity_color(sev: &str) -> &'static str {
+    match sev {
+        "high" | "warning" => RED,
+        "medium" => YELLOW,
+        _ => CYAN,
+    }
+}
+
+fn sev_rank(c: &str) -> u8 {
+    match c {
+        RED => 3,
+        YELLOW => 2,
+        _ => 1,
+    }
+}
+
+fn highlighter() -> &'static (SyntaxSet, Theme) {
+    static HL: OnceLock<(SyntaxSet, Theme)> = OnceLock::new();
+    HL.get_or_init(|| {
+        let ps = SyntaxSet::load_defaults_newlines();
+        let ts = ThemeSet::load_defaults();
+        let theme = ts.themes["base16-ocean.dark"].clone();
+        (ps, theme)
+    })
+}
+
+fn syntax_for<'a>(ps: &'a SyntaxSet, path: &str) -> &'a SyntaxReference {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("");
+    ps.find_syntax_by_extension(ext)
+        .unwrap_or_else(|| ps.find_syntax_plain_text())
+}
+
+/// Syntax-highlight one line of code to 24-bit ANSI (fg only). Each line is
+/// highlighted independently — good enough for a diff view, where lines arrive
+/// out of file order (a perfect render is Level 2 / a `delta`-style rebuild).
+fn highlight_line(code: &str, syntax: &SyntaxReference) -> String {
+    let (ps, theme) = highlighter();
+    let mut h = HighlightLines::new(syntax, theme);
+    match h.highlight_line(code, ps) {
+        Ok(ranges) => {
+            let mut out = as_24_bit_terminal_escaped(&ranges, false);
+            out.push_str("\x1b[0m");
+            out
+        }
+        Err(_) => code.to_string(),
+    }
+}
+
+/// Parse the new-side start line from a hunk header: `@@ -a,b +c,d @@` -> c.
+fn hunk_new_start(header: &str) -> Option<u64> {
+    header
+        .split_whitespace()
+        .find(|t| t.starts_with('+'))
+        .and_then(|t| t.trim_start_matches('+').split(',').next())
+        .and_then(|n| n.parse::<u64>().ok())
+}
+
+/// Render a file's unified diff with syntax highlighting and inline AI-highlight
+/// annotations: a severity gutter bar on flagged lines plus the comment printed
+/// above its start line. Falls back to plain text when color is disabled.
+fn render_file_diff(f: &FileDiff) {
+    let indent = "  ";
+    let color = color_enabled();
+
+    // Map new-side line numbers to the highlights that start there, and the set
+    // of new-side lines covered by any highlight (for the gutter bar).
+    let mut starts: HashMap<u64, Vec<&Highlight>> = HashMap::new();
+    let mut covered: HashMap<u64, &'static str> = HashMap::new();
+    for h in &f.highlights {
+        starts.entry(h.start_line).or_default().push(h);
+        let sev = severity_color(&h.severity);
+        for ln in h.start_line..=h.end_line {
+            covered
+                .entry(ln)
+                .and_modify(|c| {
+                    if sev_rank(sev) > sev_rank(c) {
+                        *c = sev;
+                    }
+                })
+                .or_insert(sev);
+        }
+    }
+
+    let (ps, _) = highlighter();
+    let syntax = syntax_for(ps, &f.path);
+
+    let mut new_ln: Option<u64> = None;
+    for line in f.unified_diff.lines() {
+        if line.starts_with("@@") {
+            new_ln = hunk_new_start(line);
+            println!("{indent}{}", paint(line, CYAN));
+            continue;
+        }
+
+        let (marker, rest, on_new_side, marker_color) = match line.chars().next() {
+            Some('+') => ('+', &line[1..], true, GREEN),
+            Some('-') => ('-', &line[1..], false, RED),
+            Some(' ') => (' ', &line[1..], true, DIM),
+            _ => {
+                // "\ No newline at end of file", stray blank lines, etc.
+                println!("{indent} {}", paint(line, DIM));
+                continue;
+            }
         };
-        println!("        {colored}");
+
+        let cur_new = if on_new_side { new_ln } else { None };
+
+        // Annotation: print the comment(s) just above the line they start on.
+        if let Some(ln) = cur_new {
+            if let Some(hs) = starts.get(&ln) {
+                for h in hs {
+                    let sev = severity_color(&h.severity);
+                    let loc = if h.start_line == h.end_line {
+                        format!("L{}", h.start_line)
+                    } else {
+                        format!("L{}-{}", h.start_line, h.end_line)
+                    };
+                    println!("{indent}{} {} {}", paint("▸", sev), paint(&loc, sev), h.comment);
+                }
+            }
+        }
+
+        let gutter = match cur_new.and_then(|ln| covered.get(&ln)) {
+            Some(sev) => paint("▍", sev),
+            None => " ".to_string(),
+        };
+        let marker_str = if color {
+            paint(&marker.to_string(), marker_color)
+        } else {
+            marker.to_string()
+        };
+        let code = if color { highlight_line(rest, syntax) } else { rest.to_string() };
+        println!("{indent}{gutter}{marker_str}{code}");
+
+        if on_new_side {
+            if let Some(n) = new_ln.as_mut() {
+                *n += 1;
+            }
+        }
     }
 }
 
@@ -549,8 +705,10 @@ const GREEN: &str = "32";
 const YELLOW: &str = "33";
 const CYAN: &str = "36";
 
+static COLOR: OnceLock<bool> = OnceLock::new();
+
 fn color_enabled() -> bool {
-    std::io::stdout().is_terminal() && std::env::var_os("NO_COLOR").is_none()
+    *COLOR.get().unwrap_or(&false)
 }
 
 fn paint(s: &str, code: &str) -> String {


### PR DESCRIPTION
Implements **Level 1** of #79 — the cheap, high-value, no-TUI diff viewer that lands cleanly in the new `cli`/`core` crates (thanks to #80).

## What changed
`marrow review <pr> --diffs` goes from a flat colored dump to a real reading experience:

- **Syntax highlighting** via `syntect` (fancy-regex backend — pure Rust, **no oniguruma/C dependency**, so the CLI stays easy to cross-compile and `cargo install`).
- **AI highlights inline** — the comment prints directly above its start line, and a severity-colored gutter bar (`▍`) marks every covered line. Line placement is mapped from new-side line numbers parsed off each `@@` hunk header.
- The per-file risk badge is kept; the summary highlight list is **suppressed when `--diffs` is set** (shown inline instead) to avoid duplication.
- New global **`--color auto|always|never`** flag. `auto` colorizes only on a TTY; plain mode still shows the `▸`/`▍` structure so piped output stays informative.

## Example (`--color never`)
```
  HIGH pkg/cmd/attestation/verify/verify.go  +1 -0
  @@ -127,6 +127,7 @@ func NewVerifyCmd(...)
    	// general flags
    	verifyCmd.Flags().StringVarP(&opts.BundlePath, "bundle", ...)
  ▸ L130 --bundle flag now skips auth check; confirm verify can operate offline when bundle is provided.
  ▍+	cmdutil.DisableAuthCheckFlag(verifyCmd.Flags().Lookup("bundle"))
```

## Verification
- ✅ `--color always` emits 24-bit ANSI (syntect active); `auto` strips all ANSI when piped (0 escapes); `never` is plain.
- ✅ Annotations land on the correct lines (new-side numbering validated against the hunk header).
- ✅ Full workspace builds.

## Notes / follow-ups (not in this PR)
- Per-line highlighting is stateless (each diff line highlighted independently). Good enough here; a `delta`-style reconstructed render is Level 2.
- Pager handoff and a raw `marrow diff` mode (for `| nvim`) remain separate items under #79.

Related: #76, #78, #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)