### PR TITLE
feat(gui): view full file in the desktop diff viewer (#69)

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1477,7 +1477,10 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
         : [],
     [fullFile, file, lang]
   );
-  const canViewFullFile = file.diff_type === "modified" && !!file.head_content;
+  // Offer "view full file" whenever we're showing a partial (hunk) diff and
+  // have the new file content to expand into — this covers modified files and
+  // files rendered as hunks regardless of their add/modify badge.
+  const canViewFullFile = useHunkView && !!file.head_content;
 
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -662,47 +662,65 @@ function buildFullFileLines(content: string, type: "add" | "remove", lang: strin
   }));
 }
 
-// Render the whole new file (head content) as flat diff lines for "view full
-// file" on a modified file: every line is shown, with the lines the diff added
-// marked "add" (tinted) and the rest "context". AI highlights and review
-// threads still map by new-side line number.
-function buildModifiedFullFileLines(
+// Expand a modified file's diff to the WHOLE file: keep the real additions and
+// removals (and their split/unified rendering), and fill in every unchanged
+// line from head_content as context — like GitHub's "expand all". Produces no
+// `@@` headers, so groupIntoHunks yields a single hunk the normal renderer
+// shows without a hunk header.
+function buildFullFileDiffLines(
   headContent: string,
   unifiedDiff: string,
   lang: string | undefined
 ): DiffLine[] {
   if (!headContent) return [];
+  const parsed = parseDiffLines(unifiedDiff, lang);
+  const newLines = headContent.split("\n");
+  const newHtml = highlightLines(headContent, lang);
 
-  // New-side line numbers the diff adds.
-  const added = new Set<number>();
-  let newLine = 0;
-  for (const line of unifiedDiff.split("\n")) {
-    if (line.startsWith("@@")) {
-      const m = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
-      if (m) newLine = parseInt(m[1], 10);
-    } else if (line.startsWith("+")) {
-      added.add(newLine);
-      newLine++;
-    } else if (line.startsWith("-") || line.startsWith("\\")) {
-      // old-side only / "No newline" marker — no new-side advance
+  const contextLine = (newLineNum: number, oldLineNum: number): DiffLine => ({
+    type: "context",
+    content: newLines[newLineNum - 1] ?? "",
+    html: newHtml[newLineNum - 1] ?? escapeHtml(newLines[newLineNum - 1] ?? ""),
+    oldLineNum,
+    newLineNum,
+  });
+
+  const out: DiffLine[] = [];
+  let nextNew = 1; // next unchanged new-side line to emit
+  let nextOld = 1; // its old-side counterpart (they advance together in gaps)
+
+  for (const e of parsed) {
+    if (e.type === "header") {
+      const m = e.content.match(/@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      const newStart = m ? parseInt(m[2], 10) : nextNew;
+      while (nextNew < newStart) {
+        out.push(contextLine(nextNew, nextOld));
+        nextNew++;
+        nextOld++;
+      }
+      continue; // don't emit the @@ header itself
+    }
+    out.push(e);
+    if (e.type === "add") {
+      nextNew = (e.newLineNum ?? nextNew) + 1;
+    } else if (e.type === "remove") {
+      nextOld = (e.oldLineNum ?? nextOld) + 1;
     } else {
-      newLine++; // context
+      nextNew = (e.newLineNum ?? nextNew) + 1;
+      nextOld = (e.oldLineNum ?? nextOld) + 1;
     }
   }
 
-  const lines = headContent.split("\n");
-  const htmlLines = highlightLines(headContent, lang);
-  return lines.map((line, idx) => {
-    const newLineNum = idx + 1;
-    return {
-      type: added.has(newLineNum) ? "add" : "context",
-      content: line,
-      html: htmlLines[idx] ?? escapeHtml(line),
-      oldLineNum: null,
-      newLineNum,
-    } as DiffLine;
-  });
+  while (nextNew <= newLines.length) {
+    out.push(contextLine(nextNew, nextOld));
+    nextNew++;
+    nextOld++;
+  }
+  return out;
 }
+
+// Shared empty set for "nothing collapsed" (full-file view never collapses).
+const NO_COLLAPSED: Set<number> = new Set();
 
 const LINE_TINT_THRESHOLD = 50;
 
@@ -1449,9 +1467,14 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
     };
   }, [file]);
 
-  // Whole-file lines, built lazily only when the "view full file" toggle is on.
-  const fullFileLines = useMemo(
-    () => (fullFile ? buildModifiedFullFileLines(file.head_content, file.unified_diff, lang) : []),
+  // Whole-file diff (real adds/removes + all context), built lazily only when
+  // the "view full file" toggle is on, then grouped into one hunk so it renders
+  // through the normal split/unified views.
+  const fullFileHunks = useMemo(
+    () =>
+      fullFile
+        ? groupIntoHunks(buildFullFileDiffLines(file.head_content, file.unified_diff, lang), [])
+        : [],
     [fullFile, file, lang]
   );
   const canViewFullFile = file.diff_type === "modified" && !!file.head_content;
@@ -1755,12 +1778,12 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
         </div>
       )}
       <div className="diff-content" ref={diffContentRef}>
-        {!fullFile && useHunkView ? (
+        {fullFile || useHunkView ? (
           viewMode === "unified" || file.diff_type !== "modified" ? (
             <UnifiedView
-              hunks={hunks}
+              hunks={fullFile ? fullFileHunks : hunks}
               highlights={highlights}
-              collapsedHunks={collapsedHunks}
+              collapsedHunks={fullFile ? NO_COLLAPSED : collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
               commentingOn={commentingOn}
@@ -1780,9 +1803,9 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
             />
           ) : (
             <SplitView
-              hunks={hunks}
+              hunks={fullFile ? fullFileHunks : hunks}
               highlights={highlights}
-              collapsedHunks={collapsedHunks}
+              collapsedHunks={fullFile ? NO_COLLAPSED : collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
               commentingOn={commentingOn}
@@ -1810,7 +1833,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={fullFile ? fullFileLines : diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
+              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
             </tbody>
           </table>
         )}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1482,6 +1482,22 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
   // files rendered as hunks regardless of their add/modify badge.
   const canViewFullFile = useHunkView && !!file.head_content;
 
+  // A genuinely whole-new or whole-deleted file (no context lines, only one
+  // side) can't be shown side-by-side, so it forces unified. Everything else —
+  // including files mislabeled "added"/"removed" that are really modifications —
+  // respects the split/unified toggle. Decide from content, not `diff_type`.
+  const oneSidedFile = useMemo(() => {
+    let ctx = false;
+    let add = false;
+    let rem = false;
+    for (const l of diffLines) {
+      if (l.type === "context") ctx = true;
+      else if (l.type === "add") add = true;
+      else if (l.type === "remove") rem = true;
+    }
+    return !ctx && add !== rem;
+  }, [diffLines]);
+
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)
   const [collapsedHunks, setCollapsedHunks] = useState<Set<number>>(() => {
@@ -1782,7 +1798,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
       )}
       <div className="diff-content" ref={diffContentRef}>
         {fullFile || useHunkView ? (
-          viewMode === "unified" || file.diff_type !== "modified" ? (
+          viewMode === "unified" || oneSidedFile ? (
             <UnifiedView
               hunks={fullFile ? fullFileHunks : hunks}
               highlights={highlights}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -662,6 +662,48 @@ function buildFullFileLines(content: string, type: "add" | "remove", lang: strin
   }));
 }
 
+// Render the whole new file (head content) as flat diff lines for "view full
+// file" on a modified file: every line is shown, with the lines the diff added
+// marked "add" (tinted) and the rest "context". AI highlights and review
+// threads still map by new-side line number.
+function buildModifiedFullFileLines(
+  headContent: string,
+  unifiedDiff: string,
+  lang: string | undefined
+): DiffLine[] {
+  if (!headContent) return [];
+
+  // New-side line numbers the diff adds.
+  const added = new Set<number>();
+  let newLine = 0;
+  for (const line of unifiedDiff.split("\n")) {
+    if (line.startsWith("@@")) {
+      const m = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (m) newLine = parseInt(m[1], 10);
+    } else if (line.startsWith("+")) {
+      added.add(newLine);
+      newLine++;
+    } else if (line.startsWith("-") || line.startsWith("\\")) {
+      // old-side only / "No newline" marker — no new-side advance
+    } else {
+      newLine++; // context
+    }
+  }
+
+  const lines = headContent.split("\n");
+  const htmlLines = highlightLines(headContent, lang);
+  return lines.map((line, idx) => {
+    const newLineNum = idx + 1;
+    return {
+      type: added.has(newLineNum) ? "add" : "context",
+      content: line,
+      html: htmlLines[idx] ?? escapeHtml(line),
+      oldLineNum: null,
+      newLineNum,
+    } as DiffLine;
+  });
+}
+
 const LINE_TINT_THRESHOLD = 50;
 
 function getHighlightForLine(
@@ -1304,6 +1346,8 @@ function SplitView({
 export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
+  // "View full file" toggle (modified files). Resets per file via the key prop.
+  const [fullFile, setFullFile] = useState(false);
   const diffContentRef = useRef<HTMLDivElement>(null);
 
   function handleLineMouseDown(line: number, side: "LEFT" | "RIGHT") {
@@ -1404,6 +1448,13 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
       useHunkView: false,
     };
   }, [file]);
+
+  // Whole-file lines, built lazily only when the "view full file" toggle is on.
+  const fullFileLines = useMemo(
+    () => (fullFile ? buildModifiedFullFileLines(file.head_content, file.unified_diff, lang) : []),
+    [fullFile, file, lang]
+  );
+  const canViewFullFile = file.diff_type === "modified" && !!file.head_content;
 
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)
@@ -1644,12 +1695,21 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
             {highlights.length} AI {highlights.length === 1 ? "note" : "notes"}
           </span>
         )}
+        {canViewFullFile && (
+          <button
+            className="hunk-toggle-all"
+            onClick={() => setFullFile((v) => !v)}
+            title={fullFile ? "Show only the changed hunks" : "Show the whole file with changes highlighted"}
+          >
+            {fullFile ? "View diff" : "View full file"}
+          </button>
+        )}
         {showHunkSignificance && highHunkCount > 0 && (
           <span className="hunk-high-summary">
             {highHunkCount} high-significance {highHunkCount === 1 ? "hunk" : "hunks"}
           </span>
         )}
-        {collapsedCount > 0 && (
+        {!fullFile && collapsedCount > 0 && (
           <>
             <span className="hunk-collapse-summary">
               {collapsedCount} {collapsedCount === 1 ? "hunk" : "hunks"} collapsed
@@ -1659,7 +1719,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
             </button>
           </>
         )}
-        {showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && (
+        {!fullFile && showHunkSignificance && collapsedCount === 0 && hunks.length > 1 && (
           <button className="hunk-toggle-all" onClick={collapseAll}>
             Collapse All
           </button>
@@ -1695,7 +1755,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
         </div>
       )}
       <div className="diff-content" ref={diffContentRef}>
-        {useHunkView ? (
+        {!fullFile && useHunkView ? (
           viewMode === "unified" || file.diff_type !== "modified" ? (
             <UnifiedView
               hunks={hunks}
@@ -1750,7 +1810,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
+              <UnifiedHunkLines lines={fullFile ? fullFileLines : diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
             </tbody>
           </table>
         )}


### PR DESCRIPTION
Closes #69. Adds a **"View full file"** toggle to the desktop diff viewer for modified files — the GUI counterpart to the TUI's full-file view (#102).

## What
A per-file **View full file / View diff** button in the diff header. When on, the whole new file (`head_content`) renders with:
- the diff's **added lines tinted**, the rest as context,
- **AI annotations** and **inline review threads** still mapped by line,
- **commenting on any line** (changed or not) — useful for leaving context-aware notes.

Toggle back returns to the hunk view. State resets per file (existing `key` prop).

## How (frontend-only, low-risk)
- The issue assumed the full content "is not currently present in the manifest" — that's **outdated**: `FileDiff.head_content` is already populated by the fetch pipeline and typed in the frontend. No new Tauri command/fetch.
- New `buildModifiedFullFileLines()` parses the unified diff for the added new-side line numbers, then renders every `head_content` line as a `DiffLine` (`"add"` for added, `"context"` otherwise).
- Routes through the **existing flat-render path** (`UnifiedHunkLines`) that added/removed files already use — so highlights/threads/comment-on-line come for free. Built lazily (only when toggled on).
- Full-file always renders **unified** (a side-by-side "whole file" doesn't add much, and matches the TUI); hunk-collapse controls hide while it's on.

## Testing
- `tsc --noEmit` clean; `bun run build` succeeds.
- ⚠️ Visual behavior in the running Tauri app wasn't exercised here — worth a quick click-through (toggle on a modified file: full content shows, added lines tinted, AI notes + threads still appear, comment-on-line works, toggle off restores hunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)