### PR TITLE
docs: move Homebrew to umbrella tap besendorfer/tap

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -89,22 +89,27 @@ Review and **publish the draft release**, then the tarball download links work.
 > longer match the generated formula. Publish the draft as-is, and always take
 > `marrow.rb` from the **same** release the binaries are on.
 
-### Homebrew tap (one-time setup)
+### Homebrew tap
 
-The tap lives in a repo named **`homebrew-marrow`** (Homebrew maps the tap
-`besendorfer/marrow` → the repo `homebrew-marrow`):
+The formula lives in the **umbrella tap** `besendorfer/tap` (repo
+[`Besendorfer/homebrew-tap`](https://github.com/Besendorfer/homebrew-tap)) — one
+tap for all of Besendorfer's tools, so users tap once and `brew install` any of
+them. (The old per-project `homebrew-marrow` tap is deprecated and redirects
+here.)
 
-1. Create the repo `Besendorfer/homebrew-marrow`.
-2. After each CLI release, copy the generated `marrow.rb` from the release into
-   `Formula/marrow.rb` in that repo and push.
-
-Users then install with the short name after a one-time tap:
+After each CLI release, copy the generated `marrow.rb` from the release into
+`Formula/marrow.rb` in the tap repo and push. Users then install with the short
+name after a one-time tap:
 
 ```bash
-brew tap besendorfer/marrow
+brew tap besendorfer/tap
 brew install marrow
-# (or, without tapping first: brew install besendorfer/marrow/marrow)
+# (or, without tapping first: brew install besendorfer/tap/marrow)
 ```
+
+> **Untrusted-tap error?** If a user's Homebrew has `HOMEBREW_REQUIRE_TAP_TRUST`
+> set, it refuses non-official taps until trusted: `brew trust besendorfer/tap`
+> (one-time, per machine). Only homebrew-core formulae are exempt.
 
 > Future automation: have `cli-release.yml` push `marrow.rb` to the tap repo
 > directly (needs a `HOMEBREW_TAP_TOKEN` secret with write access to the tap).

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ Marrow also ships as a terminal app -- the same fetch/classify/review workflow i
 
 ```bash
 # Homebrew (macOS / Linux):
-brew tap besendorfer/marrow
+brew tap besendorfer/tap
 brew install marrow
+# (if Homebrew refuses with an "untrusted tap" error: brew trust besendorfer/tap)
 
 # Prebuilt binary: download a tarball for your platform from the CLI releases
 # (tags starting `cli-v`) and put `marrow` on your PATH.

--- a/app/src-tauri/crates/cli/README.md
+++ b/app/src-tauri/crates/cli/README.md
@@ -15,8 +15,9 @@ built on the shared `marrow-core` crate (no Tauri, no webview).
 
 ```bash
 # Homebrew (macOS / Linux):
-brew tap besendorfer/marrow
+brew tap besendorfer/tap
 brew install marrow
+# (untrusted-tap error? run: brew trust besendorfer/tap)
 
 # Cargo (from crates.io):
 cargo install marrow-cli


### PR DESCRIPTION
Switches the Homebrew docs from the per-project tap `besendorfer/marrow` to the **umbrella tap `besendorfer/tap`** (repo `Besendorfer/homebrew-tap`) — one tap for all of Besendorfer's tools, so users tap once and `brew install` any of them.

Already done outside this PR:
- Created **`Besendorfer/homebrew-tap`** with `Formula/marrow.rb` (the verified `cli-v0.1.0-alpha.1` formula). Validated: `brew tap besendorfer/tap && brew info besendorfer/tap/marrow` resolves.
- Deprecated **`homebrew-marrow`** — formula removed, README redirects to the umbrella tap (repo left in place; not deleted).

This PR (docs only):
- README + CLI README → `brew tap besendorfer/tap`, with an "untrusted-tap" hint.
- PUBLISHING.md → tap section repointed; documents the `HOMEBREW_REQUIRE_TAP_TRUST` → `brew trust besendorfer/tap` gate (the error a user hit on a fresh machine), and notes only homebrew-core is exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)