### PR TITLE
feat(ai): multi-provider (GPT/Gemini/OpenRouter) — re-land #107 onto main

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,24 @@ Settings are stored in `~/.config/marrow/config` (run `marrow init` to scaffold 
 
 | Setting | Description |
 |---|---|
-| `model` | Claude model name (e.g. `claude-sonnet-4-6`) or AWS Bedrock ARN |
-| `github_token` | GitHub personal access token (optional if `GH_TOKEN` or `GITHUB_TOKEN` env var is set) |
+| `model` | Model name (`claude*` / `gpt*` / `gemini*`) or AWS Bedrock ARN |
+| `github_token` | GitHub personal access token (optional if `GH_TOKEN` / `GITHUB_TOKEN` env var is set) |
+| `anthropic_api_key` | Anthropic API key for `claude*` models (or `ANTHROPIC_API_KEY`) |
+| `openai_api_key` | OpenAI / OpenAI-compatible key for `gpt*`/`o3*` (or `OPENAI_API_KEY`) |
+| `gemini_api_key` | Gemini key for `gemini*` models (or `GEMINI_API_KEY`) |
+| `provider` | Optional override (`openai` / `gemini` / `openai-compatible` / …); blank = auto-detect |
+| `openai_base_url` | OpenAI-compatible base URL for OpenRouter / a local server (or `OPENAI_BASE_URL`) |
 | `aws_profile` | AWS profile name (only used with Bedrock ARNs; uses default credential chain if empty) |
 
 GitHub token resolution order: config file > `GH_TOKEN` env > `GITHUB_TOKEN` env.
+
+> **Secret storage.** The token and API keys are written to this config file in
+> **plaintext** (`0600` / owner-only on macOS & Linux; user-profile ACLs on
+> Windows). Keys are never logged or printed (`marrow settings` shows only
+> `set` / `not set`). To keep secrets off disk, leave the fields blank and use
+> the environment variables instead. Note that `~/.config` can be picked up by
+> backups / dotfile sync. See [SECURITY.md](SECURITY.md); OS-keychain storage
+> is a tracked future enhancement.
 
 When using a Bedrock ARN, the AWS region is extracted automatically from the ARN. When using a model name, the app invokes the `claude` CLI.
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ marrow review <pr> # fetch + classify, then open the TUI
 
 You'll need:
 
-- A **Claude model** -- any one of:
-  - A model name (e.g. `claude-sonnet-4-6`) + an **Anthropic API key** (`ANTHROPIC_API_KEY` or the `anthropic_api_key` setting) -- simplest, no AWS or extra CLI, **or**
-  - A model name with the [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed, **or**
-  - An AWS Bedrock model ARN with AWS credentials configured (env vars, `~/.aws/credentials`, or SSO)
+- An **AI model + key**. The provider is auto-detected from the model name; set the matching API key (config setting or env var):
+  - `claude*` -> **Anthropic** (`anthropic_api_key` / `ANTHROPIC_API_KEY`), or just a model name with the [Claude CLI](https://docs.anthropic.com/en/docs/claude-cli) installed
+  - `gpt*` / `o3*` -> **OpenAI** (`openai_api_key` / `OPENAI_API_KEY`)
+  - `gemini*` -> **Gemini** (`gemini_api_key` / `GEMINI_API_KEY`)
+  - an AWS **Bedrock** model ARN with AWS credentials configured (env vars, `~/.aws/credentials`, or SSO)
+  - **OpenRouter / a local server / any OpenAI-compatible endpoint** -- set `provider=openai-compatible` + `openai_base_url` + `openai_api_key`
 - A **GitHub personal access token** (or `GH_TOKEN` / `GITHUB_TOKEN` environment variable)
 
 ## Configuration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,28 @@ You should receive a response within 72 hours. Once confirmed, a fix will be pri
 This policy covers:
 
 - The Marrow desktop application
-- The `rr` CLI script
+- The `marrow` CLI (and the legacy `rr` script)
 - GitHub API token handling
-- AWS credential handling
+- AI provider API keys (Anthropic, OpenAI, Gemini) and AWS credential handling
+
+## Secret storage
+
+Marrow stores its GitHub token and AI provider API keys (`anthropic_api_key`,
+`openai_api_key`, `gemini_api_key`) in a **plaintext** config file at
+`~/.config/marrow/config` (`%APPDATA%\marrow\config` on Windows).
+
+- On macOS/Linux the file is written with `0600` permissions (owner read/write
+  only). On Windows it inherits your user profile's default ACLs (no extra
+  restriction is applied).
+- Secrets are **never printed** — `marrow settings` reports only `set` /
+  `not set`, and keys are not written to logs or error messages.
+
+This matches common dev tooling (`gh`, `~/.aws/credentials`, `~/.netrc`,
+`.env`). If you'd rather keep secrets off disk entirely, leave the config
+fields blank and use environment variables instead: `GH_TOKEN` /
+`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`.
+
+Be aware that anything under `~/.config` can be swept into backups or dotfile
+sync (Time Machine, cloud backup, a dotfiles repo) — where the key would travel
+in plaintext. Storing secrets in the OS keychain is tracked as a future
+enhancement.

--- a/app/src-tauri/crates/cli/README.md
+++ b/app/src-tauri/crates/cli/README.md
@@ -27,16 +27,21 @@ marrow init          # scaffold ~/.config/marrow/config
 marrow settings      # check resolved config (token source is masked)
 ```
 
-You'll need a GitHub token (in the config, or `GH_TOKEN` / `GITHUB_TOKEN`) and a
-Claude model. Simplest setup — no AWS, no extra CLI:
+You'll need a GitHub token (in the config, or `GH_TOKEN` / `GITHUB_TOKEN`) and an
+AI model + key. The **provider is auto-detected from the model name** — set the
+matching API key (config field or env var):
 
-- set `model` to a model name (e.g. `claude-sonnet-4-6`), and
-- set an Anthropic API key via `anthropic_api_key` in the config or the
-  `ANTHROPIC_API_KEY` env var ([console.anthropic.com](https://console.anthropic.com)).
+| Model name | Provider | Key |
+| --- | --- | --- |
+| `claude*` | Anthropic | `anthropic_api_key` / `ANTHROPIC_API_KEY` (or the `claude` CLI) |
+| `gpt*`, `o3*` | OpenAI | `openai_api_key` / `OPENAI_API_KEY` |
+| `gemini*` | Gemini | `gemini_api_key` / `GEMINI_API_KEY` |
+| `arn:aws:bedrock:…` | AWS Bedrock | AWS credentials + `aws_profile` |
 
-Alternatively, use a model name with the [`claude` CLI](https://docs.anthropic.com/en/docs/claude-cli)
-installed, or an AWS Bedrock model ARN with AWS credentials configured.
-`marrow settings` shows which backend your config resolves to.
+For **OpenRouter, a local server, or any OpenAI-compatible endpoint**, set
+`provider=openai-compatible`, `openai_base_url`, and `openai_api_key`. To
+override auto-detect, set `provider` explicitly. `marrow settings` shows which
+backend your config resolves to.
 
 ## Usage
 

--- a/app/src-tauri/crates/cli/src/main.rs
+++ b/app/src-tauri/crates/cli/src/main.rs
@@ -17,7 +17,8 @@ use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::as_24_bit_terminal_escaped;
 
 use marrow_core::config::{
-    app_config_dir, config_path, load_settings, resolve_anthropic_api_key, resolve_github_token,
+    app_config_dir, config_path, load_settings, resolve_anthropic_api_key, resolve_gemini_api_key,
+    resolve_github_token, resolve_openai_api_key, resolve_openai_base_url,
 };
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
@@ -791,14 +792,23 @@ async fn checks(pr: &str, json: bool) -> Result<(), String> {
 /// A commented starter config written by `marrow init` when none exists.
 const CONFIG_TEMPLATE: &str = "\
 # Marrow config — https://github.com/Besendorfer/marrow
-# GitHub personal access token (optional for public repos; or set GH_TOKEN / GITHUB_TOKEN).
+# (No inline comments on value lines — everything after `=` is the value.)
+# GitHub personal access token (optional for public repos; or GH_TOKEN / GITHUB_TOKEN).
 github_token=
-# AI model. Either a Claude model name (e.g. claude-sonnet-4-6) or an AWS
-# Bedrock model ARN.
+# AI model. The provider is auto-detected from the name: claude* -> Anthropic,
+# gpt*/o3* -> OpenAI, gemini* -> Gemini; or an AWS Bedrock model ARN.
 model=
-# Simplest AI setup: an Anthropic API key (or set ANTHROPIC_API_KEY). Used with
-# a model name; no AWS or `claude` CLI needed. Get one at console.anthropic.com.
+# API key for your model (or the matching env var). Set the one you need:
+#   anthropic_api_key  for claude*  (or ANTHROPIC_API_KEY)
+#   openai_api_key     for gpt*/o*  (or OPENAI_API_KEY)
+#   gemini_api_key     for gemini*  (or GEMINI_API_KEY)
 anthropic_api_key=
+openai_api_key=
+gemini_api_key=
+# Optional: override auto-detect. provider=openai-compatible (e.g. OpenRouter or
+# a local server) then set openai_base_url + openai_api_key.
+provider=
+openai_base_url=
 # AWS profile name (only used with a Bedrock ARN model).
 aws_profile=
 ";
@@ -842,16 +852,24 @@ fn settings_cmd() {
         Some(t) if !t.is_empty() => paint(&format!("set ({}…)", &t.chars().take(4).collect::<String>()), GREEN),
         _ => paint("not set", RED),
     };
-    let anthropic_key = resolve_anthropic_api_key(&s);
-    let anthropic_status = match &anthropic_key {
-        Some(k) if !k.is_empty() => paint("set", GREEN),
+    let key_status = |k: Option<String>| match k {
+        Some(v) if !v.is_empty() => paint("set", GREEN),
         _ => paint("not set", DIM),
     };
     // Which backend a `marrow review` would use with this config.
-    let backend = marrow_core::ai::choose_backend(&s.model, anthropic_key.as_deref());
+    let backend = marrow_core::ai::provider_for_settings(&s);
+    let base_url = resolve_openai_base_url(&s);
     println!("model:          {}", if s.model.is_empty() { paint("(none)", RED) } else { s.model.clone() });
-    println!("github_token:   {token_status}");
-    println!("anthropic_key:  {anthropic_status}");
+    println!("github_token:   {}", token_status);
+    println!("anthropic_key:  {}", key_status(resolve_anthropic_api_key(&s)));
+    println!("openai_key:     {}", key_status(resolve_openai_api_key(&s)));
+    println!("gemini_key:     {}", key_status(resolve_gemini_api_key(&s)));
+    if let Some(url) = &base_url {
+        println!("openai_base:    {url}");
+    }
+    if !s.provider.is_empty() {
+        println!("provider:       {} (override)", s.provider);
+    }
     println!("aws_profile:    {}", if s.aws_profile.is_empty() { paint("(none)", DIM) } else { s.aws_profile.clone() });
     println!(
         "ai backend:     {}",

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -1,7 +1,14 @@
 use crate::bedrock::BedrockClient;
+use crate::types::Settings;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
+
+/// OpenAI's default API base; also the shape OpenRouter / Groq / Together / many
+/// local servers (Ollama, LM Studio) speak.
+const OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+/// Google Gemini's OpenAI-compatible endpoint.
+const GEMINI_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/openai";
 
 /// Extract a JSON array from text that may contain markdown fences or preamble.
 pub fn extract_json_array(text: &str) -> Result<serde_json::Value, String> {
@@ -42,40 +49,84 @@ pub fn extract_json_array(text: &str) -> Result<serde_json::Value, String> {
     ))
 }
 
-/// Which backend a (model, api-key) pair resolves to. Pure decision, separated
-/// from construction so it's testable without hitting AWS/network.
+/// The AI provider a config resolves to. A pure decision, separated from
+/// construction so it's testable without hitting AWS/network.
 #[derive(Debug, PartialEq, Eq)]
-pub enum BackendChoice {
+pub enum Provider {
     Bedrock,
     Anthropic,
     ClaudeCli,
+    OpenAi,
+    Gemini,
+    /// Generic OpenAI-compatible endpoint (OpenRouter, a local server, …).
+    OpenAiCompatible,
 }
 
-impl BackendChoice {
+impl Provider {
     /// Human-readable label for `marrow settings`.
     pub fn label(&self) -> &'static str {
         match self {
-            BackendChoice::Bedrock => "bedrock",
-            BackendChoice::Anthropic => "anthropic-api",
-            BackendChoice::ClaudeCli => "claude-cli",
+            Provider::Bedrock => "bedrock",
+            Provider::Anthropic => "anthropic-api",
+            Provider::ClaudeCli => "claude-cli",
+            Provider::OpenAi => "openai",
+            Provider::Gemini => "gemini",
+            Provider::OpenAiCompatible => "openai-compatible",
         }
     }
 }
 
-/// Decide the backend: an `arn:` model → Bedrock; otherwise an Anthropic API
-/// key (config or env) → the direct Anthropic API; otherwise the `claude` CLI.
-pub fn choose_backend(model: &str, anthropic_key: Option<&str>) -> BackendChoice {
+/// Resolve the provider. An explicit `provider_override` wins; otherwise
+/// auto-detect: `arn:` → Bedrock; a custom base URL → OpenAI-compatible;
+/// `gpt`/`o1`/`o3`/`o4`/`chatgpt` → OpenAI; `gemini` → Gemini; else (claude*/
+/// unknown) → Anthropic if a key is present, else the `claude` CLI.
+pub fn choose_provider(
+    model: &str,
+    provider_override: &str,
+    has_base_url: bool,
+    has_anthropic_key: bool,
+) -> Provider {
+    match provider_override.trim().to_ascii_lowercase().as_str() {
+        "anthropic" => return Provider::Anthropic,
+        "openai" => return Provider::OpenAi,
+        "gemini" | "google" => return Provider::Gemini,
+        "bedrock" => return Provider::Bedrock,
+        "claude-cli" | "claude_cli" | "cli" => return Provider::ClaudeCli,
+        "openai-compatible" | "compatible" | "openrouter" => return Provider::OpenAiCompatible,
+        _ => {} // empty or unrecognized → fall through to auto-detect
+    }
+
     if model.starts_with("arn:") {
-        BackendChoice::Bedrock
-    } else if anthropic_key.is_some_and(|k| !k.is_empty()) {
-        BackendChoice::Anthropic
+        return Provider::Bedrock;
+    }
+    if has_base_url {
+        return Provider::OpenAiCompatible;
+    }
+    let m = model.to_ascii_lowercase();
+    if ["gpt", "o1", "o3", "o4", "chatgpt"].iter().any(|p| m.starts_with(p)) {
+        return Provider::OpenAi;
+    }
+    if m.starts_with("gemini") {
+        return Provider::Gemini;
+    }
+    if has_anthropic_key {
+        Provider::Anthropic
     } else {
-        BackendChoice::ClaudeCli
+        Provider::ClaudeCli
     }
 }
 
-/// AI backend that dispatches to AWS Bedrock (ARN model IDs), the Anthropic API
-/// (a model name + API key), or the `claude` CLI (a model name, no key).
+/// The provider a full `Settings` resolves to (reads keys/base-url from config +
+/// env). Used for construction and for the `marrow settings` display.
+pub fn provider_for_settings(s: &Settings) -> Provider {
+    let has_anthropic = crate::config::resolve_anthropic_api_key(s).is_some();
+    let has_base_url = crate::config::resolve_openai_base_url(s).is_some();
+    choose_provider(&s.model, &s.provider, has_base_url, has_anthropic)
+}
+
+/// AI backend that dispatches to AWS Bedrock, the Anthropic API, an
+/// OpenAI-compatible endpoint (OpenAI / Gemini / OpenRouter / local), or the
+/// `claude` CLI. See [`choose_provider`] for the dispatch rule.
 pub enum AiBackend {
     Bedrock {
         client: BedrockClient,
@@ -85,31 +136,81 @@ pub enum AiBackend {
         api_key: String,
         model: String,
     },
+    OpenAiCompatible {
+        base_url: String,
+        api_key: String,
+        model: String,
+    },
     ClaudeCli {
         model: String,
     },
 }
 
 impl AiBackend {
-    /// Create a backend from the model string and an optional Anthropic API key.
-    /// See [`choose_backend`] for the dispatch rule.
-    pub async fn new(
-        model: &str,
-        aws_profile: &str,
-        anthropic_key: Option<&str>,
-    ) -> Result<Self, String> {
-        match choose_backend(model, anthropic_key) {
-            BackendChoice::Bedrock => {
-                let region = crate::bedrock::region_from_arn(model)?;
-                let client = BedrockClient::new(&region, aws_profile).await?;
-                Ok(AiBackend::Bedrock { client, model_arn: model.to_string() })
+    /// Build a backend from a full `Settings` (resolving keys/base-url from
+    /// config + env).
+    pub async fn from_settings(s: &Settings) -> Result<Self, String> {
+        match provider_for_settings(s) {
+            Provider::Bedrock => {
+                let region = crate::bedrock::region_from_arn(&s.model)?;
+                let client = BedrockClient::new(&region, &s.aws_profile).await?;
+                Ok(AiBackend::Bedrock { client, model_arn: s.model.clone() })
             }
-            BackendChoice::Anthropic => Ok(AiBackend::Anthropic {
-                api_key: anthropic_key.unwrap_or_default().to_string(),
-                model: model.to_string(),
-            }),
-            BackendChoice::ClaudeCli => Ok(AiBackend::ClaudeCli { model: model.to_string() }),
+            Provider::Anthropic => {
+                let api_key = crate::config::resolve_anthropic_api_key(s).ok_or(
+                    "Anthropic provider selected but no API key. Set anthropic_api_key or ANTHROPIC_API_KEY (or install the `claude` CLI).",
+                )?;
+                Ok(AiBackend::Anthropic { api_key, model: s.model.clone() })
+            }
+            Provider::ClaudeCli => Ok(AiBackend::ClaudeCli { model: s.model.clone() }),
+            Provider::OpenAi => Self::openai_compatible(
+                s,
+                OPENAI_BASE_URL,
+                crate::config::resolve_openai_api_key(s),
+                "OpenAI",
+                "OPENAI_API_KEY",
+            ),
+            Provider::Gemini => Self::openai_compatible(
+                s,
+                GEMINI_BASE_URL,
+                crate::config::resolve_gemini_api_key(s),
+                "Gemini",
+                "GEMINI_API_KEY",
+            ),
+            Provider::OpenAiCompatible => {
+                let base_url = crate::config::resolve_openai_base_url(s).ok_or(
+                    "openai-compatible provider selected but no base URL. Set openai_base_url or OPENAI_BASE_URL.",
+                )?;
+                let base_url = base_url.trim_end_matches('/').to_string();
+                Self::openai_compatible_with_base(s, base_url, crate::config::resolve_openai_api_key(s))
+            }
         }
+    }
+
+    /// Helper: an OpenAI-compatible backend at a fixed `base_url` (OpenAI/Gemini).
+    fn openai_compatible(
+        s: &Settings,
+        base_url: &str,
+        api_key: Option<String>,
+        name: &str,
+        env_var: &str,
+    ) -> Result<Self, String> {
+        let api_key = api_key.ok_or_else(|| {
+            format!("{name} provider selected but no API key. Set the key in config or {env_var}.")
+        })?;
+        Ok(AiBackend::OpenAiCompatible { base_url: base_url.to_string(), api_key, model: s.model.clone() })
+    }
+
+    /// Helper: an OpenAI-compatible backend at a custom `base_url`.
+    fn openai_compatible_with_base(
+        s: &Settings,
+        base_url: String,
+        api_key: Option<String>,
+    ) -> Result<Self, String> {
+        let api_key = api_key.ok_or(
+            "openai-compatible provider needs an API key. Set openai_api_key or OPENAI_API_KEY.",
+        )?;
+        Ok(AiBackend::OpenAiCompatible { base_url, api_key, model: s.model.clone() })
     }
 
     /// Send a prompt to the AI and return the text response.
@@ -120,6 +221,9 @@ impl AiBackend {
             }
             AiBackend::Anthropic { api_key, model } => {
                 invoke_anthropic(api_key, model, prompt).await
+            }
+            AiBackend::OpenAiCompatible { base_url, api_key, model } => {
+                invoke_openai_compatible(base_url, api_key, model, prompt).await
             }
             AiBackend::ClaudeCli { model } => invoke_claude_cli(model, prompt).await,
         }
@@ -169,6 +273,48 @@ async fn invoke_anthropic(api_key: &str, model: &str, prompt: &str) -> Result<St
     if out.trim().is_empty() {
         let snippet: String = text.chars().take(500).collect();
         return Err(format!("Anthropic API returned no text content. Raw: {snippet}"));
+    }
+    Ok(out)
+}
+
+/// Call an OpenAI-compatible Chat Completions endpoint (OpenAI, Gemini's compat
+/// endpoint, OpenRouter, local servers). A single user message; `max_tokens` is
+/// omitted for the widest compatibility (incl. reasoning models).
+async fn invoke_openai_compatible(
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    prompt: &str,
+) -> Result<String, String> {
+    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [{ "role": "user", "content": prompt }],
+    });
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("OpenAI-compatible request to {url} failed: {e}"))?;
+
+    let status = resp.status();
+    let text = resp.text().await.map_err(|e| format!("OpenAI-compatible read failed: {e}"))?;
+    if !status.is_success() {
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!(
+            "OpenAI-compatible API error ({status}) from {url}: {snippet}. Check the API key, base URL, and that `{model}` is valid there."
+        ));
+    }
+
+    let json: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| format!("OpenAI-compatible API returned invalid JSON: {e}"))?;
+    let out = json["choices"][0]["message"]["content"].as_str().unwrap_or_default().to_string();
+    if out.trim().is_empty() {
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!("OpenAI-compatible API returned no content. Raw: {snippet}"));
     }
     Ok(out)
 }
@@ -270,23 +416,37 @@ async fn invoke_claude_cli(model: &str, prompt: &str) -> Result<String, String> 
 mod tests {
     use super::*;
 
+    // (model, override, has_base_url, has_anthropic_key)
+    fn pick(model: &str, ov: &str, base: bool, anthropic: bool) -> Provider {
+        choose_provider(model, ov, base, anthropic)
+    }
+
     #[test]
-    fn arn_model_picks_bedrock() {
+    fn auto_detects_provider_from_model_name() {
         let arn = "arn:aws:bedrock:us-east-1:123:inference-profile/x";
-        assert_eq!(choose_backend(arn, None), BackendChoice::Bedrock);
-        // An ARN takes precedence even if an API key is present.
-        assert_eq!(choose_backend(arn, Some("sk-ant-xxx")), BackendChoice::Bedrock);
+        assert_eq!(pick(arn, "", false, true), Provider::Bedrock);
+        assert_eq!(pick("gpt-4o", "", false, false), Provider::OpenAi);
+        assert_eq!(pick("o3-mini", "", false, false), Provider::OpenAi);
+        assert_eq!(pick("gemini-2.0-flash", "", false, false), Provider::Gemini);
+        assert_eq!(pick("claude-sonnet-4-6", "", false, true), Provider::Anthropic);
+        // claude-family / unknown with no key falls back to the CLI.
+        assert_eq!(pick("claude-sonnet-4-6", "", false, false), Provider::ClaudeCli);
     }
 
     #[test]
-    fn model_name_with_key_picks_anthropic() {
-        assert_eq!(choose_backend("claude-sonnet-4-6", Some("sk-ant-xxx")), BackendChoice::Anthropic);
+    fn explicit_provider_overrides_detection() {
+        // A GPT model name forced to the compatible/openrouter path, etc.
+        assert_eq!(pick("gpt-4o", "openrouter", false, false), Provider::OpenAiCompatible);
+        assert_eq!(pick("claude-sonnet-4-6", "openai", false, true), Provider::OpenAi);
+        assert_eq!(pick("anything", "gemini", false, false), Provider::Gemini);
+        // Unrecognized override is ignored → auto-detect.
+        assert_eq!(pick("gpt-4o", "bogus", false, false), Provider::OpenAi);
     }
 
     #[test]
-    fn model_name_without_key_falls_back_to_cli() {
-        assert_eq!(choose_backend("claude-sonnet-4-6", None), BackendChoice::ClaudeCli);
-        // An empty key string is treated as "not set".
-        assert_eq!(choose_backend("claude-sonnet-4-6", Some("")), BackendChoice::ClaudeCli);
+    fn a_custom_base_url_implies_openai_compatible() {
+        assert_eq!(pick("some-local-model", "", true, false), Provider::OpenAiCompatible);
+        // But an ARN still wins over a stray base URL.
+        assert_eq!(pick("arn:aws:bedrock:...", "", true, false), Provider::Bedrock);
     }
 }

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -91,6 +91,10 @@ fn default_settings() -> Settings {
         github_token: String::new(),
         aws_profile: String::new(),
         anthropic_api_key: String::new(),
+        provider: String::new(),
+        openai_api_key: String::new(),
+        gemini_api_key: String::new(),
+        openai_base_url: String::new(),
         filter_older: true,
         filter_team: true,
         view_mode: "split".to_string(),
@@ -115,6 +119,10 @@ pub fn load_settings() -> Settings {
     let mut github_token = String::new();
     let mut aws_profile = String::new();
     let mut anthropic_api_key = String::new();
+    let mut provider = String::new();
+    let mut openai_api_key = String::new();
+    let mut gemini_api_key = String::new();
+    let mut openai_base_url = String::new();
     let mut filter_older = true;
     let mut filter_team = true;
     let mut view_mode = "split".to_string();
@@ -131,6 +139,14 @@ pub fn load_settings() -> Settings {
             aws_profile = val.to_string();
         } else if let Some(val) = line.strip_prefix("anthropic_api_key=") {
             anthropic_api_key = val.to_string();
+        } else if let Some(val) = line.strip_prefix("provider=") {
+            provider = val.to_string();
+        } else if let Some(val) = line.strip_prefix("openai_api_key=") {
+            openai_api_key = val.to_string();
+        } else if let Some(val) = line.strip_prefix("gemini_api_key=") {
+            gemini_api_key = val.to_string();
+        } else if let Some(val) = line.strip_prefix("openai_base_url=") {
+            openai_base_url = val.to_string();
         } else if let Some(val) = line.strip_prefix("filter_older=") {
             filter_older = val == "true";
         } else if let Some(val) = line.strip_prefix("filter_team=") {
@@ -151,6 +167,10 @@ pub fn load_settings() -> Settings {
         github_token,
         aws_profile,
         anthropic_api_key,
+        provider,
+        openai_api_key,
+        gemini_api_key,
+        openai_base_url,
         filter_older,
         filter_team,
         view_mode,
@@ -176,6 +196,18 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     }
     if !settings.anthropic_api_key.is_empty() {
         content.push_str(&format!("anthropic_api_key={}\n", settings.anthropic_api_key));
+    }
+    if !settings.provider.is_empty() {
+        content.push_str(&format!("provider={}\n", settings.provider));
+    }
+    if !settings.openai_api_key.is_empty() {
+        content.push_str(&format!("openai_api_key={}\n", settings.openai_api_key));
+    }
+    if !settings.gemini_api_key.is_empty() {
+        content.push_str(&format!("gemini_api_key={}\n", settings.gemini_api_key));
+    }
+    if !settings.openai_base_url.is_empty() {
+        content.push_str(&format!("openai_base_url={}\n", settings.openai_base_url));
     }
     content.push_str(&format!("filter_older={}\n", settings.filter_older));
     content.push_str(&format!("filter_team={}\n", settings.filter_team));
@@ -222,11 +254,32 @@ pub fn resolve_github_token(settings: &Settings) -> Option<String> {
 /// Resolve the Anthropic API key: config file > ANTHROPIC_API_KEY env. Returns
 /// None if unset (then the backend falls back to the `claude` CLI).
 pub fn resolve_anthropic_api_key(settings: &Settings) -> Option<String> {
-    if !settings.anthropic_api_key.is_empty() {
-        return Some(settings.anthropic_api_key.clone());
+    resolve_secret(&settings.anthropic_api_key, "ANTHROPIC_API_KEY")
+}
+
+/// Resolve the OpenAI (or OpenAI-compatible) API key: config > OPENAI_API_KEY.
+pub fn resolve_openai_api_key(settings: &Settings) -> Option<String> {
+    resolve_secret(&settings.openai_api_key, "OPENAI_API_KEY")
+}
+
+/// Resolve the Gemini API key: config > GEMINI_API_KEY.
+pub fn resolve_gemini_api_key(settings: &Settings) -> Option<String> {
+    resolve_secret(&settings.gemini_api_key, "GEMINI_API_KEY")
+}
+
+/// Resolve the OpenAI-compatible base URL: config > OPENAI_BASE_URL. None = use
+/// the provider's built-in default.
+pub fn resolve_openai_base_url(settings: &Settings) -> Option<String> {
+    resolve_secret(&settings.openai_base_url, "OPENAI_BASE_URL")
+}
+
+/// A config-field-or-env value: the field wins; else the env var if non-empty.
+fn resolve_secret(field: &str, env_var: &str) -> Option<String> {
+    if !field.is_empty() {
+        return Some(field.to_string());
     }
-    match env::var("ANTHROPIC_API_KEY") {
-        Ok(key) if !key.is_empty() => Some(key),
+    match env::var(env_var) {
+        Ok(v) if !v.is_empty() => Some(v),
         _ => None,
     }
 }

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -92,12 +92,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
 
     // Step 3: AI classification
     emit_progress(app, 3, "Classifying files with AI", FetchStatus::Running, None, None);
-    let ai = AiBackend::new(
-        &settings.model,
-        &settings.aws_profile,
-        crate::config::resolve_anthropic_api_key(settings).as_deref(),
-    )
-    .await?;
+    let ai = AiBackend::from_settings(settings).await?;
 
     let classification_prompt =
         build_classification_prompt(&pr_title, &file_list, &full_diff);

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -91,6 +91,21 @@ pub struct Settings {
     /// model name and this/`ANTHROPIC_API_KEY` is set). No AWS/CLI needed.
     #[serde(default)]
     pub anthropic_api_key: String,
+    /// Explicit provider override (anthropic / openai / gemini / bedrock /
+    /// claude-cli / openai-compatible). Empty = auto-detect from the model name.
+    #[serde(default)]
+    pub provider: String,
+    /// OpenAI (and OpenAI-compatible: OpenRouter, local, …) API key.
+    #[serde(default)]
+    pub openai_api_key: String,
+    /// Google Gemini API key (used via Gemini's OpenAI-compatible endpoint).
+    #[serde(default)]
+    pub gemini_api_key: String,
+    /// Base URL for the OpenAI-compatible backend (e.g. OpenRouter or a local
+    /// server). Empty = OpenAI's default. Setting it implies an OpenAI-compatible
+    /// provider unless overridden.
+    #[serde(default)]
+    pub openai_base_url: String,
     #[serde(default = "default_true")]
     pub filter_older: bool,
     #[serde(default = "default_true")]

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -16,6 +16,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [githubToken, setGithubToken] = useState("");
   const [awsProfile, setAwsProfile] = useState("");
   const [anthropicKey, setAnthropicKey] = useState("");
+  const [openaiKey, setOpenaiKey] = useState("");
+  const [geminiKey, setGeminiKey] = useState("");
+  const [provider, setProvider] = useState("");
+  const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -32,6 +36,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setGithubToken(s.github_token || "");
         setAwsProfile(s.aws_profile || "");
         setAnthropicKey(s.anthropic_api_key || "");
+        setOpenaiKey(s.openai_api_key || "");
+        setGeminiKey(s.gemini_api_key || "");
+        setProvider(s.provider || "");
+        setOpenaiBaseUrl(s.openai_base_url || "");
         setCurrentSettings(s);
       });
       setSaved(false);
@@ -48,6 +56,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           github_token: githubToken.trim(),
           aws_profile: awsProfile.trim(),
           anthropic_api_key: anthropicKey.trim(),
+          openai_api_key: openaiKey.trim(),
+          gemini_api_key: geminiKey.trim(),
+          provider: provider.trim(),
+          openai_base_url: openaiBaseUrl.trim(),
           filter_older: currentSettings?.filter_older ?? true,
           filter_team: currentSettings?.filter_team ?? true,
           view_mode: currentSettings?.view_mode ?? "split",
@@ -79,9 +91,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             Claude Model
           </label>
           <p className="settings-hint">
-            A Claude model name (e.g. <code>claude-sonnet-4-6</code>) used with
-            an Anthropic API key or the <code>claude</code> CLI, or a Bedrock
-            ARN for AWS.
+            A model name — the provider is auto-detected:{" "}
+            <code>claude*</code> → Anthropic, <code>gpt*</code>/<code>o3*</code>{" "}
+            → OpenAI, <code>gemini*</code> → Gemini. Or a Bedrock ARN for AWS.
+            Set the matching API key below.
           </p>
           <input
             id="model"
@@ -102,10 +115,9 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
                 Anthropic API Key
               </label>
               <p className="settings-hint">
-                Calls the Anthropic API directly — no AWS or <code>claude</code>{" "}
-                CLI needed. Falls back to <code>ANTHROPIC_API_KEY</code>, then to
-                the <code>claude</code> CLI if unset. Get one at{" "}
-                <code>console.anthropic.com</code>.
+                For <code>claude*</code> models — calls the Anthropic API
+                directly (no AWS or <code>claude</code> CLI needed). Falls back to{" "}
+                <code>ANTHROPIC_API_KEY</code>, then the <code>claude</code> CLI.
               </p>
               <input
                 id="anthropic-key"
@@ -119,6 +131,90 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
                 placeholder="sk-ant-..."
                 spellCheck={false}
                 autoComplete="off"
+              />
+
+              <label className="settings-label" htmlFor="openai-key">
+                OpenAI API Key
+              </label>
+              <p className="settings-hint">
+                For <code>gpt*</code> / <code>o3*</code> models (or{" "}
+                <code>OPENAI_API_KEY</code>). Also used for OpenAI-compatible
+                endpoints below.
+              </p>
+              <input
+                id="openai-key"
+                className="settings-input"
+                type="password"
+                value={openaiKey}
+                onChange={(e) => {
+                  setOpenaiKey(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="sk-..."
+                spellCheck={false}
+                autoComplete="off"
+              />
+
+              <label className="settings-label" htmlFor="gemini-key">
+                Gemini API Key
+              </label>
+              <p className="settings-hint">
+                For <code>gemini*</code> models (or <code>GEMINI_API_KEY</code>).
+              </p>
+              <input
+                id="gemini-key"
+                className="settings-input"
+                type="password"
+                value={geminiKey}
+                onChange={(e) => {
+                  setGeminiKey(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="AIza..."
+                spellCheck={false}
+                autoComplete="off"
+              />
+
+              <label className="settings-label" htmlFor="provider">
+                Provider override
+              </label>
+              <p className="settings-hint">
+                Optional — leave blank to auto-detect from the model name. Set{" "}
+                <code>openai-compatible</code> for OpenRouter or a local server,
+                then fill in the base URL + OpenAI key.
+              </p>
+              <input
+                id="provider"
+                className="settings-input"
+                type="text"
+                value={provider}
+                onChange={(e) => {
+                  setProvider(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="(auto) · openai · gemini · openai-compatible"
+                spellCheck={false}
+              />
+
+              <label className="settings-label" htmlFor="openai-base-url">
+                OpenAI-compatible Base URL
+              </label>
+              <p className="settings-hint">
+                Optional — point at OpenRouter, a local server, etc. (or{" "}
+                <code>OPENAI_BASE_URL</code>). Setting it routes through the
+                OpenAI-compatible backend.
+              </p>
+              <input
+                id="openai-base-url"
+                className="settings-input"
+                type="text"
+                value={openaiBaseUrl}
+                onChange={(e) => {
+                  setOpenaiBaseUrl(e.target.value);
+                  setSaved(false);
+                }}
+                placeholder="https://openrouter.ai/api/v1"
+                spellCheck={false}
               />
             </>
           )}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -148,6 +148,10 @@ export interface Settings {
   github_token: string;
   aws_profile: string;
   anthropic_api_key: string;
+  provider: string;
+  openai_api_key: string;
+  gemini_api_key: string;
+  openai_base_url: string;
   filter_older: boolean;
   filter_team: boolean;
   view_mode: DiffViewMode;


### PR DESCRIPTION
Re-lands **#107**, which was accidentally merged into the `feat/anthropic-api-backend` branch (its stacked base) instead of `main` — so the multi-provider work never reached `main`. #106 (the Anthropic backend) *is* in `main`; this PR carries exactly the remaining two commits:

- `feat(ai): multi-provider via OpenAI-compatible backend (GPT, Gemini, …)`
- `docs(security): document plaintext secret storage + env-var alternative`

Diff against `main` is the expected 10 files only (no #106 content, since that already merged). Content is unchanged from the reviewed #107 — see #107 for the full description, and #108 for the tracked keychain enhancement.

## Recap
- Adds GPT/OpenAI, Gemini, OpenRouter, and any OpenAI-compatible/local endpoint via one shared backend; provider auto-detected from the model name with an explicit `provider` override.
- SECURITY.md + README document the plaintext `0600` secret storage + env-var alternative.

39 Rust tests pass; frontend `tsc` clean; no new clippy warnings (verified on #107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)