### PR TITLE
fix(ci): cross-compile Intel macOS CLI on Apple Silicon (drop macos-13)

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -22,7 +22,9 @@ jobs:
         include:
           - runner: macos-14 # Apple Silicon
             target: aarch64-apple-darwin
-          - runner: macos-13 # Intel
+          # Intel macOS, cross-compiled on Apple Silicon — the macos-13 (Intel)
+          # runner image is scarce/deprecated and queues for a long time.
+          - runner: macos-14
             target: x86_64-apple-darwin
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
## Problem
The first `cli-v0.1.0-alpha.1` run got stuck: **3 of 4 builds succeeded** (macOS arm64, Linux, Windows) but **`x86_64-apple-darwin` on the `macos-13` Intel runner queued indefinitely** (~10+ min, never picked up). The `release` job needs all builds, so the release never got created. GitHub's Intel-macOS image is scarce/deprecated and queues far longer than the others — not a billing or config issue (repo is public).

## Fix
Build `x86_64-apple-darwin` by **cross-compiling on the `macos-14` (Apple Silicon) runner** instead of using `macos-13`. Macs build both arches natively, and the arm64 job already succeeds on `macos-14`, so the toolchain (incl. the ring/aws-lc crypto build) is known-good there. Intel-Mac support is preserved; the deprecated runner dependency is gone.

No other changes — same 4 artifacts, same release flow.

## After merge
Re-tag to re-run: I'll delete + re-push `cli-v0.1.0-alpha.1` at the new `main` so the release builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)