### PR TITLE
fix(ci): publish CLI releases as pre-releases

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -102,6 +102,12 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           draft: true
+          # CLI releases must be pre-releases so they never claim GitHub's
+          # "Latest" badge — the desktop auto-updater resolves
+          # releases/latest/download/latest.json, which only the desktop (v*)
+          # release carries. A non-prerelease cli-v* release steals "Latest" and
+          # breaks the updater.
+          prerelease: true
           files: |
             dist/marrow-*.tar.gz
             dist/marrow-*.zip


### PR DESCRIPTION
## Summary
- CLI (`cli-v*`) releases were published **without** `prerelease`, so each one claimed GitHub's **Latest** badge (GitHub picks the newest non-prerelease release by date).
- The desktop auto-updater resolves `https://github.com/Besendorfer/marrow/releases/latest/download/latest.json`, and only the desktop (`v*`) release carries `latest.json`. So whenever a CLI release became "Latest", the desktop updater broke for all users.
- This bit us deploying `cli-v0.1.0-alpha.3` (fixed live by marking it pre-release and re-asserting `v0.11.0` as Latest); `cli-v0.1.0-alpha.2` likely broke the updater silently for ~a day.

## Change
- Add `prerelease: true` to the `softprops/action-gh-release` step in `.github/workflows/cli-release.yml` so CLI releases never claim "Latest".

## Test Plan
- [ ] Next `cli-v*` tag publishes a release flagged **Pre-release**
- [ ] After it builds, the desktop `v*` release retains the **Latest** badge and `releases/latest/download/latest.json` still serves the desktop version

## Note
Already handled live (outside this PR): `cli-v0.1.0-alpha.3` and `cli-v0.1.0-alpha.2` set to pre-release, `v0.11.0` re-pinned as Latest, updater manifest verified serving 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)