### PR TITLE
rebrand: rename visible app name to Marrow (#77 phase 1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug in Relevant Reviews
+description: Report a bug in Marrow
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           tagName: ${{ github.ref_name }}
-          releaseName: "Relevant Reviews ${{ github.ref_name }}"
+          releaseName: "Marrow ${{ github.ref_name }}"
           releaseDraft: true
           prerelease: false
           tauriScript: bunx tauri
@@ -101,7 +101,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           ARCH=$(echo "${{ matrix.target }}" | cut -d- -f1)
-          DMG="app/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/Relevant Reviews_${VERSION}_${ARCH}.dmg"
-          STABLE_NAME="Relevant Reviews_${ARCH}.dmg"
+          DMG="app/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/Marrow_${VERSION}_${ARCH}.dmg"
+          STABLE_NAME="Marrow_${ARCH}.dmg"
           cp "$DMG" "$STABLE_NAME"
           gh release upload "$GITHUB_REF_NAME" "$STABLE_NAME" --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Relevant Reviews
+# Contributing to Marrow
 
 Thanks for your interest in contributing! This guide covers how to get started.
 
@@ -28,7 +28,7 @@ bun run tauri build
 
 ## Reporting bugs
 
-Open a [bug report](https://github.com/Besendorfer/relevant-reviews/issues/new?template=bug_report.yml). Include:
+Open a [bug report](https://github.com/Besendorfer/marrow/issues/new?template=bug_report.yml). Include:
 
 - Steps to reproduce
 - Expected vs actual behavior
@@ -37,7 +37,7 @@ Open a [bug report](https://github.com/Besendorfer/relevant-reviews/issues/new?t
 
 ## Suggesting features
 
-Open a [feature request](https://github.com/Besendorfer/relevant-reviews/issues/new?template=feature_request.yml) describing the problem you're trying to solve and your proposed solution.
+Open a [feature request](https://github.com/Besendorfer/marrow/issues/new?template=feature_request.yml) describing the problem you're trying to solve and your proposed solution.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# Relevant Reviews
+# Marrow
 
-[![GitHub Release](https://img.shields.io/github/v/release/Besendorfer/relevant-reviews?label=release)](https://github.com/Besendorfer/relevant-reviews/releases/latest)
-[![Downloads](https://img.shields.io/github/downloads/Besendorfer/relevant-reviews/total)](https://github.com/Besendorfer/relevant-reviews/releases)
+[![GitHub Release](https://img.shields.io/github/v/release/Besendorfer/marrow?label=release)](https://github.com/Besendorfer/marrow/releases/latest)
+[![Downloads](https://img.shields.io/github/downloads/Besendorfer/marrow/total)](https://github.com/Besendorfer/marrow/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Platform](https://img.shields.io/badge/platform-macOS%20(Apple%20Silicon)-lightgrey)](https://github.com/Besendorfer/relevant-reviews/releases/latest)
+[![Platform](https://img.shields.io/badge/platform-macOS%20(Apple%20Silicon)-lightgrey)](https://github.com/Besendorfer/marrow/releases/latest)
 
 A desktop app that uses AI to surface only the parts of a GitHub pull request that matter -- business logic, infrastructure, API changes -- so you can focus your review where it counts.
 
 <p align="center">
-  <img src="assets/screenshot.png" alt="Relevant Reviews showing a PR with AI-annotated diffs and change groups" width="900" />
+  <img src="assets/screenshot.png" alt="Marrow showing a PR with AI-annotated diffs and change groups" width="900" />
 </p>
 
 ## Why?
 
 A typical pull request touches 30-50 files. Most of them are UI components, tests, lock files, and config -- noise that buries the changes that actually matter. Reviewers either spend time scrolling past irrelevant diffs or start skimming and miss critical logic changes.
 
-Relevant Reviews loads a PR, uses AI to classify every file by what it contains, and surfaces only the business logic, infrastructure, and API changes. A second AI pass highlights the specific lines that deserve attention -- auth changes, removed safety checks, breaking API contracts -- so you know exactly where to focus.
+Marrow loads a PR, uses AI to classify every file by what it contains, and surfaces only the business logic, infrastructure, and API changes. A second AI pass highlights the specific lines that deserve attention -- auth changes, removed safety checks, breaking API contracts -- so you know exactly where to focus.
 
-**In a typical 40-file PR, only 8-12 files contain reviewable business logic. Relevant Reviews finds them in seconds.**
+**In a typical 40-file PR, only 8-12 files contain reviewable business logic. Marrow finds them in seconds.**
 
 ## Download
 
-**[Download for macOS (Apple Silicon)](https://github.com/Besendorfer/relevant-reviews/releases/latest/download/Relevant.Reviews_aarch64.dmg)**
+**[Download for macOS (Apple Silicon)](https://github.com/Besendorfer/marrow/releases/latest/download/Marrow_aarch64.dmg)**
 
-Or browse [all releases](https://github.com/Besendorfer/relevant-reviews/releases).
+Or browse [all releases](https://github.com/Besendorfer/marrow/releases).
 
-> The app is signed and notarized by Apple. After downloading the `.dmg`, open it and drag "Relevant Reviews" to your Applications folder. Auto-updates are built in -- you'll be notified when new versions are available.
+> The app is signed and notarized by Apple. After downloading the `.dmg`, open it and drag "Marrow" to your Applications folder. Auto-updates are built in -- you'll be notified when new versions are available.
 
 ## How it works
 
@@ -94,7 +94,7 @@ bun install
 bun run tauri build
 ```
 
-The built app will be at `app/src-tauri/target/release/bundle/macos/Relevant Reviews.app`.
+The built app will be at `app/src-tauri/target/release/bundle/macos/Marrow.app`.
 
 ### Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ You should receive a response within 72 hours. Once confirmed, a fix will be pri
 
 This policy covers:
 
-- The Relevant Reviews desktop application
+- The Marrow desktop application
 - The `rr` CLI script
 - GitHub API token handling
 - AWS credential handling

--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Relevant Reviews</title>
+    <title>Marrow</title>
   </head>
   <body>
     <div id="root"></div>

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -1,4 +1,4 @@
-//! `marrow` — a thin terminal frontend over the Relevant Reviews Rust core.
+//! `marrow` — a thin terminal frontend over the `marrow-core` Rust core.
 //!
 //! This is a prototype to evaluate a TUI/CLI direction. It deliberately reuses
 //! the exact same modules the desktop app's Tauri commands call — `github.rs`,
@@ -34,7 +34,7 @@ enum ColorWhen {
 #[derive(Parser)]
 #[command(
     name = "marrow",
-    about = "Relevant Reviews in your terminal (prototype CLI over the shared Rust core)",
+    about = "Marrow in your terminal — surface the PR changes that matter",
     version
 )]
 struct Cli {

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/nickkadutskyi/jb-tauri-plugin/refs/heads/main/schemas/tauri.conf.json",
-  "productName": "Relevant Reviews",
+  "productName": "Marrow",
   "version": "0.3.1",
   "identifier": "com.relevant-reviews.app",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Relevant Reviews",
+        "title": "Marrow",
         "width": 1400,
         "height": 900
       }
@@ -50,7 +50,7 @@
     },
     "updater": {
       "endpoints": [
-        "https://github.com/Besendorfer/relevant-reviews/releases/latest/download/latest.json"
+        "https://github.com/Besendorfer/marrow/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDczMjNBNDJERkRBNjRBQjEKUldTeFNxYjlMYVFqYzZ0MnJVRHJ0MDJiSU5rb1ZhSmVBbHRlaDFVUkwvYldGQkVyMWpvc0lHTVEK"
     }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1233,7 +1233,7 @@ function App() {
                     <pre>{activeTab.error}</pre>
                   </div>
                 )}
-                <h1>Relevant Reviews</h1>
+                <h1>Marrow</h1>
                 <p>
                   Drop a manifest JSON file here, or enter a PR URL below to start
                   a review.

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -145,7 +145,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           <h3 className="settings-section-title">Browser Integration</h3>
           <p className="settings-hint">
             Drag this link to your bookmark bar. When you're on a GitHub PR
-            page, click it to open the PR directly in Relevant Reviews.
+            page, click it to open the PR directly in Marrow.
           </p>
           <a
             className="bookmarklet-link"
@@ -153,7 +153,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             onClick={(e) => e.preventDefault()}
             draggable
           >
-            Open in Relevant Reviews
+            Open in Marrow
           </a>
 
           <div className="settings-actions">

--- a/rr
+++ b/rr
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ─── Relevant Reviews (rr) ───────────────────────────────────────────────────
+# ─── Marrow (rr) ───────────────────────────────────────────────────
 # Fetches a GitHub PR, uses AI to classify which files contain relevant changes
-# (business logic, infrastructure), and opens them in the Relevant Reviews app.
+# (business logic, infrastructure), and opens them in the Marrow app.
 # ──────────────────────────────────────────────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -32,7 +32,7 @@ Arguments:
 Options:
   --list-only        Only list classified files, don't open the app
   --manifest-only    Build manifest and print its path, don't open any viewer
-  --vscode           Open diffs in VSCode instead of the Relevant Reviews app
+  --vscode           Open diffs in VSCode instead of the Marrow app
   --help             Show this help message
 
 Examples:
@@ -571,18 +571,18 @@ if [[ "$USE_VSCODE" == true ]]; then
 
   echo "Done! Opened ${OPENED} diff tabs in VSCode."
 else
-  # Launch the Relevant Reviews desktop app
+  # Launch the Marrow desktop app
   APP_BINARY="$SCRIPT_DIR/app/src-tauri/target/release/relevant-reviews"
-  APP_BUNDLE="$SCRIPT_DIR/app/src-tauri/target/release/bundle/macos/Relevant Reviews.app"
+  APP_BUNDLE="$SCRIPT_DIR/app/src-tauri/target/release/bundle/macos/Marrow.app"
 
   if [[ -d "$APP_BUNDLE" ]]; then
-    echo "Opening Relevant Reviews app..."
+    echo "Opening Marrow app..."
     open "$APP_BUNDLE" --args "$MANIFEST_PATH"
   elif [[ -x "$APP_BINARY" ]]; then
-    echo "Opening Relevant Reviews app..."
+    echo "Opening Marrow app..."
     "$APP_BINARY" "$MANIFEST_PATH" &
   else
-    echo "Error: Relevant Reviews app not found." >&2
+    echo "Error: Marrow app not found." >&2
     echo "Build it with: cd $SCRIPT_DIR/app && cargo tauri build" >&2
     echo ""
     echo "Falling back to VSCode..."


### PR DESCRIPTION
Phase 1 of #77 — the **visible-name** pass. Changes what users see; keeps the **invisible identity fixed** so existing installs keep auto-updating and nobody loses their config.

Repo was also renamed on GitHub (`relevant-reviews` → `marrow`); old URLs auto-redirect.

## Kept stable on purpose (move in phase 2, behind a migration shim)
- Bundle identifier `com.relevant-reviews.app` — changing it makes the OS treat it as a new app and breaks auto-update for everyone installed.
- Deep-link scheme `relevantreviews://`
- Config dir `~/.config/relevant-reviews/`

## Changed
- **Docs:** README, CONTRIBUTING, SECURITY, bug-report template.
- **UI:** `productName` + window title → Marrow, `index.html` `<title>`, `App.tsx` heading, Settings "Open in Marrow" bookmarklet text.
- **CLI:** `marrow` about text + module doc.
- **Repo URLs / updater:** badges, download links, and the updater endpoint now point at `Besendorfer/marrow` (old URLs redirect, so installed clients keep updating).
- **Release naming:** `productName` → "Marrow" means the bundle is now `Marrow_<version>_<arch>.dmg`, so `release.yml` (DMG path, stable-name asset, release title) and the README download link move in lockstep → `Marrow_aarch64.dmg`.
- **`rr` (legacy script):** display strings + the `Marrow.app` bundle path it launches (kept the `relevant-reviews` dev-binary path — the Cargo package name is unchanged).

## Deferred to phase 2 (full rebrand)
Config-dir rename + first-launch migration shim, `marrow://` deep-link scheme (keeping `relevantreviews://` as an alias), and the browser extension (name + scheme + Firefox id).

## Testing
- CLI builds; 32 CLI tests pass.
- `tauri.conf.json` validated as JSON; bundle ID + deep-link scheme confirmed unchanged.
- Pure string/branding changes otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)