### PR TITLE
feat(cli): show review comments inline in the TUI diff [#93 part 1]

### DIFF
--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -88,6 +88,8 @@ struct App<'a> {
     threads: Option<Vec<ReviewThread>>,
     thread_at_row: Vec<Option<usize>>,
     pending_thread: Option<usize>,
+    /// Whether we've tried the one-time startup thread load (for inline comments).
+    threads_autoloaded: bool,
     /// Last action result, shown in the header.
     status: Option<String>,
 }
@@ -118,6 +120,7 @@ impl<'a> App<'a> {
             threads: None,
             thread_at_row: Vec::new(),
             pending_thread: None,
+            threads_autoloaded: false,
             status: None,
         };
         app.rebuild_rows();
@@ -317,7 +320,15 @@ impl<'a> App<'a> {
             if file.unified_diff.is_empty() {
                 Rendered::message("(no diff)")
             } else {
-                diff_lines_for(file)
+                // Open review threads on this file, shown inline in the diff.
+                let file_threads: Vec<&ReviewThread> = self
+                    .threads
+                    .as_ref()
+                    .map(|ts| {
+                        ts.iter().filter(|t| t.path == file.path && !t.is_resolved).collect()
+                    })
+                    .unwrap_or_default();
+                diff_lines_for(file, &file_threads)
             }
         } else {
             Rendered::default()
@@ -391,6 +402,14 @@ impl<'a> App<'a> {
     fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
         loop {
             terminal.draw(|f| self.ui(f))?;
+            // After the first frame, load review threads once so they appear
+            // inline in the diff without the user pressing T. Redraw afterwards.
+            if !self.threads_autoloaded {
+                self.threads_autoloaded = true;
+                self.ensure_threads_loaded();
+                self.cache_idx = None;
+                continue;
+            }
             // Blocking read — also delivers resize events, which just redraw.
             let Event::Key(key) = event::read()? else {
                 continue;
@@ -955,15 +974,22 @@ impl Rendered {
 }
 
 /// Render a file's diff as styled ratatui lines: syntect syntax highlighting on
-/// the code, AI-highlight comments inline (`▸` above the line they start on),
-/// and a severity gutter bar (`▍`) on covered lines. Also records the row
-/// indices of hunk headers and findings for jump navigation. Reuses the Level 1
-/// syntect + hunk-parsing helpers from the CLI module.
-fn diff_lines_for(file: &FileDiff) -> Rendered {
+/// the code, AI-highlight comments inline (`▸` above the line they start on), a
+/// severity gutter bar (`▍`) on covered lines, and open review-thread comments
+/// inline (`💬` below the line). Also records the row indices of hunk headers
+/// and findings for jump navigation.
+fn diff_lines_for(file: &FileDiff, threads: &[&ReviewThread]) -> Rendered {
     // new-side line → highlights starting there, and lines covered by any (for
     // the gutter bar, keeping the highest severity).
     let mut starts: HashMap<u64, Vec<&Highlight>> = HashMap::new();
     let mut covered: HashMap<u64, Color> = HashMap::new();
+    // new-side line → review threads anchored there (shown inline).
+    let mut threads_at: HashMap<u64, Vec<&ReviewThread>> = HashMap::new();
+    for t in threads {
+        if let Some(l) = t.line {
+            threads_at.entry(l).or_default().push(t);
+        }
+    }
     for h in &file.highlights {
         starts.entry(h.start_line).or_default().push(h);
         let c = sev_color(&h.severity);
@@ -1050,6 +1076,33 @@ fn diff_lines_for(file: &FileDiff) -> Rendered {
             _ => new_ln.map(|line| CommentTarget { line, side: "RIGHT" }),
         };
         targets.push(target);
+
+        // Open review-thread comments, shown inline below the line they're on.
+        if let Some(ln) = cur_new {
+            if let Some(ths) = threads_at.get(&ln) {
+                for th in ths {
+                    out.push(Line::from(Span::styled(
+                        "  💬 thread".to_string(),
+                        Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                    )));
+                    targets.push(None);
+                    for c in &th.comments {
+                        out.push(Line::from(Span::styled(
+                            format!("    @{}", c.author.login),
+                            Style::default().fg(Color::Cyan),
+                        )));
+                        targets.push(None);
+                        for l in crate::wrap(&c.body, 72) {
+                            out.push(Line::from(Span::styled(
+                                format!("      {l}"),
+                                Style::default().fg(Color::Gray),
+                            )));
+                            targets.push(None);
+                        }
+                    }
+                }
+            }
+        }
 
         // Advance the line counters: '+' new only, '-' old only, ' ' both.
         match marker {
@@ -1549,5 +1602,28 @@ mod tests {
         app.on_key(KeyCode::Enter);
         assert!(matches!(app.mode, Mode::ReplyInput));
         assert!(app.status.as_deref().unwrap_or("").contains("needs a message"));
+    }
+
+    #[test]
+    fn open_thread_renders_inline_in_diff() {
+        let m = manifest(); // default selects pkg/high.go (lines L1 ctx, L2 added)
+        let mut app = App::new(&m);
+        app.threads = Some(vec![thread(false, "pkg/high.go", 2, "needs a guard here")]);
+        app.cache_idx = None;
+        app.sync_cache();
+        let text = lines_text(&app);
+        assert!(text.contains('💬'), "inline comment marker");
+        assert!(text.contains("@alice"), "author");
+        assert!(text.contains("needs a guard here"), "comment body");
+    }
+
+    #[test]
+    fn resolved_thread_not_shown_inline() {
+        let m = manifest();
+        let mut app = App::new(&m);
+        app.threads = Some(vec![thread(true, "pkg/high.go", 2, "already handled")]);
+        app.cache_idx = None;
+        app.sync_cache();
+        assert!(!lines_text(&app).contains("already handled"), "resolved threads stay out of the diff");
     }
 }

--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -973,6 +973,9 @@ impl Rendered {
     }
 }
 
+/// Background tint for inline review-comment blocks (a muted dark purple).
+const COMMENT_BG: Color = Color::Rgb(52, 42, 75);
+
 /// Render a file's diff as styled ratatui lines: syntect syntax highlighting on
 /// the code, AI-highlight comments inline (`▸` above the line they start on), a
 /// severity gutter bar (`▍`) on covered lines, and open review-thread comments
@@ -1077,27 +1080,42 @@ fn diff_lines_for(file: &FileDiff, threads: &[&ReviewThread]) -> Rendered {
         };
         targets.push(target);
 
-        // Open review-thread comments, shown inline below the line they're on.
+        // Open review-thread comments, shown inline below the line they're on,
+        // on a tinted background with a magenta left bar so they stand out.
         if let Some(ln) = cur_new {
             if let Some(ths) = threads_at.get(&ln) {
-                for th in ths {
-                    out.push(Line::from(Span::styled(
-                        "  💬 thread".to_string(),
-                        Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
-                    )));
+                let bg = Style::default().bg(COMMENT_BG);
+                // Trailing pad so the line's background fills the row into a band
+                // (a Line's bg only covers the cells it occupies).
+                let bar = || Span::styled("▌ ", Style::default().fg(Color::Magenta));
+                let pad = || Span::raw(" ".repeat(160));
+                let mut push = |spans: Vec<Span<'static>>| {
+                    let mut s = spans;
+                    s.push(pad());
+                    out.push(Line::from(s).style(bg));
                     targets.push(None);
+                };
+                for th in ths {
+                    push(vec![
+                        bar(),
+                        Span::styled(
+                            "💬 thread",
+                            Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                        ),
+                    ]);
                     for c in &th.comments {
-                        out.push(Line::from(Span::styled(
-                            format!("    @{}", c.author.login),
-                            Style::default().fg(Color::Cyan),
-                        )));
-                        targets.push(None);
+                        push(vec![
+                            bar(),
+                            Span::styled(
+                                format!("@{}", c.author.login),
+                                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                            ),
+                        ]);
                         for l in crate::wrap(&c.body, 72) {
-                            out.push(Line::from(Span::styled(
-                                format!("      {l}"),
-                                Style::default().fg(Color::Gray),
-                            )));
-                            targets.push(None);
+                            push(vec![
+                                bar(),
+                                Span::styled(format!("  {l}"), Style::default().fg(Color::White)),
+                            ]);
                         }
                     }
                 }


### PR DESCRIPTION
Part 1 of #93 — human review-thread comments now render **inline in the diff**, not only in the separate Threads view.

## What's in this PR
- **Auto-load**: review threads load once after the first frame (no need to press `T`), so inline comments appear on their own.
- **Inline rendering**: for the current file, **open** threads matching its path render below the line they're on — `💬` + `@author` + wrapped body — anchored via the same new-side line mapping used for AI annotations.
- **Resolved threads stay out** of the diff (they remain in the Threads view), keeping the inline view focused on actionable discussion.
- `diff_lines_for` now takes the file's threads.

So you see AI notes (`▸`) *and* human comments (`💬`) in context as you read the diff.

## Tests (headless)
- open thread renders inline (`💬` + `@alice` + body)
- resolved thread does **not** render inline
- all existing tests pass (**18 total**)

## Verification
- ✅ `cargo test -p marrow` — 18 pass
- ✅ full workspace builds
- ⚠️ The auto-load network path can't run headlessly; inline rendering is tested via injected threads. Worth a quick manual run on a PR with review comments:
```
git checkout feat/tui-inline-comments && cd app/src-tauri && cargo build -p marrow
./target/debug/marrow review <pr-with-comments>   # comments appear inline in the diff
```

## Next (#93 part 2)
Multi-line comments in the TUI via a `v` range/visual selection → `c`. The core already supports ranges (`start_line`/`start_side`); only the TUI's `c` is single-line. Separate PR.

Parent: #93. Related: #92 (threads view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)