### PR TITLE
feat(cli): bulk navigation in the TUI (half-page, page, home/end)

### DIFF
--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -81,8 +81,12 @@ struct App<'a> {
     /// The pending review verb while typing its message (ReviewInput mode).
     review_event: &'static str,
     review_input: String,
-    /// The line being commented on while in CommentInput mode.
+    /// The line (range end) being commented on while in CommentInput mode, and
+    /// the range start for a multi-line comment (None = single line).
     pending_comment: Option<CommentTarget>,
+    pending_comment_start: Option<CommentTarget>,
+    /// Anchor row of an active line selection (`v`); the range is anchor..cursor.
+    selection_anchor: Option<u16>,
     /// Review threads (None = not loaded yet), the per-row thread index for the
     /// threads view, and the thread being replied to (ReplyInput mode).
     threads: Option<Vec<ReviewThread>>,
@@ -117,6 +121,8 @@ impl<'a> App<'a> {
             review_event: "",
             review_input: String::new(),
             pending_comment: None,
+            pending_comment_start: None,
+            selection_anchor: None,
             threads: None,
             thread_at_row: Vec::new(),
             pending_thread: None,
@@ -246,6 +252,7 @@ impl<'a> App<'a> {
             if Self::is_selectable(&self.rows[i]) {
                 self.list_state.select(Some(i));
                 self.cursor = 0;
+                self.selection_anchor = None;
                 return;
             }
         }
@@ -428,7 +435,19 @@ impl<'a> App<'a> {
     fn on_key(&mut self, code: KeyCode) -> bool {
         match self.mode {
             Mode::Normal => match code {
-                KeyCode::Char('q') | KeyCode::Esc => return true,
+                KeyCode::Char('q') => return true,
+                KeyCode::Esc => {
+                    // Esc cancels an active selection; otherwise it quits.
+                    if self.selection_anchor.take().is_none() {
+                        return true;
+                    }
+                }
+                KeyCode::Char('v') => {
+                    if matches!(self.current_row(), Some(Row::File(_))) {
+                        self.selection_anchor =
+                            if self.selection_anchor.is_some() { None } else { Some(self.cursor) };
+                    }
+                }
                 KeyCode::Char('j') | KeyCode::Down => self.cursor_down(1),
                 KeyCode::Char('k') | KeyCode::Up => self.cursor_up(1),
                 KeyCode::Char('g') => self.cursor = 0,
@@ -514,15 +533,43 @@ impl<'a> App<'a> {
         if !matches!(self.current_row(), Some(Row::File(_))) {
             return;
         }
-        match self.targets.get(self.cursor as usize).copied().flatten() {
-            Some(target) => {
-                self.pending_comment = Some(target);
-                self.review_input.clear();
-                self.status = None;
-                self.mode = Mode::CommentInput;
+        let cursor_t = self.targets.get(self.cursor as usize).copied().flatten();
+        // (end, start) — start is the lower line of a same-side selection.
+        let (end, start) = if let Some(anchor) = self.selection_anchor {
+            let anchor_t = self.targets.get(anchor as usize).copied().flatten();
+            match (anchor_t, cursor_t) {
+                (Some(a), Some(b)) if a.side == b.side => {
+                    if a.line <= b.line {
+                        (b, Some(a))
+                    } else {
+                        (a, Some(b))
+                    }
+                }
+                (Some(_), Some(_)) => {
+                    self.status = Some("error: selection spans both sides".to_string());
+                    return;
+                }
+                _ => {
+                    self.status = Some("not a commentable selection".to_string());
+                    return;
+                }
             }
-            None => self.status = Some("not a commentable line".to_string()),
-        }
+        } else {
+            match cursor_t {
+                Some(t) => (t, None),
+                None => {
+                    self.status = Some("not a commentable line".to_string());
+                    return;
+                }
+            }
+        };
+        // Collapse to a single line if the range is one line.
+        self.pending_comment = Some(end);
+        self.pending_comment_start = start.filter(|s| s.line != end.line);
+        self.selection_anchor = None;
+        self.review_input.clear();
+        self.status = None;
+        self.mode = Mode::CommentInput;
     }
 
     /// Post the inline comment as a new review thread. Blocks the UI briefly.
@@ -538,6 +585,10 @@ impl<'a> App<'a> {
                 self.mode = Mode::Normal;
                 return;
             }
+        };
+        let (start_line, start_side) = match self.pending_comment_start {
+            Some(s) => (Some(s.line), Some(s.side)),
+            None => (None, None),
         };
         let path = match self.selected() {
             Some(f) => f.path.clone(),
@@ -565,11 +616,23 @@ impl<'a> App<'a> {
                 .get_pull_request_id(&parsed.owner, &parsed.repo, parsed.number)
                 .await?;
             github
-                .create_review_thread(&pr_id, &body, &path, target.line, target.side, None, None)
+                .create_review_thread(
+                    &pr_id,
+                    &body,
+                    &path,
+                    target.line,
+                    target.side,
+                    start_line,
+                    start_side,
+                )
                 .await
         });
+        let span = match start_line {
+            Some(sl) => format!("{}:{sl}-{}", target.side, target.line),
+            None => format!("{}:{}", target.side, target.line),
+        };
         self.status = Some(match result {
-            Ok(_) => format!("✓ comment added on {}:{}", target.side, target.line),
+            Ok(_) => format!("✓ comment added on {span}"),
             Err(e) => format!("error: {e}"),
         });
         self.mode = Mode::Normal;
@@ -853,12 +916,18 @@ impl<'a> App<'a> {
                 Span::styled("▏  (Enter submit · Esc cancel)", Style::default().fg(Color::DarkGray)),
             ])),
             _ => {
-                let hint = if matches!(self.current_row(), Some(Row::Threads)) {
-                    " r reply · x resolve · T reload · ]/[ view · ? help · q quit "
+                if let Some(anchor) = self.selection_anchor {
+                    let n = anchor.abs_diff(self.cursor) + 1;
+                    let hint = format!(" SELECT {n} lines · j/k extend · c comment · v/Esc cancel ");
+                    Paragraph::new(hint).style(Style::default().fg(Color::Yellow))
                 } else {
-                    " ]/[ file · n/N find · c comment · R review · T threads · / search · ? help · q quit "
-                };
-                Paragraph::new(hint).style(Style::default().fg(Color::DarkGray))
+                    let hint = if matches!(self.current_row(), Some(Row::Threads)) {
+                        " r reply · x resolve · T reload · ]/[ view · ? help · q quit "
+                    } else {
+                        " ]/[ file · n/N find · c comment · v select · R review · T threads · ? help · q quit "
+                    };
+                    Paragraph::new(hint).style(Style::default().fg(Color::DarkGray))
+                }
             }
         };
         f.render_widget(footer, rows[2]);
@@ -937,11 +1006,19 @@ impl<'a> App<'a> {
         }
         self.view_top = self.view_top.min(total.saturating_sub(inner_h));
 
-        // Highlight the cursor line in the diff/threads pane (not the overview).
+        // Highlight the selection range and the cursor line (diff/threads only).
         let mut lines = self.diff_cache.clone();
         if !is_overview {
+            if let Some(anchor) = self.selection_anchor {
+                let (lo, hi) = (anchor.min(self.cursor), anchor.max(self.cursor));
+                for r in lo..=hi {
+                    if let Some(line) = lines.get_mut(r as usize) {
+                        line.style = Style::default().bg(SELECT_BG);
+                    }
+                }
+            }
             if let Some(line) = lines.get_mut(self.cursor as usize) {
-                line.style = Style::default().bg(Color::Rgb(45, 50, 60));
+                line.style = Style::default().bg(CURSOR_BG);
             }
         }
 
@@ -975,6 +1052,9 @@ impl Rendered {
 
 /// Background tint for inline review-comment blocks (a muted dark purple).
 const COMMENT_BG: Color = Color::Rgb(52, 42, 75);
+/// Cursor-line background, and the line-selection range background.
+const CURSOR_BG: Color = Color::Rgb(45, 50, 60);
+const SELECT_BG: Color = Color::Rgb(38, 48, 70);
 
 /// Render a file's diff as styled ratatui lines: syntect syntax highlighting on
 /// the code, AI-highlight comments inline (`▸` above the line they start on), a
@@ -1251,6 +1331,7 @@ fn render_help(f: &mut Frame) {
         Line::from(""),
         head("Actions"),
         Line::from("  c            comment on the cursor line"),
+        Line::from("  v            select a line range, then c"),
         Line::from("  R            submit a review"),
         Line::from(""),
         head("Threads"),
@@ -1643,5 +1724,39 @@ mod tests {
         app.cache_idx = None;
         app.sync_cache();
         assert!(!lines_text(&app).contains("already handled"), "resolved threads stay out of the diff");
+    }
+
+    #[test]
+    fn v_toggles_selection_and_sets_range() {
+        // Three added lines → new-side L1, L2, L3 (all RIGHT).
+        let f = file("pkg/m.go", "high", "@@ -1,0 +1,3 @@\n+a\n+b\n+c\n");
+        let m = ReviewManifest { files: vec![f], ..manifest() };
+        let mut app = App::new(&m);
+        app.sync_cache();
+        // Anchor on the first added line (row 1 = L1), extend to row 3 (L3).
+        app.cursor = 1;
+        app.on_key(KeyCode::Char('v'));
+        assert_eq!(app.selection_anchor, Some(1));
+        app.cursor = 3;
+        app.on_key(KeyCode::Char('c'));
+        assert!(matches!(app.mode, Mode::CommentInput));
+        let end = app.pending_comment.unwrap();
+        let start = app.pending_comment_start.unwrap();
+        assert_eq!((start.side, start.line), ("RIGHT", 1), "range start");
+        assert_eq!((end.side, end.line), ("RIGHT", 3), "range end");
+        assert_eq!(app.selection_anchor, None, "selection consumed");
+    }
+
+    #[test]
+    fn v_pressed_twice_clears_selection() {
+        let f = file("pkg/m.go", "high", "@@ -1,0 +1,3 @@\n+a\n+b\n+c\n");
+        let m = ReviewManifest { files: vec![f], ..manifest() };
+        let mut app = App::new(&m);
+        app.sync_cache();
+        app.cursor = 1;
+        app.on_key(KeyCode::Char('v'));
+        assert_eq!(app.selection_anchor, Some(1));
+        app.on_key(KeyCode::Char('v'));
+        assert_eq!(app.selection_anchor, None);
     }
 }

--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -9,7 +9,7 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 
-use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -66,6 +66,8 @@ struct App<'a> {
     /// Focused row in the main pane; the view scrolls to keep it visible.
     cursor: u16,
     view_top: u16,
+    /// Last-rendered viewport height, for half-page / page jumps.
+    viewport_h: u16,
     /// Rendered main pane for the current selection (built lazily, not per
     /// frame), plus the row indices of hunk headers and AI findings for jumps,
     /// and a per-row comment target (None for non-commentable rows).
@@ -109,6 +111,7 @@ impl<'a> App<'a> {
             list_state: ListState::default(),
             cursor: 0,
             view_top: 0,
+            viewport_h: 20,
             diff_cache: Vec::new(),
             hunk_rows: Vec::new(),
             finding_rows: Vec::new(),
@@ -406,6 +409,14 @@ impl<'a> App<'a> {
         self.cursor = self.cursor.saturating_sub(n);
     }
 
+    fn half_page(&self) -> u16 {
+        (self.viewport_h / 2).max(1)
+    }
+
+    fn full_page(&self) -> u16 {
+        self.viewport_h.max(1)
+    }
+
     fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
         loop {
             terminal.draw(|f| self.ui(f))?;
@@ -424,7 +435,7 @@ impl<'a> App<'a> {
             if key.kind != KeyEventKind::Press {
                 continue;
             }
-            if self.on_key(key.code) {
+            if self.on_key(key.code, key.modifiers) {
                 break;
             }
         }
@@ -432,7 +443,8 @@ impl<'a> App<'a> {
     }
 
     /// Handle one key press. Returns true when the app should quit.
-    fn on_key(&mut self, code: KeyCode) -> bool {
+    fn on_key(&mut self, code: KeyCode, mods: KeyModifiers) -> bool {
+        let ctrl = mods.contains(KeyModifiers::CONTROL);
         match self.mode {
             Mode::Normal => match code {
                 KeyCode::Char('q') => return true,
@@ -450,6 +462,15 @@ impl<'a> App<'a> {
                 }
                 KeyCode::Char('j') | KeyCode::Down => self.cursor_down(1),
                 KeyCode::Char('k') | KeyCode::Up => self.cursor_up(1),
+                // Bulk navigation.
+                KeyCode::Char('d') if ctrl => self.cursor_down(self.half_page()),
+                KeyCode::Char('u') if ctrl => self.cursor_up(self.half_page()),
+                KeyCode::Char('f') if ctrl => self.cursor_down(self.full_page()),
+                KeyCode::Char('b') if ctrl => self.cursor_up(self.full_page()),
+                KeyCode::PageDown => self.cursor_down(self.full_page()),
+                KeyCode::PageUp => self.cursor_up(self.full_page()),
+                KeyCode::Home => self.cursor = 0,
+                KeyCode::End => self.cursor = self.diff_line_count().saturating_sub(1),
                 KeyCode::Char('g') => self.cursor = 0,
                 KeyCode::Char('G') => self.cursor = self.diff_line_count().saturating_sub(1),
                 KeyCode::Char(']') | KeyCode::Tab => self.select_step(true),
@@ -996,6 +1017,7 @@ impl<'a> App<'a> {
         // block's title row).
         let total = self.diff_cache.len() as u16;
         let inner_h = area.height.saturating_sub(1).max(1);
+        self.viewport_h = inner_h;
         if total > 0 {
             self.cursor = self.cursor.min(total - 1);
         }
@@ -1319,7 +1341,9 @@ fn render_help(f: &mut Frame) {
     let head = |s| Line::from(Span::styled(s, Style::default().add_modifier(Modifier::BOLD)));
     let lines = vec![
         head("Navigation"),
-        Line::from("  j / k        scroll"),
+        Line::from("  j / k        line down / up"),
+        Line::from("  ^d / ^u      half page down / up"),
+        Line::from("  PgDn / PgUp  page down / up"),
         Line::from("  g / G        top / bottom"),
         Line::from("  ] / [        next / prev item"),
         Line::from("  } / {        next / prev hunk"),
@@ -1390,6 +1414,10 @@ mod tests {
         app.list_state.select(Some(pos));
         app.cache_idx = None;
         app.sync_cache();
+    }
+
+    fn press(app: &mut App, code: KeyCode) -> bool {
+        app.on_key(code, KeyModifiers::NONE)
     }
 
     fn file(path: &str, risk: &str, diff: &str) -> FileDiff {
@@ -1600,32 +1628,32 @@ mod tests {
         let m = manifest();
         let mut app = App::new(&m);
         // R → verb picker → approve → message input.
-        assert!(!app.on_key(KeyCode::Char('R')));
+        assert!(!press(&mut app, KeyCode::Char('R')));
         assert!(matches!(app.mode, Mode::ReviewPick));
-        app.on_key(KeyCode::Char('a'));
+        press(&mut app, KeyCode::Char('a'));
         assert!(matches!(app.mode, Mode::ReviewInput));
         assert_eq!(app.review_event, "APPROVE");
         // Typing accumulates the message.
         for c in "lgtm".chars() {
-            app.on_key(KeyCode::Char(c));
+            press(&mut app, KeyCode::Char(c));
         }
         assert_eq!(app.review_input, "lgtm");
         // Esc backs out without submitting; q then quits.
-        app.on_key(KeyCode::Esc);
+        press(&mut app, KeyCode::Esc);
         assert!(matches!(app.mode, Mode::Normal));
-        assert!(app.on_key(KeyCode::Char('q')));
+        assert!(press(&mut app, KeyCode::Char('q')));
     }
 
     #[test]
     fn request_changes_requires_message() {
         let m = manifest();
         let mut app = App::new(&m);
-        app.on_key(KeyCode::Char('R'));
-        app.on_key(KeyCode::Char('r')); // REQUEST_CHANGES
+        press(&mut app, KeyCode::Char('R'));
+        press(&mut app, KeyCode::Char('r')); // REQUEST_CHANGES
         assert!(matches!(app.mode, Mode::ReviewInput));
         // Submitting empty hits the guard before any network call: stays in
         // input with an error status.
-        app.on_key(KeyCode::Enter);
+        press(&mut app, KeyCode::Enter);
         assert!(matches!(app.mode, Mode::ReviewInput));
         assert!(app.status.as_deref().unwrap_or("").contains("needs a message"));
     }
@@ -1653,20 +1681,20 @@ mod tests {
         let mut app = App::new(&m);
         app.sync_cache();
         // Cursor on the hunk header → not commentable.
-        app.on_key(KeyCode::Char('c'));
+        press(&mut app, KeyCode::Char('c'));
         assert!(matches!(app.mode, Mode::Normal));
         assert!(app.status.as_deref().unwrap_or("").contains("not a commentable"));
         // Move to the context line → opens comment input with the right target.
         app.cursor_down(1);
-        app.on_key(KeyCode::Char('c'));
+        press(&mut app, KeyCode::Char('c'));
         assert!(matches!(app.mode, Mode::CommentInput));
         let t = app.pending_comment.unwrap();
         assert_eq!((t.side, t.line), ("RIGHT", 5));
         // Submitting empty hits the guard before any network call.
-        app.on_key(KeyCode::Enter);
+        press(&mut app, KeyCode::Enter);
         assert!(matches!(app.mode, Mode::CommentInput));
         assert!(app.status.as_deref().unwrap_or("").contains("needs a message"));
-        app.on_key(KeyCode::Esc);
+        press(&mut app, KeyCode::Esc);
         assert!(matches!(app.mode, Mode::Normal));
     }
 
@@ -1694,11 +1722,11 @@ mod tests {
         app.threads = Some(vec![thread(false, "pkg/a.go", 10, "fix")]);
         select_threads(&mut app);
         app.cursor = 0;
-        app.on_key(KeyCode::Char('r'));
+        press(&mut app, KeyCode::Char('r'));
         assert!(matches!(app.mode, Mode::ReplyInput));
         assert_eq!(app.pending_thread, Some(0));
         // Submitting empty hits the guard before any network call.
-        app.on_key(KeyCode::Enter);
+        press(&mut app, KeyCode::Enter);
         assert!(matches!(app.mode, Mode::ReplyInput));
         assert!(app.status.as_deref().unwrap_or("").contains("needs a message"));
     }
@@ -1735,10 +1763,10 @@ mod tests {
         app.sync_cache();
         // Anchor on the first added line (row 1 = L1), extend to row 3 (L3).
         app.cursor = 1;
-        app.on_key(KeyCode::Char('v'));
+        press(&mut app, KeyCode::Char('v'));
         assert_eq!(app.selection_anchor, Some(1));
         app.cursor = 3;
-        app.on_key(KeyCode::Char('c'));
+        press(&mut app, KeyCode::Char('c'));
         assert!(matches!(app.mode, Mode::CommentInput));
         let end = app.pending_comment.unwrap();
         let start = app.pending_comment_start.unwrap();
@@ -1754,9 +1782,34 @@ mod tests {
         let mut app = App::new(&m);
         app.sync_cache();
         app.cursor = 1;
-        app.on_key(KeyCode::Char('v'));
+        press(&mut app, KeyCode::Char('v'));
         assert_eq!(app.selection_anchor, Some(1));
-        app.on_key(KeyCode::Char('v'));
+        press(&mut app, KeyCode::Char('v'));
         assert_eq!(app.selection_anchor, None);
+    }
+
+    #[test]
+    fn bulk_navigation() {
+        let mut diff = String::from("@@ -1,0 +1,40 @@\n");
+        for i in 0..40 {
+            diff.push_str(&format!("+line{i}\n"));
+        }
+        let f = file("pkg/big.go", "high", &diff);
+        let m = ReviewManifest { files: vec![f], ..manifest() };
+        let mut app = App::new(&m);
+        app.sync_cache();
+        app.viewport_h = 20; // simulate a rendered viewport
+        let last = app.diff_cache.len() as u16 - 1;
+
+        app.on_key(KeyCode::Char('d'), KeyModifiers::CONTROL); // half page down
+        assert_eq!(app.cursor, 10);
+        press(&mut app, KeyCode::PageDown); // full page down
+        assert_eq!(app.cursor, 30);
+        press(&mut app, KeyCode::End); // bottom
+        assert_eq!(app.cursor, last);
+        app.on_key(KeyCode::Char('u'), KeyModifiers::CONTROL); // half page up
+        assert_eq!(app.cursor, last - 10);
+        press(&mut app, KeyCode::Home); // top
+        assert_eq!(app.cursor, 0);
     }
 }


### PR DESCRIPTION
Adds keys for moving more than one line at a time in the diff / threads pane.

## New keys
- **`^d` / `^u`** — half page down / up
- **`PgDn` / `PgUp`** (and `^f` / `^b`) — full page down / up
- **`Home` / `End`** — top / bottom (`g` / `G` already did this; now the standard keys work too)

## How
`on_key` now receives key modifiers, so it can match the `^d`/`^u`/`^f`/`^b` combos. Page size comes from the **last-rendered viewport height** (cached in `viewport_h`); a jump moves the cursor and the view follows it. The `?` overlay lists the new keys.

## Tests (headless)
- tests now use a small `press()` helper for unmodified keys
- new `bulk_navigation` test checks the half-page / page / Home / End cursor math against a 40-line diff
- **21 total**

## Verification
- ✅ `cargo test -p marrow` — 21 pass
- ✅ full workspace builds

Quick to try in a terminal:
```
git checkout feat/tui-bulk-nav && cd app/src-tauri && cargo build -p marrow
./target/debug/marrow review <pr>   # ^d/^u half page · PgDn/PgUp page · Home/End
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)