### PR TITLE
fix: classify logic-bearing UI files as relevant; show NOT_RELEVANT on demand

### DIFF
--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -89,7 +89,9 @@ struct App<'a> {
     mode: Mode,
     search_input: String,
     rows: Vec<Row>,
-    filter_low: bool,
+    /// Show NOT_RELEVANT files in the sidebar. Off by default (the AI deemed them
+    /// noise — tests, generated, presentational); `t` reveals them on demand.
+    show_irrelevant: bool,
     /// The pending review verb while typing its message (ReviewInput mode).
     review_event: &'static str,
     review_input: String,
@@ -152,7 +154,7 @@ impl<'a> App<'a> {
             mode: Mode::Normal,
             search_input: String::new(),
             rows: Vec::new(),
-            filter_low: false,
+            show_irrelevant: false,
             review_event: "",
             review_input: String::new(),
             pending_comment: None,
@@ -206,11 +208,11 @@ impl<'a> App<'a> {
 
     /// Build the sidebar: an overview header, then files grouped by AI
     /// change-group (risk-ordered within), then an "Other" section for any
-    /// ungrouped files. Falls back to a flat list with no groups. `filter_low`
-    /// hides low-risk files.
+    /// ungrouped files. Falls back to a flat list with no groups. Unless
+    /// `show_irrelevant` is set, NOT_RELEVANT files are hidden.
     fn build_rows(&self) -> Vec<Row> {
-        let filter_low = self.filter_low;
-        let keep = |f: &FileDiff| !filter_low || f.risk_level != "low";
+        let show_irrelevant = self.show_irrelevant;
+        let keep = |f: &FileDiff| show_irrelevant || f.classification == "RELEVANT";
         let mut rows = vec![Row::Overview, Row::Threads];
 
         if self.manifest.change_groups.is_empty() {
@@ -269,8 +271,13 @@ impl<'a> App<'a> {
     }
 
     fn toggle_filter(&mut self) {
-        self.filter_low = !self.filter_low;
+        self.show_irrelevant = !self.show_irrelevant;
         self.rebuild_rows();
+    }
+
+    /// Count of changed files the AI classified NOT_RELEVANT (hidden by default).
+    fn irrelevant_count(&self) -> usize {
+        self.files.iter().filter(|f| f.classification != "RELEVANT").count()
     }
 
     /// Move the selection to the next/previous selectable row, skipping group
@@ -302,26 +309,34 @@ impl<'a> App<'a> {
     /// Overview content: risk counts, the PR summary, and change-group blurbs.
     fn build_overview(&self) -> Rendered {
         let mut lines: Vec<Line> = Vec::new();
+        // Counts cover the relevant files (the review set); NOT_RELEVANT files are
+        // reported separately so the risk breakdown isn't skewed by noise.
+        let relevant: Vec<&&FileDiff> =
+            self.files.iter().filter(|f| f.classification == "RELEVANT").collect();
         let (mut hi, mut me, mut lo) = (0u32, 0u32, 0u32);
-        for f in &self.files {
+        for f in &relevant {
             match f.risk_level.as_str() {
                 "high" => hi += 1,
                 "low" => lo += 1,
                 _ => me += 1,
             }
         }
+        let mut header = format!("{} files · {hi} high · {me} med · {lo} low", relevant.len());
+        let nr = self.irrelevant_count();
+        if nr > 0 {
+            header.push_str(&format!("  ·  {nr} not relevant (press t)"));
+        }
         lines.push(Line::from(Span::styled(
-            format!("{} files · {hi} high · {me} med · {lo} low", self.files.len()),
+            header,
             Style::default().add_modifier(Modifier::BOLD),
         )));
-        let viewed = self
-            .files
+        let viewed = relevant
             .iter()
             .filter(|f| self.viewed_status(&f.path, &f.diff_hash) == ViewedStatus::Viewed)
             .count();
         lines.push(Line::from(Span::styled(
-            format!("{viewed}/{} viewed", self.files.len()),
-            Style::default().fg(if viewed == self.files.len() && viewed > 0 {
+            format!("{viewed}/{} viewed", relevant.len()),
+            Style::default().fg(if viewed == relevant.len() && viewed > 0 {
                 Color::Green
             } else {
                 Color::DarkGray
@@ -1198,11 +1213,18 @@ impl<'a> App<'a> {
                 Row::File(i) => {
                     let file = self.files[*i];
                     // Risk is kept as the filename color (no HIGH/med/low text);
-                    // churn shows additions/deletions.
-                    let color = match file.risk_level.as_str() {
-                        "high" => Color::Red,
-                        "low" => Color::Green,
-                        _ => Color::Yellow,
+                    // churn shows additions/deletions. NOT_RELEVANT files (only
+                    // shown when the filter is toggled on) are gray, since their
+                    // risk level is just a placeholder.
+                    let relevant = file.classification == "RELEVANT";
+                    let color = if !relevant {
+                        Color::DarkGray
+                    } else {
+                        match file.risk_level.as_str() {
+                            "high" => Color::Red,
+                            "low" => Color::Green,
+                            _ => Color::Yellow,
+                        }
                     };
                     // A leading glyph marks viewed (✓) / stale (~); viewed names
                     // dim so unreviewed files stand out. The glyph keeps the same
@@ -1214,7 +1236,7 @@ impl<'a> App<'a> {
                         ViewedStatus::Unviewed => ("  ", color),
                     };
                     let mut name_style = Style::default().fg(color);
-                    if status == ViewedStatus::Viewed {
+                    if status == ViewedStatus::Viewed || !relevant {
                         name_style = name_style.add_modifier(Modifier::DIM);
                     }
                     ListItem::new(Line::from(vec![
@@ -1229,7 +1251,14 @@ impl<'a> App<'a> {
             })
             .collect();
 
-        let title = if self.filter_low { "Files (relevant)" } else { "Files" };
+        let nr = self.irrelevant_count();
+        let title = if self.show_irrelevant {
+            "Files (all)".to_string()
+        } else if nr > 0 {
+            format!("Files ({nr} not relevant hidden)")
+        } else {
+            "Files".to_string()
+        };
         let list = List::new(items)
             .block(Block::default().borders(Borders::RIGHT).title(title))
             .highlight_style(Style::default().bg(CURSOR_BG))
@@ -1773,7 +1802,7 @@ fn render_help(f: &mut Frame) {
         Line::from("  a            toggle full file / diff"),
         Line::from("  z / Z        fold hunk / all hunks"),
         Line::from("  /            search in file"),
-        Line::from("  t            filter low-risk"),
+        Line::from("  t            show/hide not-relevant"),
         Line::from(""),
         head("Actions"),
         Line::from("  c            comment on the cursor line"),
@@ -1957,8 +1986,14 @@ mod tests {
     }
 
     #[test]
-    fn grouping_and_low_risk_filter() {
+    fn grouping_and_relevance_filter() {
         let mut m = manifest();
+        // low.go is noise: hidden by default, revealed by the filter.
+        for f in &mut m.files {
+            if f.path == "pkg/low.go" {
+                f.classification = "NOT_RELEVANT".into();
+            }
+        }
         m.change_groups = vec![ChangeGroup {
             label: "Core".into(),
             description: "core logic".into(),
@@ -1967,13 +2002,13 @@ mod tests {
         let mut app = App::new(&m);
         let groups = |a: &App| a.rows.iter().filter(|r| matches!(r, Row::Group(_))).count();
         let files = |a: &App| a.rows.iter().filter(|r| matches!(r, Row::File(_))).count();
-        // Core (high.go) + Other (low.go).
-        assert_eq!(groups(&app), 2);
-        assert_eq!(files(&app), 2);
-        // Filtering low-risk drops low.go and its now-empty "Other" section.
-        app.toggle_filter();
+        // Default hides NOT_RELEVANT: only high.go in its Core group.
         assert_eq!(files(&app), 1);
         assert_eq!(groups(&app), 1);
+        // Toggling reveals low.go under an "Other" section.
+        app.toggle_filter();
+        assert_eq!(files(&app), 2);
+        assert_eq!(groups(&app), 2);
     }
 
     #[test]
@@ -2066,7 +2101,7 @@ mod tests {
         app.mode = Mode::Help;
         let out = render_to_string(&mut app, 100, 30);
         assert!(out.contains("Keys"), "help title missing");
-        assert!(out.contains("filter low-risk"), "help body missing");
+        assert!(out.contains("not-relevant"), "help body missing");
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -90,13 +90,6 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         .map(|f| (f.filename.clone(), (f.additions, f.deletions)))
         .collect();
 
-    // GitHub's authoritative per-file status (added/removed/modified/renamed/…),
-    // used to classify diff_type instead of guessing from content emptiness.
-    let status_by_path: HashMap<String, String> = pr_files
-        .iter()
-        .map(|f| (f.filename.clone(), f.status.clone()))
-        .collect();
-
     // Step 3: AI classification
     emit_progress(app, 3, "Classifying files with AI", FetchStatus::Running, None, None);
     let ai = AiBackend::from_settings(settings).await?;
@@ -116,128 +109,133 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         .filter(|c| c.classification == "RELEVANT")
         .collect();
 
-    if relevant.is_empty() {
-        return Ok(ReviewManifest {
-            pr_title,
-            pr_url,
-            pr_number,
-            base_ref,
-            head_ref,
-            base_sha,
-            head_sha,
-            summary: String::new(),
-            change_groups: vec![],
-            files: vec![],
-        });
-    }
-
-    // Step 4: AI highlight analysis + summary + grouping (parallel)
-    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
+    // NOT_RELEVANT files still go into the manifest (the UIs surface them behind
+    // a relevance filter); only the analysis below is scoped to the relevant
+    // subset, and it's skipped entirely when nothing is relevant — so a PR whose
+    // changes are all classified NOT_RELEVANT still lists its files instead of
+    // coming back empty.
     let per_file_diff_map = build_per_file_diff_map(&full_diff);
-    let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
-    let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
-
-    let summary_prompt = build_summary_prompt(&pr_title, &relevant);
-    let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
-
-    let mut ai_stream: FuturesUnordered<_> = [
-        ("highlights", ai.invoke(&highlight_prompt)),
-        ("summary", ai.invoke(&summary_prompt)),
-        ("grouping", ai.invoke(&grouping_prompt)),
-    ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
-
-    let mut highlights_raw = Err("not started".to_string());
-    let mut summary_raw = Err("not started".to_string());
-    let mut grouping_raw = Err("not started".to_string());
-    let mut ai_done: u32 = 0;
-    while let Some((name, result)) = ai_stream.next().await {
-        ai_done += 1;
-        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
-        match name {
-            "highlights" => highlights_raw = result,
-            "summary" => summary_raw = result,
-            "grouping" => grouping_raw = result,
-            _ => {}
-        }
-    }
-    emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Done, None, None);
-
-    let highlights_raw = highlights_raw.unwrap_or_else(|_| "[]".to_string());
-
-    let highlights_json = extract_json_array(&highlights_raw).unwrap_or_else(|_| {
-        serde_json::Value::Array(vec![])
-    });
-
-    let highlight_results: Vec<HighlightResult> =
-        serde_json::from_value(highlights_json).unwrap_or_default();
-
-    let summary = summary_raw.unwrap_or_default();
-
-    let change_groups: Vec<ChangeGroup> = grouping_raw
-        .ok()
-        .and_then(|raw| extract_json_array(&raw).ok())
-        .and_then(|json| serde_json::from_value(json).ok())
-        .unwrap_or_default();
-
-    // Index highlights by file path
     let mut highlights_by_path: HashMap<String, Vec<Highlight>> = HashMap::new();
-    for h in highlight_results {
-        highlights_by_path
-            .entry(h.path.clone())
-            .or_default()
-            .push(Highlight {
-                start_line: h.start_line,
-                end_line: h.end_line,
-                severity: h.severity,
-                comment: h.comment,
-            });
-    }
+    let mut summary = String::new();
+    let mut change_groups: Vec<ChangeGroup> = Vec::new();
+    // Fetched full contents (base, head), keyed by path — only relevant files,
+    // so NOT_RELEVANT files show their diff but not a full-file view.
+    let mut content_by_path: HashMap<String, (String, String)> = HashMap::new();
 
-    // Step 5: Fetch file contents for all relevant files concurrently
-    let files_total = relevant.len() as u32;
-    emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((0, files_total)));
-    let content_futures: Vec<_> = relevant
-        .iter()
-        .map(|f| {
-            let path = f.path.clone();
-            let owner = parsed.owner.clone();
-            let repo = parsed.repo.clone();
-            let base = base_sha.clone();
-            let head = head_sha.clone();
-            let gh = &github;
-            async move {
-                let (base_content, head_content) = tokio::join!(
-                    gh.get_file_content(&owner, &repo, &path, &base),
-                    gh.get_file_content(&owner, &repo, &path, &head),
-                );
-                (path, base_content, head_content)
+    if !relevant.is_empty() {
+        // Step 4: AI highlight analysis + summary + grouping (parallel)
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
+        let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
+        let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
+
+        let summary_prompt = build_summary_prompt(&pr_title, &relevant);
+        let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
+
+        let mut ai_stream: FuturesUnordered<_> = [
+            ("highlights", ai.invoke(&highlight_prompt)),
+            ("summary", ai.invoke(&summary_prompt)),
+            ("grouping", ai.invoke(&grouping_prompt)),
+        ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
+
+        let mut highlights_raw = Err("not started".to_string());
+        let mut summary_raw = Err("not started".to_string());
+        let mut grouping_raw = Err("not started".to_string());
+        let mut ai_done: u32 = 0;
+        while let Some((name, result)) = ai_stream.next().await {
+            ai_done += 1;
+            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
+            match name {
+                "highlights" => highlights_raw = result,
+                "summary" => summary_raw = result,
+                "grouping" => grouping_raw = result,
+                _ => {}
             }
-        })
-        .collect();
+        }
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Done, None, None);
 
-    let mut stream: FuturesUnordered<_> = content_futures.into_iter().collect();
-    let mut contents = Vec::with_capacity(files_total as usize);
-    let mut files_done: u32 = 0;
-    while let Some(result) = stream.next().await {
-        files_done += 1;
-        emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((files_done, files_total)));
-        contents.push(result);
+        let highlights_raw = highlights_raw.unwrap_or_else(|_| "[]".to_string());
+
+        let highlights_json = extract_json_array(&highlights_raw).unwrap_or_else(|_| {
+            serde_json::Value::Array(vec![])
+        });
+
+        let highlight_results: Vec<HighlightResult> =
+            serde_json::from_value(highlights_json).unwrap_or_default();
+
+        summary = summary_raw.unwrap_or_default();
+
+        change_groups = grouping_raw
+            .ok()
+            .and_then(|raw| extract_json_array(&raw).ok())
+            .and_then(|json| serde_json::from_value(json).ok())
+            .unwrap_or_default();
+
+        // Index highlights by file path
+        for h in highlight_results {
+            highlights_by_path
+                .entry(h.path.clone())
+                .or_default()
+                .push(Highlight {
+                    start_line: h.start_line,
+                    end_line: h.end_line,
+                    severity: h.severity,
+                    comment: h.comment,
+                });
+        }
+
+        // Step 5: Fetch file contents for all relevant files concurrently
+        let files_total = relevant.len() as u32;
+        emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((0, files_total)));
+        let content_futures: Vec<_> = relevant
+            .iter()
+            .map(|f| {
+                let path = f.path.clone();
+                let owner = parsed.owner.clone();
+                let repo = parsed.repo.clone();
+                let base = base_sha.clone();
+                let head = head_sha.clone();
+                let gh = &github;
+                async move {
+                    let (base_content, head_content) = tokio::join!(
+                        gh.get_file_content(&owner, &repo, &path, &base),
+                        gh.get_file_content(&owner, &repo, &path, &head),
+                    );
+                    (path, base_content, head_content)
+                }
+            })
+            .collect();
+
+        let mut stream: FuturesUnordered<_> = content_futures.into_iter().collect();
+        let mut files_done: u32 = 0;
+        while let Some((path, base_result, head_result)) = stream.next().await {
+            files_done += 1;
+            emit_progress(app, 5, "Fetching file contents", FetchStatus::Running, None, Some((files_done, files_total)));
+            content_by_path.insert(
+                path,
+                (
+                    base_result.as_deref().unwrap_or("").to_string(),
+                    head_result.as_deref().unwrap_or("").to_string(),
+                ),
+            );
+        }
+        emit_progress(app, 5, "Fetching file contents", FetchStatus::Done, None, None);
     }
-    emit_progress(app, 5, "Fetching file contents", FetchStatus::Done, None, None);
 
     // Step 6: Build the manifest
     emit_progress(app, 6, "Building review manifest", FetchStatus::Running, None, None);
     let mut file_diffs = Vec::new();
 
-    for (path, base_result, head_result) in &contents {
-        let base_content = base_result.as_deref().unwrap_or("").to_string();
-        let head_content = head_result.as_deref().unwrap_or("").to_string();
+    for pr_file in &pr_files {
+        let path = &pr_file.filename;
+        // Full content is only fetched for relevant files; others show their
+        // diff but fall back to "(full file unavailable)" in the viewer.
+        let (base_content, head_content) = content_by_path.get(path).cloned().unwrap_or_default();
 
-        // Classify from GitHub's status. Inferring from content emptiness is
-        // wrong for renames (the new path 404s at the base SHA → empty base)
-        // and for failed/oversized base fetches, which all look "added".
+        // GitHub's per-file status is authoritative for diff_type; content
+        // emptiness is only a fallback — and NOT_RELEVANT files have no fetched
+        // content, so the status is what we rely on for them.
         let diff_type = classify_diff_type(
-            status_by_path.get(path.as_str()).map(|s| s.as_str()),
+            Some(pr_file.status.as_str()),
             base_content.is_empty(),
             head_content.is_empty(),
         );
@@ -256,10 +254,22 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
             })
             .unwrap_or_default();
 
-        let classification = classifications
+        // The AI's classification, or a NOT_RELEVANT default for any changed
+        // file the classifier omitted (so nothing silently disappears).
+        let (classification, reason, category, risk_level) = classifications
             .iter()
             .find(|c| c.path == *path)
-            .unwrap();
+            .map(|c| {
+                (
+                    c.classification.clone(),
+                    c.reason.clone(),
+                    c.category.clone(),
+                    c.risk_level.clone(),
+                )
+            })
+            .unwrap_or_else(|| {
+                ("NOT_RELEVANT".to_string(), "not classified".to_string(), "N/A".to_string(), "low".to_string())
+            });
 
         let (additions, deletions) = file_stats.get(path).copied().unwrap_or((0, 0));
 
@@ -278,10 +288,10 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
 
         file_diffs.push(FileDiff {
             path: path.clone(),
-            classification: classification.classification.clone(),
-            reason: classification.reason.clone(),
-            category: classification.category.clone(),
-            risk_level: classification.risk_level.clone(),
+            classification,
+            reason,
+            category,
+            risk_level,
             diff_type: diff_type.to_string(),
             base_content,
             head_content,

--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -12,7 +12,7 @@ RELEVANT files include:
 - Shared libraries and utilities used by business logic
 
 NOT_RELEVANT files include:
-- UI components (React components that render JSX/HTML, CSS, Tailwind config, styles, layouts, pages that are purely presentational)
+- Purely presentational UI: web markup and styling only (React/Vue/Svelte components that just render JSX/HTML, CSS/SCSS, Tailwind config, stylesheets, layouts/pages with no logic). This exclusion is about markup and styling — NOT about anything that "deals with display". A file that contains real logic is RELEVANT even if it ultimately drives a UI.
 - Test files — ANY file matching these patterns is NOT_RELEVANT regardless of content: *.test.*, *.spec.*, __tests__/, test/, tests/, pact/, e2e/, **/e2e/**, *.e2e.*, playwright/*, cypress/*
 - Documentation (*.md, docs/, README)
 - IDE/editor config (.vscode/, .idea/)
@@ -29,6 +29,7 @@ IMPORTANT EDGE CASES:
 - tRPC router files ARE relevant
 - Hook files that contain business logic (data fetching, state management with business rules) ARE relevant
 - Hook files that are purely UI state (animations, UI toggles) are NOT relevant
+- Rendering/view code that contains non-trivial logic IS relevant — e.g. terminal/TUI rendering, view-models, editors, or components with parsing, state machines, cursor/scroll/layout math, or data transformation. Only the purely-markup/styling case above is NOT_RELEVANT; when a "UI" file carries substantial logic, classify it RELEVANT.
 - Shared utility libraries: classify based on whether they contain business logic or UI helpers
 - Page object files, test helpers, test fixtures, and test utilities are NOT_RELEVANT
 

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -176,8 +176,11 @@ function FileItem({
 }) {
   const isCritical =
     file.risk_level === "critical" || file.risk_level === "high";
+  const notRelevant = file.classification === "NOT_RELEVANT";
   return (
-    <div className={`file-item-wrapper ${isCritical ? "file-critical" : ""}`}>
+    <div
+      className={`file-item-wrapper ${isCritical ? "file-critical" : ""} ${notRelevant ? "file-not-relevant" : ""}`}
+    >
       <button
         className={`file-item ${selectedFile?.path === file.path ? "selected" : ""} ${isViewed ? "viewed" : ""} ${isStale ? "stale" : ""}`}
         onClick={() => onSelectFile(file)}
@@ -442,19 +445,29 @@ export function FileSidebar({
   };
 
   const [hideViewed, setHideViewed] = useState(true);
+  // NOT_RELEVANT files (tests, generated, presentational — judged noise by the
+  // AI) are hidden by default; this toggle reveals them on demand.
+  const [hideNotRelevant, setHideNotRelevant] = useState(true);
+
+  const notRelevantCount = useMemo(
+    () => files.filter((f) => f.classification === "NOT_RELEVANT").length,
+    [files],
+  );
 
   const visiblePaths = useMemo(() => {
     const needsViewedFilter = hideViewed;
+    const needsRelevanceFilter = hideNotRelevant && notRelevantCount > 0;
     const needsHunkFilter = showHunkSignificance && hunkFilter !== "all";
-    if (!needsViewedFilter && !needsHunkFilter) return null; // null = show all
+    if (!needsViewedFilter && !needsRelevanceFilter && !needsHunkFilter) return null; // null = show all
     const set = new Set<string>();
     for (const f of files) {
       if (needsViewedFilter && viewedFiles.has(f.path)) continue;
+      if (needsRelevanceFilter && f.classification === "NOT_RELEVANT") continue;
       if (needsHunkFilter && !fileMatchesHunkFilter(f, hunkFilter)) continue;
       set.add(f.path);
     }
     return set;
-  }, [files, viewedFiles, hideViewed, showHunkSignificance, hunkFilter]);
+  }, [files, viewedFiles, hideViewed, hideNotRelevant, notRelevantCount, showHunkSignificance, hunkFilter]);
 
   const isVisible = (f: { path: string }) => visiblePaths === null || visiblePaths.has(f.path);
 
@@ -545,6 +558,16 @@ export function FileSidebar({
         >
           {hideViewed ? "Show reviewed" : "Hide reviewed"}
           <span className="hide-viewed-count">{viewedCount}</span>
+        </button>
+      )}
+      {notRelevantCount > 0 && (
+        <button
+          className={`hide-viewed-toggle ${hideNotRelevant ? "active" : ""}`}
+          onClick={() => setHideNotRelevant((h) => !h)}
+          title="Files the AI judged not relevant to review"
+        >
+          {hideNotRelevant ? "Show not relevant" : "Hide not relevant"}
+          <span className="hide-viewed-count">{notRelevantCount}</span>
         </button>
       )}
       {showHunkSignificance && (

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -644,6 +644,13 @@ body {
   border-left-color: var(--risk-critical);
 }
 
+/* NOT_RELEVANT files (only shown when the relevance filter is toggled on) are
+   dimmed to keep them visually subordinate to the review set. */
+.file-item-wrapper.file-not-relevant .file-name {
+  opacity: 0.55;
+  font-style: italic;
+}
+
 .file-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- **Fixes the "nothing to review" case**: a PR whose changed files the AI classified `NOT_RELEVANT` (e.g. the TUI file in #117) came back with an empty manifest — no files, no message. The classifier was treating logic-bearing terminal-UI code as "purely presentational UI" and dropping it, and the pipeline then discarded NOT_RELEVANT files entirely.
- **Refines the classification prompt** so logic-bearing render/view code is RELEVANT.
- **Surfaces NOT_RELEVANT files on demand** in both the TUI and GUI behind a relevance filter (hidden by default), so even a misclassification no longer hides a file completely.

## Changes
**Prompt (`core/src/prompts.rs`)**
- Narrowed the "UI = NOT_RELEVANT" rule to *purely presentational web markup/styling* (JSX/HTML/CSS/Tailwind).
- Added an edge case: render/view code with real logic (terminal/TUI rendering, view-models, parsing, cursor/scroll/layout math, data transformation) is RELEVANT.

**Core pipeline (`core/src/fetch.rs`)**
- Every changed file now goes into the manifest with its `classification` and diff. Relevant files still get highlights/summary/grouping and full content; NOT_RELEVANT files carry their diff only (full-file view is "unavailable" for them — keeps API cost unchanged).
- AI analysis steps run only when there are relevant files; removed the silent empty-manifest early-return.
- Files the classifier omits default to NOT_RELEVANT so nothing silently disappears.

**TUI (`cli/src/tui.rs`)**
- The `t` filter now hides/shows NOT_RELEVANT files (hidden by default), dims them, and the sidebar title / overview report how many are hidden. (Replaces the previous "hide low-risk" meaning of `t`.)

**GUI (`src/components/FileSidebar.tsx`, `styles.css`)**
- Added a "Show/Hide not relevant" toggle mirroring "Hide reviewed"; not-relevant files render dimmed/italic.

## Test Plan
- [ ] `cargo test -p marrow-core -p marrow-cli` — passes (34 cli + 9 core)
- [ ] `cargo clippy -p marrow-cli` — no new warnings
- [ ] `cd app && npx tsc --noEmit` — clean
- [ ] Re-fetch a PR whose only changes are logic-bearing "UI" code (e.g. #117's `tui.rs`) and confirm it now classifies RELEVANT and appears
- [ ] Fetch a PR with some tests/lockfiles → confirm they're hidden by default, sidebar title shows "(N not relevant hidden)", and `t` (TUI) / the toggle (GUI) reveals them dimmed
- [ ] Confirm a PR where *all* files are NOT_RELEVANT now lists them (after toggling) instead of an empty review

## Notes
- Separate from #117 (line numbers + wrapping); branched from `main`.
- NOT_RELEVANT files intentionally don't fetch full base/head content, so their full-file view shows "(full file unavailable)" — only their diff is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)