### PR TITLE
chore(cli): publish-readiness — crate metadata + 0.1.0-alpha.1 pre-release

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,61 @@
+# Publishing the `marrow` CLI to crates.io
+
+The terminal app is published as two crates from the workspace at
+`app/src-tauri/`:
+
+| Crate         | crates.io name | Notes                                            |
+| ------------- | -------------- | ------------------------------------------------ |
+| `crates/core` | `marrow-core`  | Library. The bare name was free.                 |
+| `crates/cli`  | `marrow-cli`   | Binary is `marrow` (bare `marrow` crate is taken).|
+
+`cargo install marrow-cli` installs a command named **`marrow`**.
+
+## Current status: pre-release
+
+The workspace version is **`0.1.0-alpha.1`** (set once in
+`[workspace.package]` in `app/src-tauri/Cargo.toml`; both crates inherit it).
+
+Publishing this pre-release **claims both names permanently** without burning a
+stable `0.1.0`. Pre-releases are *not* selected by `cargo install marrow-cli`
+or `^` version requirements unless a user explicitly asks for them:
+
+```bash
+cargo install marrow-cli --version 0.1.0-alpha.1
+```
+
+So a casual `cargo install marrow-cli` will report "no stable release" until a
+real `0.1.0` is published — which is the point: the names are reserved, but the
+not-yet-announce-ready build isn't handed to people by default.
+
+> Reminder: crates.io versions are **immutable and permanent** — you can't
+> overwrite or delete a published version, only `yank` it (which hides it from
+> new resolution but leaves it downloadable forever). "Republishing" always
+> means publishing a *higher* version.
+
+## Publish order (always core → cli)
+
+`marrow-cli` depends on `marrow-core`, so `marrow-core` must exist on crates.io
+first. From `app/src-tauri/`:
+
+```bash
+# 0. dry-run first (no upload) — note: the marrow-cli dry-run errors with
+#    "no matching marrow-core" until marrow-core is actually published; that's
+#    expected, not a problem.
+cargo publish --dry-run -p marrow-core
+
+# 1. publish the library
+cargo publish -p marrow-core
+
+# 2. then the CLI (its marrow-core dep now resolves on crates.io)
+cargo publish -p marrow-cli
+```
+
+## Cutting a later version
+
+1. Bump `version` in `[workspace.package]` (`app/src-tauri/Cargo.toml`).
+2. Bump the `marrow-core` dependency version in `crates/cli/Cargo.toml` to match
+   (keep them in lockstep).
+3. Re-run the publish order above.
+
+The stable announce version is just the first non-pre-release publish (e.g.
+`0.1.0`). Do that once the AI-backend first-run friction is resolved.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ Or browse [all releases](https://github.com/Besendorfer/marrow/releases).
 
 > The app is signed and notarized by Apple. After downloading the `.dmg`, open it and drag "Marrow" to your Applications folder. Auto-updates are built in -- you'll be notified when new versions are available.
 
+## Terminal (CLI/TUI)
+
+Marrow also ships as a terminal app -- the same fetch/classify/review workflow in an interactive TUI, built on the same core (no webview).
+
+```bash
+# From a clone (works today):
+cargo install --path app/src-tauri/crates/cli
+
+# From crates.io (once published — the crate is `marrow-cli`, the command is `marrow`):
+cargo install marrow-cli
+
+marrow init        # scaffold ~/.config/marrow/config
+marrow review <pr> # fetch + classify, then open the TUI
+```
+
+`<pr>` is a URL, `owner/repo/pull/N`, or `owner/repo#N`. See [the CLI readme](app/src-tauri/crates/cli/README.md) for the full command list.
+
 ## How it works
 
 1. **Fetch** -- pulls PR metadata, file list, and diff via the GitHub REST API

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2818,7 +2818,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "marrow"
+name = "marrow-cli"
 version = "0.1.0"
 dependencies = [
  "chrono",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
 
 [[package]]
 name = "marrow-cli"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "clap",
@@ -2832,7 +2832,7 @@ dependencies = [
 
 [[package]]
 name = "marrow-core"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "aws-config",
  "aws-sdk-bedrockruntime",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -17,8 +17,11 @@ resolver = "2"
 # Shared metadata the published crates (marrow, marrow-core) inherit via
 # `<field>.workspace = true`. The desktop `relevant-reviews` package keeps its
 # own explicit fields and isn't published.
+# Pre-release: claims the crates.io names (marrow-core, marrow-cli) without
+# burning a stable 0.1.0. Pre-releases aren't selected by `cargo install` or
+# `^` deps without an explicit `--version`, so casual users won't get this build.
 [workspace.package]
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Besendorfer/marrow"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -14,6 +14,16 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 members = ["crates/core", "crates/cli"]
 resolver = "2"
 
+# Shared metadata the published crates (marrow, marrow-core) inherit via
+# `<field>.workspace = true`. The desktop `relevant-reviews` package keeps its
+# own explicit fields and isn't published.
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/Besendorfer/marrow"
+authors = ["Teancum Besendorfer"]
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/app/src-tauri/crates/cli/Cargo.toml
+++ b/app/src-tauri/crates/cli/Cargo.toml
@@ -1,7 +1,16 @@
+# Published as `marrow-cli` because the bare `marrow` name is taken on
+# crates.io; the installed binary is still `marrow` (see [[bin]] below).
 [package]
-name = "marrow"
-version = "0.1.0"
-edition = "2021"
+name = "marrow-cli"
+description = "Surface the parts of a GitHub PR that matter — an AI-assisted PR review TUI for the terminal."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+readme = "README.md"
+keywords = ["github", "pull-request", "code-review", "cli", "tui"]
+categories = ["command-line-utilities", "development-tools"]
 
 # The `marrow` terminal frontend. A thin CLI over marrow-core — no Tauri.
 [[bin]]
@@ -9,7 +18,9 @@ name = "marrow"
 path = "src/main.rs"
 
 [dependencies]
-marrow-core = { path = "../core" }
+# Path for local builds; version is required so the crate is publishable to
+# crates.io (publish marrow-core first).
+marrow-core = { path = "../core", version = "0.1.0" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1"

--- a/app/src-tauri/crates/cli/Cargo.toml
+++ b/app/src-tauri/crates/cli/Cargo.toml
@@ -19,8 +19,9 @@ path = "src/main.rs"
 
 [dependencies]
 # Path for local builds; version is required so the crate is publishable to
-# crates.io (publish marrow-core first).
-marrow-core = { path = "../core", version = "0.1.0" }
+# crates.io (publish marrow-core first). Keep this in lockstep with the
+# workspace version on every release.
+marrow-core = { path = "../core", version = "0.1.0-alpha.1" }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1"

--- a/app/src-tauri/crates/cli/README.md
+++ b/app/src-tauri/crates/cli/README.md
@@ -1,0 +1,49 @@
+# marrow
+
+Surface the parts of a GitHub pull request that matter — an AI-assisted PR
+review tool for the terminal.
+
+`marrow` loads a PR, uses AI to classify every file by what it contains, and
+surfaces only the business-logic, infrastructure, and API changes — then opens
+them in an interactive TUI with syntax-highlighted diffs, AI risk annotations,
+inline review threads, and write actions (comment, reply, resolve, approve).
+
+It's the terminal frontend for [Marrow](https://github.com/Besendorfer/marrow),
+built on the shared `marrow-core` crate (no Tauri, no webview).
+
+## Install
+
+```bash
+cargo install marrow-cli
+```
+
+The crate is published as `marrow-cli` (the bare `marrow` name is taken on
+crates.io), but it installs a command named **`marrow`**.
+
+## Setup
+
+```bash
+marrow init          # scaffold ~/.config/marrow/config
+marrow settings      # check resolved config (token source is masked)
+```
+
+You'll need a GitHub token (in the config, or `GH_TOKEN` / `GITHUB_TOKEN`) and a
+Claude model — either a model name with the `claude` CLI installed, or an AWS
+Bedrock model ARN with AWS credentials configured.
+
+## Usage
+
+```bash
+marrow review <pr>     # fetch + classify, then open the interactive TUI
+marrow diff <pr>       # raw relevance-ordered unified diff (pipe to nvim/delta)
+marrow comments <pr>   # show review threads
+marrow requests        # PRs awaiting your review
+```
+
+`<pr>` is a URL, `owner/repo/pull/N`, or `owner/repo#N`. Run `marrow --help` for
+the full command list. Mutating commands are gated behind `--yes` when stdin
+isn't a terminal.
+
+## License
+
+MIT

--- a/app/src-tauri/crates/core/Cargo.toml
+++ b/app/src-tauri/crates/core/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "marrow-core"
-version = "0.1.0"
-edition = "2021"
+description = "Core library for Marrow: GitHub PR fetch, diff, and AI relevance classification."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+keywords = ["github", "pull-request", "code-review", "diff"]
+categories = ["development-tools"]
 
 # Frontend-agnostic core: GitHub client, fetch/diff pipeline, AI classification,
 # config + caching. No Tauri, no UI — shared by the desktop app and the CLI.


### PR DESCRIPTION
Publish-readiness for the `marrow` CLI — the foundation of CLI packaging (#78 phase 4). Fully verifiable via `cargo publish --dry-run` (no upload).

## The crates.io name finding
The bare **`marrow` name is taken** on crates.io (`marrow` 0.2.7, "Minimalist Arrow interop"). So:
- **Library** → `marrow-core` (name is free).
- **CLI** → published as **`marrow-cli`**, but `[[bin]] name = "marrow"` is unchanged, so the installed command is still **`marrow`**. Users run `cargo install marrow-cli` and get a `marrow` binary (the ripgrep→`rg` pattern). Prebuilt binaries + Homebrew are unaffected — the name `marrow` is fully ours there.

## Changes
- **`[workspace.package]`** with shared `version`/`edition`/`license`/`repository`/`authors`, inherited by both published crates. The desktop `relevant-reviews` package keeps its own fields and isn't published.
- **`marrow-core`** + **`marrow-cli`**: `description`, `keywords`, `categories`, license/repo/version inheritance.
- **`marrow-cli`'s `marrow-core` dep** gains `version = "0.1.0"` — a bare `path` dep can't be published. **Publish order: `marrow-core` first, then `marrow-cli`.**
- Added **`crates/cli/README.md`** (the crates.io page).
- README: a **"Terminal (CLI/TUI)"** install section (`cargo install --path …` works today; `cargo install marrow-cli` once published).

## Verification
- `cargo publish --dry-run -p marrow-core` → packages cleanly (name free).
- `cargo publish --dry-run -p marrow-cli` → packages with **no name collision**; the only error is the expected "no matching `marrow-core` on crates.io" (can't fully verify a dependent until its dep is published).
- 35 tests pass under the renamed package; binary still `marrow`.

## Not in this PR
- **Actual publish** is your call (irreversible name claim) — run `cargo publish -p marrow-core` then `-p marrow-cli` when ready.
- **Prebuilt-binary CI** (cross-compiled `marrow` tarballs attached to releases) and a **Homebrew tap/formula** — the natural next PR; binaries unblock the formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)