### PR TITLE
feat(config): cross-platform marrow config dir + migration + marrow init

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You'll need:
 
 ## Configuration
 
-Settings are stored in `~/.config/relevant-reviews/config` and can be edited from the app's Settings modal.
+Settings are stored in `~/.config/marrow/config` (run `marrow init` to scaffold it) and can be edited from the app's Settings modal.
 
 | Setting | Description |
 |---|---|

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -16,7 +16,7 @@ use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::as_24_bit_terminal_escaped;
 
-use marrow_core::config::{load_settings, resolve_github_token};
+use marrow_core::config::{app_config_dir, config_path, load_settings, resolve_github_token};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
 use marrow_core::types::{FetchProgress, FetchStatus, FileDiff, Highlight, ReviewManifest, ReviewThread};
@@ -162,6 +162,9 @@ enum Command {
     },
     /// Print resolved settings (token source is masked)
     Settings,
+    /// Create the config directory and a starter config file (migrates the
+    /// pre-rename dir if present)
+    Init,
 }
 
 #[tokio::main]
@@ -227,6 +230,7 @@ async fn run(command: Command, yes: bool) -> Result<(), String> {
             settings_cmd();
             Ok(())
         }
+        Command::Init => init_cmd(),
     }
 }
 
@@ -781,6 +785,49 @@ async fn checks(pr: &str, json: bool) -> Result<(), String> {
 }
 
 // ── settings ────────────────────────────────────────────────────────────────
+
+/// A commented starter config written by `marrow init` when none exists.
+const CONFIG_TEMPLATE: &str = "\
+# Marrow config — https://github.com/Besendorfer/marrow
+# GitHub personal access token (optional for public repos; or set GH_TOKEN / GITHUB_TOKEN).
+github_token=
+# Claude model name (e.g. claude-sonnet-4-6) or an AWS Bedrock model ARN.
+model=
+# AWS profile name (only used with Bedrock ARNs).
+aws_profile=
+";
+
+/// Ensure the config directory exists (migrating the pre-rename dir if present)
+/// and scaffold a starter config file. Idempotent — never clobbers an existing
+/// config.
+fn init_cmd() -> Result<(), String> {
+    // Resolving the dir also runs the one-time legacy migration.
+    let dir = app_config_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| format!("create config dir: {e}"))?;
+
+    let cfg = config_path();
+    let created = !cfg.exists();
+    if created {
+        std::fs::write(&cfg, CONFIG_TEMPLATE).map_err(|e| format!("write config: {e}"))?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&cfg, std::fs::Permissions::from_mode(0o600));
+        }
+    }
+
+    println!("{} config dir: {}", paint("✓", GREEN), dir.display());
+    let note = if created { "wrote starter config" } else { "config already exists" };
+    println!("  {note}: {}", paint(&cfg.display().to_string(), DIM));
+    println!();
+    println!(
+        "Add your GitHub token to the config, or set {} / {}.",
+        paint("GH_TOKEN", CYAN),
+        paint("GITHUB_TOKEN", CYAN)
+    );
+    println!("Then run {} to verify.", paint("marrow settings", CYAN));
+    Ok(())
+}
 
 fn settings_cmd() {
     let s = load_settings();

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -1,17 +1,88 @@
 use crate::types::Settings;
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+/// The directory Marrow stores its config, cache, session, and viewed-state in.
+///
+/// - Linux / macOS: `$XDG_CONFIG_HOME/marrow`, else `~/.config/marrow`
+/// - Windows: `%APPDATA%\marrow`
+///
+/// On first access, if this dir doesn't exist yet but the pre-rename
+/// `~/.config/relevant-reviews/` dir does, its contents are copied over so
+/// tokens/settings survive the rename. The old dir is left intact as a fallback.
 pub fn app_config_dir() -> PathBuf {
-    let home = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home)
-        .join(".config")
-        .join("relevant-reviews")
+    let dir = config_base().join("marrow");
+    migrate_legacy_config(legacy_config_dir(), &dir);
+    dir
 }
 
 pub fn config_path() -> PathBuf {
     app_config_dir().join("config")
+}
+
+/// The platform's base config directory (the parent of the `marrow` dir).
+fn config_base() -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Ok(appdata) = env::var("APPDATA") {
+            if !appdata.is_empty() {
+                return PathBuf::from(appdata);
+            }
+        }
+        return PathBuf::from(env::var("USERPROFILE").unwrap_or_else(|_| ".".to_string()))
+            .join("AppData")
+            .join("Roaming");
+    }
+    #[cfg(not(windows))]
+    {
+        if let Ok(xdg) = env::var("XDG_CONFIG_HOME") {
+            if !xdg.is_empty() {
+                return PathBuf::from(xdg);
+            }
+        }
+        let home = env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        PathBuf::from(home).join(".config")
+    }
+}
+
+/// The pre-rename config dir (always `~/.config/relevant-reviews/`, as the old
+/// code hardcoded it). `None` if `HOME` is unset.
+fn legacy_config_dir() -> Option<PathBuf> {
+    let home = env::var("HOME").ok().filter(|h| !h.is_empty())?;
+    Some(PathBuf::from(home).join(".config").join("relevant-reviews"))
+}
+
+/// One-time, non-destructive migration: if `new` doesn't exist yet but `old`
+/// does, copy `old`'s contents into `new`, leaving `old` untouched. Best-effort
+/// — a copy failure must not break config access (we just fall through to a
+/// fresh config dir).
+fn migrate_legacy_config(old: Option<PathBuf>, new: &Path) {
+    if new.exists() {
+        return;
+    }
+    let Some(old) = old else { return };
+    if !old.exists() || old.as_path() == new {
+        return;
+    }
+    let _ = copy_dir_all(&old, new);
+}
+
+/// Recursively copy a directory's contents (files keep their permissions, so a
+/// `0600` config stays `0600`).
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_all(&from, &to)?;
+        } else {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }
 
 fn default_settings() -> Settings {
@@ -138,4 +209,65 @@ pub fn resolve_github_token(settings: &Settings) -> Option<String> {
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A unique, never-reused temp path (no rand/time dependency).
+    fn unique_tmp(tag: &str) -> PathBuf {
+        static N: AtomicU32 = AtomicU32::new(0);
+        let n = N.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("marrow-cfgtest-{}-{}-{}", tag, std::process::id(), n))
+    }
+
+    #[test]
+    fn migrate_copies_contents_when_new_absent() {
+        let old = unique_tmp("old");
+        let new = unique_tmp("new");
+        fs::create_dir_all(&old).unwrap();
+        fs::write(old.join("config"), "github_token=abc\n").unwrap();
+        fs::create_dir_all(old.join("cache")).unwrap();
+        fs::write(old.join("cache").join("x.json"), "{}").unwrap();
+
+        migrate_legacy_config(Some(old.clone()), &new);
+
+        assert_eq!(fs::read_to_string(new.join("config")).unwrap(), "github_token=abc\n");
+        assert!(new.join("cache").join("x.json").exists(), "nested files copied");
+        assert!(old.join("config").exists(), "old dir left intact (non-destructive)");
+
+        let _ = fs::remove_dir_all(&old);
+        let _ = fs::remove_dir_all(&new);
+    }
+
+    #[test]
+    fn migrate_is_noop_when_new_already_exists() {
+        let old = unique_tmp("old");
+        let new = unique_tmp("new");
+        fs::create_dir_all(&old).unwrap();
+        fs::write(old.join("config"), "old\n").unwrap();
+        fs::create_dir_all(&new).unwrap();
+        fs::write(new.join("config"), "new\n").unwrap();
+
+        migrate_legacy_config(Some(old.clone()), &new);
+        assert_eq!(
+            fs::read_to_string(new.join("config")).unwrap(),
+            "new\n",
+            "an existing config dir is never overwritten"
+        );
+
+        let _ = fs::remove_dir_all(&old);
+        let _ = fs::remove_dir_all(&new);
+    }
+
+    #[test]
+    fn migrate_is_noop_without_a_legacy_dir() {
+        let new = unique_tmp("new");
+        migrate_legacy_config(None, &new);
+        assert!(!new.exists(), "nothing is created when HOME/legacy dir is absent");
+        migrate_legacy_config(Some(unique_tmp("missing")), &new);
+        assert!(!new.exists(), "nothing is created when the legacy dir doesn't exist");
+    }
 }


### PR DESCRIPTION
The **config half** of the rename (issue #77 phase 2) combined with **#78's cross-platform config UX** — done together because both touch `marrow_core::config::app_config_dir`, and this is the contract we want locked *before* CLI distribution.

## What

- **Location** (XDG-style, per your choice): `$XDG_CONFIG_HOME/marrow` → else `~/.config/marrow` on Unix, `%APPDATA%\marrow` on Windows. Was hardcoded `~/.config/relevant-reviews`.
- **First-launch migration:** if the new dir is absent but the pre-rename `~/.config/relevant-reviews/` exists, its contents (config, cache, session, viewed-state) are **copied** over so tokens/settings survive the rename. **Non-destructive** — the old dir is left intact as a fallback, and the copy preserves the `0600` config permissions. Lives in shared `marrow-core`, so the desktop app and CLI migrate identically.
- **`marrow init`:** ensures the dir exists (triggering the migration), scaffolds a commented starter `config` (`0600`) if none exists, and prints next steps. Idempotent — never clobbers an existing config.
- **README:** config path → `~/.config/marrow/config` and a `marrow init` mention.

## Why copy, not move
Moving/deleting the old dir is destructive and risks data loss if an older build is still in use. Copy-once leaves a fallback; the two dirs can technically diverge only if you actively run both an old and new build, which is a transient edge case.

## Not in scope
The rest of rename phase 2 — `marrow://` deep-link scheme (+ `relevantreviews://` alias) and the browser extension — is desktop-only and doesn't touch the distribution path; it stays a separate PR. The `relevant-reviews` User-Agent string in `github.rs` is a trivial brand cleanup left for later.

## Testing
- Core unit tests: `migrate_copies_contents_when_new_absent` (incl. nested dirs + old left intact), `migrate_is_noop_when_new_already_exists` (never overwrites), `migrate_is_noop_without_a_legacy_dir`.
- `marrow init` verified end-to-end in a sandboxed `HOME`: creates `~/.config/marrow/config` at `0600` with the template.
- core + CLI test suites pass (35 total); no new clippy warnings in the changed files. Public config API signatures unchanged, so the desktop crate is unaffected.

Note: this branch is independent of #103 (visible rename) and edits only README line 69, which #103 doesn't touch — they merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)