### PR TITLE
feat(ci): auto-update Homebrew tap on CLI release publish

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -14,19 +14,36 @@ name: Update Homebrew Tap
 on:
   release:
     types: [published]
+  # Manual re-sync / backfill (and a way to test without cutting a release).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "CLI release tag to sync to the tap (e.g. cli-v0.1.0-alpha.3)"
+        required: true
 
 jobs:
   update-tap:
     # Only CLI releases carry a Homebrew formula; skip desktop (`v*`) releases.
-    if: startsWith(github.event.release.tag_name, 'cli-v')
+    # (workflow_dispatch has no release object, so allow it through and validate
+    # the tag below.)
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'cli-v') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release tag
+        id: rel
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          case "$TAG" in
+            cli-v*) ;;
+            *) echo "::error::tag must start with cli-v (got: '$TAG')"; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Download the formula from the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
         run: |
-          gh release download "$TAG" \
+          gh release download "${{ steps.rel.outputs.tag }}" \
             --repo "${{ github.repository }}" \
             --pattern marrow.rb \
             --dir .
@@ -35,7 +52,7 @@ jobs:
       - name: Commit to the tap
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ steps.rel.outputs.tag }}
         run: |
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::error::HOMEBREW_TAP_TOKEN is not set — create a PAT with contents:write on Besendorfer/homebrew-tap and add it as a repo secret."

--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,0 +1,57 @@
+name: Update Homebrew Tap
+
+# When a CLI (`cli-v*`) release is *published*, copy its generated `marrow.rb`
+# into `Formula/marrow.rb` in the umbrella tap (Besendorfer/homebrew-tap) so
+# `brew install marrow` tracks the new version automatically.
+#
+# Why `release: published` and not the tag push: cli-release.yml creates a
+# *draft* release, and a draft's asset download URLs aren't publicly reachable —
+# the formula points at those URLs, so it must only land in the tap once the
+# release is live. Publishing the draft fires this workflow.
+#
+# Requires a repo secret HOMEBREW_TAP_TOKEN: a PAT with contents:write on
+# Besendorfer/homebrew-tap (the default GITHUB_TOKEN can't push to another repo).
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-tap:
+    # Only CLI releases carry a Homebrew formula; skip desktop (`v*`) releases.
+    if: startsWith(github.event.release.tag_name, 'cli-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the formula from the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern marrow.rb \
+            --dir .
+          echo "--- formula ---" && head -8 marrow.rb
+
+      - name: Commit to the tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set — create a PAT with contents:write on Besendorfer/homebrew-tap and add it as a repo secret."
+            exit 1
+          fi
+          VERSION="${TAG#cli-v}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/Besendorfer/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp marrow.rb tap/Formula/marrow.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/marrow.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date — nothing to commit."
+          else
+            git commit -m "marrow $VERSION"
+            git push
+          fi

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -97,9 +97,18 @@ tap for all of Besendorfer's tools, so users tap once and `brew install` any of
 them. (The old per-project `homebrew-marrow` tap is deprecated and redirects
 here.)
 
-After each CLI release, copy the generated `marrow.rb` from the release into
-`Formula/marrow.rb` in the tap repo and push. Users then install with the short
-name after a one-time tap:
+Updating the tap is **automated**: when a `cli-v*` release is *published*,
+`.github/workflows/homebrew-tap.yml` copies that release's generated `marrow.rb`
+into `Formula/marrow.rb` in the tap repo and pushes. (It runs on publish, not on
+the tag push, because a draft release's asset URLs aren't reachable yet.) This
+needs a repo secret **`HOMEBREW_TAP_TOKEN`** — a PAT with `contents:write` on
+`Besendorfer/homebrew-tap` (the default `GITHUB_TOKEN` can't push to another
+repo). If the secret is missing the job fails loudly; fall back to the manual
+copy below.
+
+Manual fallback — copy the generated `marrow.rb` from the release into
+`Formula/marrow.rb` in the tap repo and push. Users install with the short name
+after a one-time tap:
 
 ```bash
 brew tap besendorfer/tap
@@ -111,10 +120,8 @@ brew install marrow
 > set, it refuses non-official taps until trusted: `brew trust besendorfer/tap`
 > (one-time, per machine). Only homebrew-core formulae are exempt.
 
-> Future automation: have `cli-release.yml` push `marrow.rb` to the tap repo
-> directly (needs a `HOMEBREW_TAP_TOKEN` secret with write access to the tap).
-> For now the formula is generated and attached to the release for a manual
-> copy — no secret required.
+> The formula is also attached to every CLI release, so the manual copy above
+> always works if the automation is unavailable (e.g. the secret is missing).
 
 ### Bare `brew install marrow` (homebrew-core, later)
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/homebrew-tap.yml` so publishing a `cli-v*` release automatically updates `Formula/marrow.rb` in `Besendorfer/homebrew-tap` — no more manual copy after each CLI release (which is what left `alpha.3` un-tapped until it was done by hand).

## How it works
- Trigger: `release: published`, gated to `cli-v*` tags (desktop `v*` releases carry no formula and are skipped).
- Downloads `marrow.rb` from the published release, clones the tap, writes `Formula/marrow.rb`, commits `marrow <version>`, and pushes. No-ops cleanly if the formula is unchanged.
- **Fires on publish, not the tag push**, on purpose: `cli-release.yml` creates a *draft*, and a draft's asset download URLs (which the formula points at) aren't publicly reachable until the release is published.

## Required setup (manual, one-time)
- Add a repo secret **`HOMEBREW_TAP_TOKEN`**: a PAT (fine-grained or classic) with **`contents:write`** on `Besendorfer/homebrew-tap`. The default `GITHUB_TOKEN` can't push to a different repo.
- If the secret is missing, the job fails loudly (it doesn't silently skip), and the formula is still attached to the release for the documented manual fallback.

## Docs
- `PUBLISHING.md` updated: tap update is now automated, with the manual copy kept as a fallback.

## Test Plan
- [ ] Add the `HOMEBREW_TAP_TOKEN` secret
- [ ] Publish a `cli-v*` release (or re-publish to fire the event) → workflow runs, commits `Formula/marrow.rb` to the tap with the right version
- [ ] `brew update && brew upgrade marrow` picks up the new version
- [ ] A desktop `v*` release publish does **not** trigger the tap job

🤖 Generated with [Claude Code](https://claude.com/claude-code)