### PR TITLE
fix(gui): show ungrouped files under "Other" in the Groups view

### DIFF
--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -491,6 +491,17 @@ export function FileSidebar({
     return buildFileTree(files.filter((f) => visiblePaths.has(f.path)));
   }, [files, visiblePaths]);
 
+  // Files not in any AI change group (NOT_RELEVANT files aren't grouped, and the
+  // grouping step can omit a file) — surfaced under "Other" in the Groups view
+  // so nothing silently disappears there.
+  const ungroupedFiles = useMemo(() => {
+    if (!hasGroups) return [];
+    const groupedPaths = new Set(changeGroups.flatMap((g) => g.file_paths));
+    return files.filter(
+      (f) => !groupedPaths.has(f.path) && (visiblePaths === null || visiblePaths.has(f.path)),
+    );
+  }, [files, changeGroups, hasGroups, visiblePaths]);
+
   const visibleCategories = useMemo(() => {
     const order = ["Business Logic", "Infrastructure", "Domain Types", "Other"];
     return Object.keys(visibleGrouped).sort((a, b) => {
@@ -629,6 +640,36 @@ export function FileSidebar({
                 </div>
               );
             })}
+            {ungroupedFiles.length > 0 && (() => {
+              const groupKey = "group:other";
+              return (
+                <div className="file-group change-group">
+                  <button
+                    className="group-header group-toggle"
+                    onClick={() => toggleCollapsed(groupKey)}
+                  >
+                    <span className={`collapse-chevron ${collapsed.has(groupKey) ? "collapsed" : ""}`}>&#9662;</span>
+                    Other
+                    <span className="group-count">{ungroupedFiles.length}</span>
+                  </button>
+                  {!collapsed.has(groupKey) && (<>
+                  <div className="change-group-description">Files not part of a change group</div>
+                  {ungroupedFiles.map((file) => (
+                    <FileItem
+                      key={file.path}
+                      file={file}
+                      selectedFile={selectedFile}
+                      isViewed={viewedFiles.has(file.path)}
+                      isStale={staleViewedFiles.has(file.path)}
+                      onSelectFile={onSelectFile}
+                      onToggleViewed={onToggleViewed}
+                      showPathHint
+                    />
+                  ))}
+                  </>)}
+                </div>
+              );
+            })()}
           </>
         ) : view === "category" ? (
           <>


### PR DESCRIPTION
## Summary
- The **Groups** tab rendered only files listed in an AI change group's `file_paths`. NOT_RELEVANT files aren't assigned to any change group (grouping runs on the relevant set only), so they never showed in Groups — even with **"Show not relevant"** enabled. The same gap would hide any relevant file the grouping step happened to omit.
- Adds an **"Other"** bucket listing visible files not in any change group, mirroring the TUI sidebar's "Other" section.

## Repro
With a PR that has a NOT_RELEVANT file (e.g. this PR's own work): Groups tab + toggle "Show not relevant" → the file is missing. Category / Tree / Comments views showed it fine; only Groups dropped it.

## Change
`app/src/components/FileSidebar.tsx`
- New `ungroupedFiles` memo: visible files whose path isn't in any `changeGroups[].file_paths`.
- Render them under an "Other" collapsible group after the AI groups (respects the relevance/viewed/significance filters via the same `visiblePaths`).

## Test Plan
- [ ] `cd app && npx tsc --noEmit` — clean
- [ ] Groups tab with "Show not relevant" on → not-relevant file appears under "Other"; with it off → hidden
- [ ] "Other" respects Hide reviewed + significance filters
- [ ] No "Other" group when every file is in a change group

🤖 Generated with [Claude Code](https://claude.com/claude-code)