### PR TITLE
feat(cli): interactive TUI skeleton [#83 Milestone 1]

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +758,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +903,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1036,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,8 +1132,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1091,12 +1161,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1965,6 +2059,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2382,12 +2478,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2430,6 +2548,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2613,6 +2740,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2637,6 +2770,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -2682,6 +2824,7 @@ dependencies = [
  "chrono",
  "clap",
  "marrow-core",
+ "ratatui",
  "serde_json",
  "syntect",
  "tokio",
@@ -2766,6 +2909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3193,6 +3337,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3747,6 +3897,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +4147,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3983,7 +4167,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4384,7 +4568,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4489,6 +4673,17 @@ checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
 ]
 
 [[package]]
@@ -4606,6 +4801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,6 +4860,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -5165,7 +5388,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5628,6 +5851,29 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -6681,7 +6927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/app/src-tauri/crates/cli/Cargo.toml
+++ b/app/src-tauri/crates/cli/Cargo.toml
@@ -17,3 +17,5 @@ chrono = "0.4"
 # fancy-regex backend = pure Rust, no oniguruma/C dependency (keeps the CLI
 # easy to cross-compile and `cargo install`).
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
+# Interactive TUI (re-exports crossterm, so no separate crossterm dep).
+ratatui = "0.29"

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -21,6 +21,8 @@ use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
 use marrow_core::types::{FetchProgress, FetchStatus, FileDiff, Highlight, ReviewManifest, ReviewThread};
 
+mod tui;
+
 /// When to colorize output. `auto` = colorize only when stdout is a terminal.
 #[derive(Copy, Clone, Debug, ValueEnum)]
 enum ColorWhen {
@@ -61,6 +63,9 @@ enum Command {
         /// Also print the unified diff for each file
         #[arg(long)]
         diffs: bool,
+        /// Force the printed report instead of the interactive TUI
+        #[arg(long)]
+        no_tui: bool,
     },
     /// Print the PR's raw unified diff (relevance-ordered, no chrome) — pipe into nvim/delta
     Diff {
@@ -181,7 +186,7 @@ fn github_client() -> GithubClient {
 
 async fn run(command: Command, yes: bool) -> Result<(), String> {
     match command {
-        Command::Review { pr, json, diffs } => review(&pr, json, diffs).await,
+        Command::Review { pr, json, diffs, no_tui } => review(&pr, json, diffs, no_tui).await,
         Command::Diff { pr } => diff_cmd(&pr).await,
         Command::Requests { days, json } => requests(days, json).await,
         Command::Comments { pr, unresolved, json } => comments(&pr, unresolved, json).await,
@@ -324,13 +329,19 @@ async fn submit(pr: &str, event: &str, body: &str) -> Result<(), String> {
 
 // ── review ──────────────────────────────────────────────────────────────────
 
-async fn review(pr: &str, json: bool, show_diffs: bool) -> Result<(), String> {
+async fn review(pr: &str, json: bool, show_diffs: bool, no_tui: bool) -> Result<(), String> {
     let settings = load_settings();
     let manifest = fetch_pr_impl(pr, &settings, &fetch_progress_to_stderr).await?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?);
         return Ok(());
+    }
+
+    // Interactive default: open the TUI on a terminal unless raw diffs were
+    // requested or it was opted out. Piped/non-TTY falls back to the report.
+    if !show_diffs && !no_tui && std::io::stdout().is_terminal() {
+        return tui::run(&manifest).map_err(|e| e.to_string());
     }
 
     let mut out = String::new();

--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -1,0 +1,310 @@
+//! Interactive TUI — Level 2, M1 skeleton (read-only review viewer).
+//!
+//! Read-only ⇒ the whole `ReviewManifest` is preloaded before we enter the
+//! loop, so the event loop never needs to await. M1 covers: alt-screen in/out,
+//! a relevance-ordered file sidebar, the selected file's diff (basic +/-
+//! coloring), j/k scrolling, ]/[ file switching, and quit. Syntax highlighting
+//! + AI annotations land in M2.
+
+use std::io;
+
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::{DefaultTerminal, Frame};
+
+use marrow_core::types::{FileDiff, ReviewManifest};
+
+/// Enter the alternate screen, run the viewer, and always restore the terminal.
+pub fn run(manifest: &ReviewManifest) -> io::Result<()> {
+    let mut terminal = ratatui::init();
+    let mut app = App::new(manifest);
+    let res = app.run(&mut terminal);
+    ratatui::restore();
+    res
+}
+
+struct App<'a> {
+    manifest: &'a ReviewManifest,
+    files: Vec<&'a FileDiff>,
+    list_state: ListState,
+    scroll: u16,
+}
+
+impl<'a> App<'a> {
+    fn new(manifest: &'a ReviewManifest) -> Self {
+        // Relevance order: high risk first (matches `marrow diff`).
+        let mut files: Vec<&FileDiff> = manifest.files.iter().collect();
+        files.sort_by_key(|f| risk_rank(&f.risk_level));
+        let mut list_state = ListState::default();
+        if !files.is_empty() {
+            list_state.select(Some(0));
+        }
+        Self { manifest, files, list_state, scroll: 0 }
+    }
+
+    fn selected(&self) -> Option<&FileDiff> {
+        self.list_state.selected().and_then(|i| self.files.get(i).copied())
+    }
+
+    fn diff_line_count(&self) -> u16 {
+        self.selected()
+            .map(|f| f.unified_diff.lines().count().min(u16::MAX as usize) as u16)
+            .unwrap_or(0)
+    }
+
+    fn next_file(&mut self) {
+        if self.files.is_empty() {
+            return;
+        }
+        let i = self.list_state.selected().unwrap_or(0);
+        self.list_state.select(Some((i + 1).min(self.files.len() - 1)));
+        self.scroll = 0;
+    }
+
+    fn prev_file(&mut self) {
+        let i = self.list_state.selected().unwrap_or(0);
+        self.list_state.select(Some(i.saturating_sub(1)));
+        self.scroll = 0;
+    }
+
+    fn scroll_down(&mut self, n: u16) {
+        let max = self.diff_line_count().saturating_sub(1);
+        self.scroll = (self.scroll + n).min(max);
+    }
+
+    fn scroll_up(&mut self, n: u16) {
+        self.scroll = self.scroll.saturating_sub(n);
+    }
+
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
+        loop {
+            terminal.draw(|f| self.ui(f))?;
+            // Blocking read — also delivers resize events, which just redraw.
+            let Event::Key(key) = event::read()? else {
+                continue;
+            };
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match key.code {
+                KeyCode::Char('q') | KeyCode::Esc => break,
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_down(1),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_up(1),
+                KeyCode::Char('g') => self.scroll = 0,
+                KeyCode::Char('G') => self.scroll = self.diff_line_count().saturating_sub(1),
+                KeyCode::Char(']') | KeyCode::Tab => self.next_file(),
+                KeyCode::Char('[') | KeyCode::BackTab => self.prev_file(),
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn ui(&mut self, f: &mut Frame) {
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1), Constraint::Length(1)])
+            .split(f.area());
+
+        let header = Line::from(vec![
+            Span::styled(
+                " marrow ",
+                Style::default().fg(Color::Black).bg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" {} #{}", self.manifest.pr_title, self.manifest.pr_number)),
+        ]);
+        f.render_widget(Paragraph::new(header), rows[0]);
+
+        let body = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Length(40), Constraint::Min(1)])
+            .split(rows[1]);
+
+        self.render_sidebar(f, body[0]);
+        self.render_diff(f, body[1]);
+
+        let footer = Paragraph::new(" j/k scroll · g/G top/bottom · ]/[ file · q quit ")
+            .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(footer, rows[2]);
+    }
+
+    fn render_sidebar(&mut self, f: &mut Frame, area: Rect) {
+        let items: Vec<ListItem> = self
+            .files
+            .iter()
+            .map(|file| {
+                let (label, color) = match file.risk_level.as_str() {
+                    "high" => ("HIGH", Color::Red),
+                    "low" => ("low ", Color::Green),
+                    _ => ("med ", Color::Yellow),
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(label, Style::default().fg(color).add_modifier(Modifier::BOLD)),
+                    Span::raw(" "),
+                    Span::raw(short_path(&file.path)),
+                ]))
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(Block::default().borders(Borders::RIGHT).title("Files"))
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .highlight_symbol("›");
+        f.render_stateful_widget(list, area, &mut self.list_state);
+    }
+
+    fn render_diff(&self, f: &mut Frame, area: Rect) {
+        let title = self
+            .selected()
+            .map(|file| format!(" {}  +{} -{} ", file.path, file.additions, file.deletions))
+            .unwrap_or_else(|| " (no file) ".to_string());
+
+        let lines: Vec<Line> = match self.selected() {
+            Some(file) if !file.unified_diff.is_empty() => {
+                file.unified_diff.lines().map(diff_line).collect()
+            }
+            Some(_) => vec![Line::from(Span::styled(
+                "(no diff)",
+                Style::default().fg(Color::DarkGray),
+            ))],
+            None => Vec::new(),
+        };
+
+        let para = Paragraph::new(lines)
+            .block(Block::default().title(title))
+            .scroll((self.scroll, 0));
+        f.render_widget(para, area);
+    }
+}
+
+/// Basic +/- diff coloring for M1 (syntect highlighting comes in M2).
+fn diff_line(line: &str) -> Line<'static> {
+    let style = if line.starts_with("@@") {
+        Style::default().fg(Color::Cyan)
+    } else if line.starts_with('+') {
+        Style::default().fg(Color::Green)
+    } else if line.starts_with('-') {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default()
+    };
+    Line::from(Span::styled(line.to_string(), style))
+}
+
+fn risk_rank(risk: &str) -> u8 {
+    match risk {
+        "high" => 0,
+        "low" => 2,
+        _ => 1,
+    }
+}
+
+/// Truncate a long path from the left for the narrow sidebar (char-safe).
+fn short_path(path: &str) -> String {
+    const MAX: usize = 34;
+    let chars: Vec<char> = path.chars().collect();
+    if chars.len() <= MAX {
+        return path.to_string();
+    }
+    let tail: String = chars[chars.len() - (MAX - 1)..].iter().collect();
+    format!("…{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    fn file(path: &str, risk: &str, diff: &str) -> FileDiff {
+        FileDiff {
+            path: path.to_string(),
+            classification: "RELEVANT".to_string(),
+            reason: String::new(),
+            category: "Business Logic".to_string(),
+            risk_level: risk.to_string(),
+            diff_type: "modified".to_string(),
+            base_content: String::new(),
+            head_content: String::new(),
+            unified_diff: diff.to_string(),
+            additions: 1,
+            deletions: 0,
+            highlights: Vec::new(),
+            hunk_scores: Vec::new(),
+            diff_hash: String::new(),
+        }
+    }
+
+    fn manifest() -> ReviewManifest {
+        ReviewManifest {
+            pr_title: "proof of concept".to_string(),
+            pr_url: "https://github.com/cli/cli/pull/9000".to_string(),
+            pr_number: 9000,
+            base_ref: "trunk".to_string(),
+            head_ref: "feature".to_string(),
+            base_sha: "aaa".to_string(),
+            head_sha: "bbb".to_string(),
+            summary: String::new(),
+            change_groups: Vec::new(),
+            files: vec![
+                file("pkg/low.go", "low", "@@ -1,1 +1,1 @@\n-a\n+b\n"),
+                file("pkg/high.go", "high", "@@ -1,1 +1,2 @@\n a\n+b\n"),
+            ],
+        }
+    }
+
+    fn render_to_string(app: &mut App, w: u16, h: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal.draw(|f| app.ui(f)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut s = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                s.push_str(buf[(x, y)].symbol());
+            }
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn high_risk_sorts_first() {
+        let m = manifest();
+        let app = App::new(&m);
+        assert_eq!(app.files[0].path, "pkg/high.go");
+        assert_eq!(app.files[1].path, "pkg/low.go");
+    }
+
+    #[test]
+    fn renders_header_sidebar_and_diff() {
+        let m = manifest();
+        let mut app = App::new(&m);
+        let out = render_to_string(&mut app, 100, 20);
+        assert!(out.contains("marrow"), "header missing");
+        assert!(out.contains("HIGH"), "risk badge missing");
+        assert!(out.contains("high.go"), "selected file path missing");
+        assert!(out.contains("@@ -1,1 +1,2 @@"), "diff hunk missing");
+        assert!(out.contains("q quit"), "footer missing");
+    }
+
+    #[test]
+    fn scroll_and_file_switch_are_clamped() {
+        let m = manifest();
+        let mut app = App::new(&m);
+        // Can't scroll above the top.
+        app.scroll_up(5);
+        assert_eq!(app.scroll, 0);
+        // Switching files resets scroll and clamps at the ends.
+        app.scroll_down(2);
+        app.next_file();
+        assert_eq!(app.scroll, 0);
+        app.next_file(); // already last → stays last
+        assert_eq!(app.list_state.selected(), Some(1));
+        app.prev_file();
+        app.prev_file(); // already first → stays first
+        assert_eq!(app.list_state.selected(), Some(0));
+    }
+}


### PR DESCRIPTION
Milestone 1 of the Level 2 TUI (#83) — a read-only `ratatui` review viewer skeleton.

## Architecture
Read-only ⇒ the `ReviewManifest` is preloaded (the async fetch runs first) and the **synchronous** event loop never awaits. Lives in a new `tui` module in `crates/cli`; adds `ratatui` (which re-exports `crossterm`, so no separate dep).

## What's in M1
- **Two-pane layout**: a relevance-ordered file sidebar (risk badge + path, high-risk first) and a scrollable diff pane for the selected file, with a header and a keybinding footer.
- **Keys**: `j/k` scroll · `g/G` top/bottom · `]/[` or Tab switch file · `q`/Esc quit. Resize-safe (a resize is just another redraw).
- **Diff coloring** is basic +/-/@@ for now; **syntect highlighting + AI annotations are M2**.
- **`marrow review` opens the TUI by default on a terminal.** `--no-tui`, piping (non-TTY), `--json`, and `--diffs` all fall back to the printed report (the agreed behavior matrix).

## Tests (headless — no TTY needed)
Using ratatui's `TestBackend`:
- relevance ordering (high sorts before low)
- a full-frame render assertion (buffer contains the header, `HIGH` badge, file path, hunk, and footer)
- scroll/file-switch clamping

## Verification
- ✅ `cargo test -p marrow` — 3 tests pass
- ✅ `--no-tui` in help; non-TTY falls back to the printed report (no terminal garbage)
- ✅ full workspace builds

## Note on manual testing
The interactive loop can't be driven in CI/headless, so **please run it in a real terminal**:
```
cargo build -p marrow
./target/debug/marrow review <pr>        # opens the TUI
# j/k to scroll, ]/[ to switch files, q to quit
./target/debug/marrow review <pr> --no-tui   # printed report
```

Next: M2 (rich diff pane — reuse the Level 1 syntect + AI-annotation render). Parent: #83. Related: #79, #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)