### PR TITLE
feat(ai): add direct Anthropic API key backend (#78 ph3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ marrow review <pr> # fetch + classify, then open the TUI
 
 You'll need:
 
-- A **Claude model** -- either:
-  - A Claude model name (e.g. `claude-sonnet-4-6`) with the [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed, **or**
+- A **Claude model** -- any one of:
+  - A model name (e.g. `claude-sonnet-4-6`) + an **Anthropic API key** (`ANTHROPIC_API_KEY` or the `anthropic_api_key` setting) -- simplest, no AWS or extra CLI, **or**
+  - A model name with the [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed, **or**
   - An AWS Bedrock model ARN with AWS credentials configured (env vars, `~/.aws/credentials`, or SSO)
 - A **GitHub personal access token** (or `GH_TOKEN` / `GITHUB_TOKEN` environment variable)
 

--- a/app/src-tauri/crates/cli/README.md
+++ b/app/src-tauri/crates/cli/README.md
@@ -28,8 +28,15 @@ marrow settings      # check resolved config (token source is masked)
 ```
 
 You'll need a GitHub token (in the config, or `GH_TOKEN` / `GITHUB_TOKEN`) and a
-Claude model — either a model name with the `claude` CLI installed, or an AWS
-Bedrock model ARN with AWS credentials configured.
+Claude model. Simplest setup — no AWS, no extra CLI:
+
+- set `model` to a model name (e.g. `claude-sonnet-4-6`), and
+- set an Anthropic API key via `anthropic_api_key` in the config or the
+  `ANTHROPIC_API_KEY` env var ([console.anthropic.com](https://console.anthropic.com)).
+
+Alternatively, use a model name with the [`claude` CLI](https://docs.anthropic.com/en/docs/claude-cli)
+installed, or an AWS Bedrock model ARN with AWS credentials configured.
+`marrow settings` shows which backend your config resolves to.
 
 ## Usage
 

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -16,7 +16,9 @@ use syntect::highlighting::{Theme, ThemeSet};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::as_24_bit_terminal_escaped;
 
-use marrow_core::config::{app_config_dir, config_path, load_settings, resolve_github_token};
+use marrow_core::config::{
+    app_config_dir, config_path, load_settings, resolve_anthropic_api_key, resolve_github_token,
+};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
 use marrow_core::types::{FetchProgress, FetchStatus, FileDiff, Highlight, ReviewManifest, ReviewThread};
@@ -791,9 +793,13 @@ const CONFIG_TEMPLATE: &str = "\
 # Marrow config — https://github.com/Besendorfer/marrow
 # GitHub personal access token (optional for public repos; or set GH_TOKEN / GITHUB_TOKEN).
 github_token=
-# Claude model name (e.g. claude-sonnet-4-6) or an AWS Bedrock model ARN.
+# AI model. Either a Claude model name (e.g. claude-sonnet-4-6) or an AWS
+# Bedrock model ARN.
 model=
-# AWS profile name (only used with Bedrock ARNs).
+# Simplest AI setup: an Anthropic API key (or set ANTHROPIC_API_KEY). Used with
+# a model name; no AWS or `claude` CLI needed. Get one at console.anthropic.com.
+anthropic_api_key=
+# AWS profile name (only used with a Bedrock ARN model).
 aws_profile=
 ";
 
@@ -836,11 +842,23 @@ fn settings_cmd() {
         Some(t) if !t.is_empty() => paint(&format!("set ({}…)", &t.chars().take(4).collect::<String>()), GREEN),
         _ => paint("not set", RED),
     };
-    println!("model:        {}", if s.model.is_empty() { paint("(none)", RED) } else { s.model.clone() });
-    println!("github_token: {token_status}");
-    println!("aws_profile:  {}", if s.aws_profile.is_empty() { paint("(none)", DIM) } else { s.aws_profile.clone() });
-    println!("view_mode:    {}", s.view_mode);
-    println!("hunk_filter:  {}", s.hunk_filter);
+    let anthropic_key = resolve_anthropic_api_key(&s);
+    let anthropic_status = match &anthropic_key {
+        Some(k) if !k.is_empty() => paint("set", GREEN),
+        _ => paint("not set", DIM),
+    };
+    // Which backend a `marrow review` would use with this config.
+    let backend = marrow_core::ai::choose_backend(&s.model, anthropic_key.as_deref());
+    println!("model:          {}", if s.model.is_empty() { paint("(none)", RED) } else { s.model.clone() });
+    println!("github_token:   {token_status}");
+    println!("anthropic_key:  {anthropic_status}");
+    println!("aws_profile:    {}", if s.aws_profile.is_empty() { paint("(none)", DIM) } else { s.aws_profile.clone() });
+    println!(
+        "ai backend:     {}",
+        if s.model.is_empty() { paint("(model not set)", RED) } else { backend.label().to_string() }
+    );
+    println!("view_mode:      {}", s.view_mode);
+    println!("hunk_filter:    {}", s.hunk_filter);
 }
 
 // ── tiny ANSI + wrapping helpers (no extra deps) ─────────────────────────────

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -42,12 +42,48 @@ pub fn extract_json_array(text: &str) -> Result<serde_json::Value, String> {
     ))
 }
 
-/// AI backend that dispatches to either AWS Bedrock (for ARN model IDs) or the
-/// `claude` CLI (for direct model names like `claude-sonnet-4-6`).
+/// Which backend a (model, api-key) pair resolves to. Pure decision, separated
+/// from construction so it's testable without hitting AWS/network.
+#[derive(Debug, PartialEq, Eq)]
+pub enum BackendChoice {
+    Bedrock,
+    Anthropic,
+    ClaudeCli,
+}
+
+impl BackendChoice {
+    /// Human-readable label for `marrow settings`.
+    pub fn label(&self) -> &'static str {
+        match self {
+            BackendChoice::Bedrock => "bedrock",
+            BackendChoice::Anthropic => "anthropic-api",
+            BackendChoice::ClaudeCli => "claude-cli",
+        }
+    }
+}
+
+/// Decide the backend: an `arn:` model → Bedrock; otherwise an Anthropic API
+/// key (config or env) → the direct Anthropic API; otherwise the `claude` CLI.
+pub fn choose_backend(model: &str, anthropic_key: Option<&str>) -> BackendChoice {
+    if model.starts_with("arn:") {
+        BackendChoice::Bedrock
+    } else if anthropic_key.is_some_and(|k| !k.is_empty()) {
+        BackendChoice::Anthropic
+    } else {
+        BackendChoice::ClaudeCli
+    }
+}
+
+/// AI backend that dispatches to AWS Bedrock (ARN model IDs), the Anthropic API
+/// (a model name + API key), or the `claude` CLI (a model name, no key).
 pub enum AiBackend {
     Bedrock {
         client: BedrockClient,
         model_arn: String,
+    },
+    Anthropic {
+        api_key: String,
+        model: String,
     },
     ClaudeCli {
         model: String,
@@ -55,20 +91,24 @@ pub enum AiBackend {
 }
 
 impl AiBackend {
-    /// Create a new AI backend based on the model string.
-    /// If the model starts with "arn:", use Bedrock. Otherwise, use the claude CLI.
-    pub async fn new(model: &str, aws_profile: &str) -> Result<Self, String> {
-        if model.starts_with("arn:") {
-            let region = crate::bedrock::region_from_arn(model)?;
-            let client = BedrockClient::new(&region, aws_profile).await?;
-            Ok(AiBackend::Bedrock {
-                client,
-                model_arn: model.to_string(),
-            })
-        } else {
-            Ok(AiBackend::ClaudeCli {
+    /// Create a backend from the model string and an optional Anthropic API key.
+    /// See [`choose_backend`] for the dispatch rule.
+    pub async fn new(
+        model: &str,
+        aws_profile: &str,
+        anthropic_key: Option<&str>,
+    ) -> Result<Self, String> {
+        match choose_backend(model, anthropic_key) {
+            BackendChoice::Bedrock => {
+                let region = crate::bedrock::region_from_arn(model)?;
+                let client = BedrockClient::new(&region, aws_profile).await?;
+                Ok(AiBackend::Bedrock { client, model_arn: model.to_string() })
+            }
+            BackendChoice::Anthropic => Ok(AiBackend::Anthropic {
+                api_key: anthropic_key.unwrap_or_default().to_string(),
                 model: model.to_string(),
-            })
+            }),
+            BackendChoice::ClaudeCli => Ok(AiBackend::ClaudeCli { model: model.to_string() }),
         }
     }
 
@@ -78,12 +118,59 @@ impl AiBackend {
             AiBackend::Bedrock { client, model_arn } => {
                 client.invoke_model(model_arn, prompt).await
             }
-            AiBackend::ClaudeCli { model } => {
-                invoke_claude_cli(model, prompt).await
+            AiBackend::Anthropic { api_key, model } => {
+                invoke_anthropic(api_key, model, prompt).await
             }
+            AiBackend::ClaudeCli { model } => invoke_claude_cli(model, prompt).await,
         }
     }
+}
 
+/// Upper bound on generated tokens for the Anthropic API (required by the API;
+/// generous so classification of large PRs isn't truncated).
+const ANTHROPIC_MAX_TOKENS: u32 = 8192;
+
+/// Call the Anthropic Messages API directly (no AWS, no CLI). A single user
+/// message, mirroring the Bedrock/CLI paths.
+async fn invoke_anthropic(api_key: &str, model: &str, prompt: &str) -> Result<String, String> {
+    let body = serde_json::json!({
+        "model": model,
+        "max_tokens": ANTHROPIC_MAX_TOKENS,
+        "messages": [{ "role": "user", "content": prompt }],
+    });
+    let resp = reqwest::Client::new()
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Anthropic API request failed: {e}"))?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| format!("Anthropic API read failed: {e}"))?;
+    if !status.is_success() {
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!(
+            "Anthropic API error ({status}): {snippet}. Check your ANTHROPIC_API_KEY and that `{model}` is a valid model name."
+        ));
+    }
+
+    let json: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| format!("Anthropic API returned invalid JSON: {e}"))?;
+    // `content` is an array of blocks; concatenate the text blocks.
+    let out: String = json["content"]
+        .as_array()
+        .map(|blocks| {
+            blocks.iter().filter_map(|b| b["text"].as_str()).collect::<Vec<_>>().join("")
+        })
+        .unwrap_or_default();
+    if out.trim().is_empty() {
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!("Anthropic API returned no text content. Raw: {snippet}"));
+    }
+    Ok(out)
 }
 
 /// Resolve the `claude` binary path.  Bundled macOS `.app` bundles inherit a
@@ -177,4 +264,29 @@ async fn invoke_claude_cli(model: &str, prompt: &str) -> Result<String, String> 
     }
 
     Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arn_model_picks_bedrock() {
+        let arn = "arn:aws:bedrock:us-east-1:123:inference-profile/x";
+        assert_eq!(choose_backend(arn, None), BackendChoice::Bedrock);
+        // An ARN takes precedence even if an API key is present.
+        assert_eq!(choose_backend(arn, Some("sk-ant-xxx")), BackendChoice::Bedrock);
+    }
+
+    #[test]
+    fn model_name_with_key_picks_anthropic() {
+        assert_eq!(choose_backend("claude-sonnet-4-6", Some("sk-ant-xxx")), BackendChoice::Anthropic);
+    }
+
+    #[test]
+    fn model_name_without_key_falls_back_to_cli() {
+        assert_eq!(choose_backend("claude-sonnet-4-6", None), BackendChoice::ClaudeCli);
+        // An empty key string is treated as "not set".
+        assert_eq!(choose_backend("claude-sonnet-4-6", Some("")), BackendChoice::ClaudeCli);
+    }
 }

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -90,6 +90,7 @@ fn default_settings() -> Settings {
         model: String::new(),
         github_token: String::new(),
         aws_profile: String::new(),
+        anthropic_api_key: String::new(),
         filter_older: true,
         filter_team: true,
         view_mode: "split".to_string(),
@@ -113,6 +114,7 @@ pub fn load_settings() -> Settings {
     let mut model = String::new();
     let mut github_token = String::new();
     let mut aws_profile = String::new();
+    let mut anthropic_api_key = String::new();
     let mut filter_older = true;
     let mut filter_team = true;
     let mut view_mode = "split".to_string();
@@ -127,6 +129,8 @@ pub fn load_settings() -> Settings {
             github_token = val.to_string();
         } else if let Some(val) = line.strip_prefix("aws_profile=") {
             aws_profile = val.to_string();
+        } else if let Some(val) = line.strip_prefix("anthropic_api_key=") {
+            anthropic_api_key = val.to_string();
         } else if let Some(val) = line.strip_prefix("filter_older=") {
             filter_older = val == "true";
         } else if let Some(val) = line.strip_prefix("filter_team=") {
@@ -146,6 +150,7 @@ pub fn load_settings() -> Settings {
         model,
         github_token,
         aws_profile,
+        anthropic_api_key,
         filter_older,
         filter_team,
         view_mode,
@@ -168,6 +173,9 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     }
     if !settings.aws_profile.is_empty() {
         content.push_str(&format!("aws_profile={}\n", settings.aws_profile));
+    }
+    if !settings.anthropic_api_key.is_empty() {
+        content.push_str(&format!("anthropic_api_key={}\n", settings.anthropic_api_key));
     }
     content.push_str(&format!("filter_older={}\n", settings.filter_older));
     content.push_str(&format!("filter_team={}\n", settings.filter_team));
@@ -209,6 +217,18 @@ pub fn resolve_github_token(settings: &Settings) -> Option<String> {
     }
 
     None
+}
+
+/// Resolve the Anthropic API key: config file > ANTHROPIC_API_KEY env. Returns
+/// None if unset (then the backend falls back to the `claude` CLI).
+pub fn resolve_anthropic_api_key(settings: &Settings) -> Option<String> {
+    if !settings.anthropic_api_key.is_empty() {
+        return Some(settings.anthropic_api_key.clone());
+    }
+    match env::var("ANTHROPIC_API_KEY") {
+        Ok(key) if !key.is_empty() => Some(key),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -260,6 +280,15 @@ mod tests {
 
         let _ = fs::remove_dir_all(&old);
         let _ = fs::remove_dir_all(&new);
+    }
+
+    #[test]
+    fn anthropic_key_resolves_from_config_field() {
+        // A config-file key short-circuits before any env lookup, so this is
+        // deterministic regardless of the test environment's ANTHROPIC_API_KEY.
+        let mut s = default_settings();
+        s.anthropic_api_key = "sk-ant-from-config".to_string();
+        assert_eq!(resolve_anthropic_api_key(&s).as_deref(), Some("sk-ant-from-config"));
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -38,7 +38,7 @@ fn emit_progress(
 
 pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_>) -> Result<ReviewManifest, String> {
     if settings.model.is_empty() {
-        return Err("No model configured. Set a Bedrock ARN or Claude model name in Settings.".to_string());
+        return Err("No model configured. Set `model` to a Claude model name (e.g. claude-sonnet-4-6) with an Anthropic API key or the `claude` CLI, or to an AWS Bedrock model ARN.".to_string());
     }
 
     let token = resolve_github_token(settings);
@@ -92,7 +92,12 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
 
     // Step 3: AI classification
     emit_progress(app, 3, "Classifying files with AI", FetchStatus::Running, None, None);
-    let ai = AiBackend::new(&settings.model, &settings.aws_profile).await?;
+    let ai = AiBackend::new(
+        &settings.model,
+        &settings.aws_profile,
+        crate::config::resolve_anthropic_api_key(settings).as_deref(),
+    )
+    .await?;
 
     let classification_prompt =
         build_classification_prompt(&pr_title, &file_list, &full_diff);

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -87,6 +87,10 @@ pub struct Settings {
     pub github_token: String,
     #[serde(default)]
     pub aws_profile: String,
+    /// Anthropic API key for the direct-API backend (used when `model` is a
+    /// model name and this/`ANTHROPIC_API_KEY` is set). No AWS/CLI needed.
+    #[serde(default)]
+    pub anthropic_api_key: String,
     #[serde(default = "default_true")]
     pub filter_older: bool,
     #[serde(default = "default_true")]

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -15,6 +15,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [model, setModel] = useState("");
   const [githubToken, setGithubToken] = useState("");
   const [awsProfile, setAwsProfile] = useState("");
+  const [anthropicKey, setAnthropicKey] = useState("");
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -30,6 +31,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setModel(s.model);
         setGithubToken(s.github_token || "");
         setAwsProfile(s.aws_profile || "");
+        setAnthropicKey(s.anthropic_api_key || "");
         setCurrentSettings(s);
       });
       setSaved(false);
@@ -45,6 +47,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           model: model.trim(),
           github_token: githubToken.trim(),
           aws_profile: awsProfile.trim(),
+          anthropic_api_key: anthropicKey.trim(),
           filter_older: currentSettings?.filter_older ?? true,
           filter_team: currentSettings?.filter_team ?? true,
           view_mode: currentSettings?.view_mode ?? "split",
@@ -76,8 +79,9 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             Claude Model
           </label>
           <p className="settings-hint">
-            A Claude model name (e.g. <code>claude-sonnet-4-6</code>) to use
-            via the <code>claude</code> CLI, or a Bedrock ARN for AWS.
+            A Claude model name (e.g. <code>claude-sonnet-4-6</code>) used with
+            an Anthropic API key or the <code>claude</code> CLI, or a Bedrock
+            ARN for AWS.
           </p>
           <input
             id="model"
@@ -91,6 +95,33 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             placeholder="claude-sonnet-4-6 or arn:aws:bedrock:..."
             spellCheck={false}
           />
+
+          {!model.trim().startsWith("arn:") && (
+            <>
+              <label className="settings-label" htmlFor="anthropic-key">
+                Anthropic API Key
+              </label>
+              <p className="settings-hint">
+                Calls the Anthropic API directly — no AWS or <code>claude</code>{" "}
+                CLI needed. Falls back to <code>ANTHROPIC_API_KEY</code>, then to
+                the <code>claude</code> CLI if unset. Get one at{" "}
+                <code>console.anthropic.com</code>.
+              </p>
+              <input
+                id="anthropic-key"
+                className="settings-input"
+                type="password"
+                value={anthropicKey}
+                onChange={(e) => {
+                  setAnthropicKey(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="sk-ant-..."
+                spellCheck={false}
+                autoComplete="off"
+              />
+            </>
+          )}
 
           {model.trim().startsWith("arn:") && (
             <>

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -147,6 +147,7 @@ export interface Settings {
   model: string;
   github_token: string;
   aws_profile: string;
+  anthropic_api_key: string;
   filter_older: boolean;
   filter_team: boolean;
   view_mode: DiffViewMode;


### PR DESCRIPTION
Removes the install-and-go adoption wall. Until now, a fresh `marrow` user needed **AWS Bedrock** or the **`claude` CLI** to get past first run. Now they can just set a model name + an **Anthropic API key** — no AWS, no extra CLI.

## Dispatch
`ai::choose_backend` (now a pure, testable fn):
1. `arn:…` model → **Bedrock** (unchanged)
2. else an **Anthropic API key** (config `anthropic_api_key` or `ANTHROPIC_API_KEY` env) → the **Anthropic Messages API** directly (`reqwest`, already a dep)
3. else the **`claude` CLI** (unchanged fallback)

Existing users are unaffected — no key set still routes to the CLI.

## Changes
- **core:** `Settings.anthropic_api_key` (serde default); config load/save + `resolve_anthropic_api_key` (config > env, mirrors `resolve_github_token`); `AiBackend::Anthropic` variant + `invoke_anthropic`; `fetch_pr_impl` passes the resolved key; clearer no-model error.
- **CLI:** `marrow init` template leads with the API-key path; `marrow settings` shows the key status **and which backend your config resolves to** (`anthropic-api` / `claude-cli` / `bedrock`).
- **desktop:** Settings UI gains an **Anthropic API Key** field (shown for model-name configs). This also fixes a latent bug — without a field, a desktop "Save" would serialize `Settings` *without* the key and silently drop a config/env-set one. `types.ts` + `SettingsModal` mirror the `github_token` field.
- **docs:** README prerequisites + CLI README now lead with the key path.

## Testing
- Unit: `choose_backend` dispatch (arn / key / no-key incl. empty-string key); `anthropic_api_key` resolves from the config field.
- Sandboxed `marrow settings`: `model + key → ai backend: anthropic-api`; `model only → claude-cli`.
- Frontend `tsc --noEmit` clean; **39 Rust tests pass**; no new clippy warnings in changed files.
- ⚠️ The live Anthropic API call itself can only be smoke-tested with a real key — flagged for manual verification.

## Deferred (separate decision)
**AI-optional mode** (running with no AI, raw diffs only) — a different product direction, not an adoption fix, so intentionally out of scope here.

This is the gate before a stable `0.1.0` announce: install → first-run now works for outsiders with just an API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)