### PR TITLE
feat(gui): add TUI-style keyboard shortcuts to the desktop app

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,9 +11,11 @@ import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
-import { SearchBar } from "./components/SearchBar";
+import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
+import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ToastContainer, createToast, type ToastData } from "./components/Toast";
 import { UpdateBanner } from "./components/UpdateBanner";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
@@ -29,6 +31,14 @@ function App() {
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchRef = useRef<SearchBarHandle>(null);
+  // Visible file order from the sidebar, used by the [ / ] navigation shortcuts.
+  const visibleOrderRef = useRef<string[]>([]);
+  const handleVisibleFilesChange = useCallback((paths: string[]) => {
+    visibleOrderRef.current = paths;
+  }, []);
   const [searchMatches, setSearchMatches] = useState<SearchMatch[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
@@ -140,6 +150,54 @@ function App() {
       return m?.filePath === selectedFilePath ? m : null;
     },
     [searchMatches, searchCurrentIndex, selectedFilePath]
+  );
+
+  // ── Keyboard shortcuts (ported from the CLI/TUI; see useKeyboardShortcuts) ──
+  function selectAdjacentFile(delta: 1 | -1) {
+    if (!activeTab?.manifest || !activeTab.selectedFile) return;
+    const order = visibleOrderRef.current.length
+      ? visibleOrderRef.current
+      : activeTab.manifest.files.map((f) => f.path);
+    const byPath = (p: string) => activeTab.manifest!.files.find((f) => f.path === p);
+    const i = order.indexOf(activeTab.selectedFile.path);
+    if (i === -1) {
+      // Current file is filtered out of the list — jump to the first visible one.
+      const first = byPath(order[0]);
+      if (first) setSelectedFile(first);
+      return;
+    }
+    const next = byPath(order[Math.min(Math.max(i + delta, 0), order.length - 1)]);
+    if (next && next.path !== activeTab.selectedFile.path) setSelectedFile(next);
+  }
+
+  function toggleThreadsView() {
+    if (!activeTab?.manifest) return;
+    if (activeTab.sidebarView === "comments") {
+      const hasGroups = (activeTab.manifest.change_groups ?? []).length > 0;
+      handleViewChange(hasGroups ? "groups" : "category");
+    } else {
+      handleViewChange("comments");
+    }
+  }
+
+  useKeyboardShortcuts(
+    {
+      onNextFile: () => selectAdjacentFile(1),
+      onPrevFile: () => selectAdjacentFile(-1),
+      onToggleViewed: () => {
+        const path = activeTab?.selectedFile?.path;
+        if (path) toggleViewed(path);
+      },
+      onToggleThreads: toggleThreadsView,
+      onRefresh: () => { if (activeTab?.manifest) handleRefreshPr(); },
+      onOpenSearch: () => searchRef.current?.open("local"),
+      onToggleHelp: () => setHelpOpen((o) => !o),
+      onCloseOverlays: () => setHelpOpen(false),
+    },
+    {
+      enabled: !!activeTab?.manifest,
+      overlayOpen: helpOpen || settingsOpen || searchOpen || showChecksModal,
+    },
   );
 
   function buildReviewTab(id: string, manifest: ReviewManifest): Tab {
@@ -1155,6 +1213,7 @@ function App() {
         onRelaunch={relaunch}
         onDismiss={() => setUpdateStatus({ state: "idle" })}
       />
+      {helpOpen && <KeyboardHelp onClose={() => setHelpOpen(false)} />}
       <ToastContainer toasts={toasts} onDismiss={removeToast} />
     </>
   );
@@ -1260,11 +1319,13 @@ function App() {
           />
         )}
         <SearchBar
+          ref={searchRef}
           files={activeTab.manifest.files}
           selectedFile={activeTab.selectedFile}
           onSelectFile={setSelectedFile}
           onHighlightMatches={(matches, idx, q) => { setSearchMatches(matches); setSearchCurrentIndex(idx); setSearchQuery(q); }}
           onClearHighlights={() => { setSearchMatches([]); setSearchCurrentIndex(0); setSearchQuery(""); }}
+          onOpenChange={setSearchOpen}
         />
         <div className="main-content">
           <FileSidebar
@@ -1283,6 +1344,7 @@ function App() {
             commentThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : []}
             selectedCommentFile={activeTab.selectedCommentFile}
             onSelectCommentFile={handleSelectCommentFile}
+            onVisibleFilesChange={handleVisibleFilesChange}
           />
           <div className="diff-pane">
             {activeTab.sidebarView === "comments" ? (

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -18,6 +18,8 @@ interface FileSidebarProps {
   commentThreads: ReviewThread[];
   selectedCommentFile: string | null;
   onSelectCommentFile: (path: string) => void;
+  /** Emits the visible file paths in manifest order, for keyboard file navigation. */
+  onVisibleFilesChange?: (paths: string[]) => void;
 }
 
 function getMaxHunkSignificance(file: FileDiff): string {
@@ -153,6 +155,19 @@ function sortedTreeEntries(node: TreeNode): TreeNode[] {
   dirs.sort((a, b) => a.name.localeCompare(b.name));
   fileNodes.sort((a, b) => a.name.localeCompare(b.name));
   return [...dirs, ...fileNodes];
+}
+
+// Flatten the tree into the top-to-bottom order of *displayed* file rows,
+// skipping the contents of collapsed folders. Mirrors TreeFolder's render so
+// keyboard file nav follows exactly what's on screen.
+function flattenTreePaths(node: TreeNode, depth: number, collapsed: Set<string>, out: string[]): void {
+  for (const child of sortedTreeEntries(node)) {
+    if (child.file) {
+      out.push(child.file.path);
+    } else if (!collapsed.has(`tree:${depth}:${child.name}`)) {
+      flattenTreePaths(child, depth + 1, collapsed, out);
+    }
+  }
 }
 
 /* ─── Shared file item renderer ─────────────────────────────────────────── */
@@ -390,6 +405,7 @@ export function FileSidebar({
   commentThreads,
   selectedCommentFile,
   onSelectCommentFile,
+  onVisibleFilesChange,
 }: FileSidebarProps) {
   const hasGroups = changeGroups.length > 0;
   const prevHasGroups = useRef(hasGroups);
@@ -510,6 +526,42 @@ export function FileSidebar({
       return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi);
     });
   }, [visibleGrouped]);
+
+  // The flat top-to-bottom order of file rows as actually displayed for the
+  // current view — respecting filters and collapsed sections, deduped to first
+  // occurrence (critical files also appear under their category). Drives the
+  // [ / ] navigation shortcuts so they follow the visible list exactly.
+  const navigableOrder = useMemo(() => {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    const push = (path: string) => {
+      if (!seen.has(path)) { seen.add(path); out.push(path); }
+    };
+    if (view === "groups") {
+      changeGroups.forEach((group, idx) => {
+        if (collapsed.has(`group:${idx}`)) return;
+        for (const p of group.file_paths) {
+          const f = filesByPath.get(p);
+          if (f && isVisible(f)) push(f.path);
+        }
+      });
+      if (!collapsed.has("group:other")) ungroupedFiles.forEach((f) => push(f.path));
+    } else if (view === "category") {
+      if (!collapsed.has(NEEDS_ATTENTION)) visibleCriticalFiles.forEach((f) => push(f.path));
+      for (const category of visibleCategories) {
+        if (collapsed.has(category)) continue;
+        visibleGrouped[category].forEach((f) => push(f.path));
+      }
+    } else if (view === "tree") {
+      flattenTreePaths(visibleFileTree, 0, collapsed, out);
+    }
+    // "comments" view drives a separate selection model — emit nothing.
+    return out;
+  }, [view, changeGroups, collapsed, filesByPath, visiblePaths, ungroupedFiles, visibleCriticalFiles, visibleCategories, visibleGrouped, visibleFileTree]);
+
+  useEffect(() => {
+    onVisibleFilesChange?.(navigableOrder);
+  }, [navigableOrder, onVisibleFilesChange]);
 
   const viewedCount = viewedFiles.size;
   const staleCount = staleViewedFiles.size;

--- a/app/src/components/KeyboardHelp.tsx
+++ b/app/src/components/KeyboardHelp.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from "react";
+
+interface KeyboardHelpProps {
+  onClose: () => void;
+}
+
+interface Binding {
+  keys: string[];
+  label: string;
+}
+
+interface Section {
+  title: string;
+  bindings: Binding[];
+}
+
+// Mirrors the implemented Tier 1 shortcuts in useKeyboardShortcuts.ts. Only list
+// bindings that actually work — don't advertise TUI keys the GUI doesn't honor yet.
+const SECTIONS: Section[] = [
+  {
+    title: "Navigation",
+    bindings: [
+      { keys: ["]"], label: "Next file" },
+      { keys: ["["], label: "Previous file" },
+      { keys: ["j"], label: "Scroll down" },
+      { keys: ["k"], label: "Scroll up" },
+      { keys: ["Space"], label: "Page down" },
+      { keys: ["⇧Space"], label: "Page up" },
+      { keys: ["⌃d"], label: "Half page down" },
+      { keys: ["⌃u"], label: "Half page up" },
+      { keys: ["g", "Home"], label: "Jump to top" },
+      { keys: ["G", "End"], label: "Jump to bottom" },
+    ],
+  },
+  {
+    title: "Actions",
+    bindings: [
+      { keys: ["V"], label: "Toggle file viewed" },
+      { keys: ["T"], label: "Toggle threads / diff" },
+      { keys: ["⌃r", "F5"], label: "Refresh PR" },
+      { keys: ["/"], label: "Search" },
+      { keys: ["?"], label: "Toggle this help" },
+      { keys: ["Esc"], label: "Close overlay" },
+    ],
+  },
+];
+
+export function KeyboardHelp({ onClose }: KeyboardHelpProps) {
+  // Self-close on ?, q, or Esc — mirrors the TUI's help dismissal. The global
+  // shortcut hook suppresses single keys while an overlay is open, so handle it here.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "?" || e.key === "q" || e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="settings-overlay" onClick={onClose}>
+      <div className="kbd-help-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="settings-header">
+          <h2>Keyboard shortcuts</h2>
+          <button className="settings-close" onClick={onClose} aria-label="Close keyboard shortcuts">
+            &times;
+          </button>
+        </div>
+        <div className="kbd-help-grid">
+          {SECTIONS.map((section) => (
+            <div key={section.title} className="kbd-help-section">
+              <h3 className="kbd-help-section-title">{section.title}</h3>
+              {section.bindings.map((b) => (
+                <div key={b.label} className="kbd-help-row">
+                  <span className="kbd-help-keys">
+                    {b.keys.map((k, i) => (
+                      <span key={k}>
+                        {i > 0 && <span className="kbd-help-or"> / </span>}
+                        <kbd className="kbd-help-key">{k}</kbd>
+                      </span>
+                    ))}
+                  </span>
+                  <span className="kbd-help-label">{b.label}</span>
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -1,8 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { FileDiff, SearchMatch } from "../types";
 import { getFileName } from "../utils";
 
 type SearchMode = "local" | "global";
+
+/** Imperative handle so a global shortcut (e.g. "/") can open the search bar. */
+export interface SearchBarHandle {
+  open: (mode?: SearchMode) => void;
+}
 
 interface SearchBarProps {
   files: FileDiff[];
@@ -10,6 +15,8 @@ interface SearchBarProps {
   onSelectFile: (file: FileDiff) => void;
   onHighlightMatches: (matches: SearchMatch[], currentIndex: number, query: string) => void;
   onClearHighlights: () => void;
+  /** Notified whenever the bar opens/closes so the parent can track overlay state. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 function searchInContent(
@@ -51,13 +58,14 @@ function dedupeMatches(matches: SearchMatch[]): SearchMatch[] {
   });
 }
 
-export function SearchBar({
+export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function SearchBar({
   files,
   selectedFile,
   onSelectFile,
   onHighlightMatches,
   onClearHighlights,
-}: SearchBarProps) {
+  onOpenChange,
+}: SearchBarProps, ref) {
   const [open, setOpen] = useState(false);
   const [mode, setMode] = useState<SearchMode>("local");
   const [query, setQuery] = useState("");
@@ -65,6 +73,23 @@ export function SearchBar({
   const [currentIndex, setCurrentIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
+
+  useImperativeHandle(ref, () => ({
+    open: (m: SearchMode = "local") => {
+      setMode(m);
+      setOpen(true);
+      setCurrentIndex(0);
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 0);
+    },
+  }), []);
+
+  // Report open/close transitions to the parent (for overlay-aware shortcuts).
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Debounce the query for global search (local stays instant)
   useEffect(() => {
@@ -318,7 +343,7 @@ export function SearchBar({
       )}
     </div>
   );
-}
+});
 
 function truncateLeft(s: string, maxLen: number): string {
   if (s.length <= maxLen) return s;

--- a/app/src/components/SearchBar.tsx
+++ b/app/src/components/SearchBar.tsx
@@ -89,7 +89,7 @@ export const SearchBar = forwardRef<SearchBarHandle, SearchBarProps>(function Se
   // Report open/close transitions to the parent (for overlay-aware shortcuts).
   useEffect(() => {
     onOpenChange?.(open);
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, onOpenChange]);
 
   // Debounce the query for global search (local stays instant)
   useEffect(() => {

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -38,12 +38,20 @@ function isEditable(target: EventTarget | null): boolean {
   return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
 }
 
+// ARIA roles whose widgets respond to Space/Enter — paging should defer to them.
+const INTERACTIVE_ROLES = new Set([
+  "button", "checkbox", "radio", "switch", "tab", "menuitem", "menuitemcheckbox",
+  "menuitemradio", "option", "link",
+]);
+
 /** Elements where Space/Enter means "activate", so paging should defer to them. */
 function isClickable(target: EventTarget | null): boolean {
   const el = target as HTMLElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  return tag === "BUTTON" || tag === "A" || tag === "SUMMARY" || el.getAttribute("role") === "button";
+  if (tag === "BUTTON" || tag === "A" || tag === "SUMMARY") return true;
+  const role = el.getAttribute("role");
+  return role !== null && INTERACTIVE_ROLES.has(role);
 }
 
 export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: ShortcutOptions): void {
@@ -87,12 +95,11 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
 
       if (!enabled || overlayOpen) return;
 
-      const ctrl = e.ctrlKey || e.metaKey;
-
-      // Ctrl/Cmd combos — handle before bailing on modifiers below.
-      // ^f (full page down in the TUI) is intentionally omitted: it collides with
-      // find, so SearchBar's own Cmd/Ctrl+F listener owns it. PageDown covers the gap.
-      if (ctrl && !e.shiftKey && !e.altKey) {
+      // Vim-style scroll/refresh combos are Ctrl-only (NOT Cmd): on macOS Cmd+R
+      // reloads the webview, Cmd+D bookmarks, Cmd+U views source — leave those to
+      // the system. ^f (full page down in the TUI) is omitted too; it collides with
+      // find, which SearchBar's own Cmd/Ctrl+F listener owns. Space covers the gap.
+      if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey) {
         switch (e.key.toLowerCase()) {
           case "d": scrollBy(page(0.5)); e.preventDefault(); return;
           case "u": scrollBy(-page(0.5)); e.preventDefault(); return;

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Global keyboard shortcuts for the review GUI, ported from the CLI/TUI
+ * keybindings (see crates/cli/src/tui.rs `on_key`). This is Tier 1: navigation
+ * and the actions that map cleanly onto existing handlers. Movement keys
+ * (j/k, ^d/^u, g/G, …) scroll the diff pane rather than driving a line cursor —
+ * the GUI has no cursor concept, so faithful c/v/z/n parity is deferred.
+ */
+export interface ShortcutHandlers {
+  onNextFile: () => void;
+  onPrevFile: () => void;
+  onToggleViewed: () => void;
+  onToggleThreads: () => void;
+  onRefresh: () => void;
+  onOpenSearch: () => void;
+  onToggleHelp: () => void;
+  /** Close transient overlays (help). Search owns its own Esc. */
+  onCloseOverlays: () => void;
+}
+
+export interface ShortcutOptions {
+  /** False on the opener/loading tab — no diff to drive, so suppress everything. */
+  enabled: boolean;
+  /** A modal (help/search/settings/checks) is open — suppress single-key nav, but keep Esc. */
+  overlayOpen: boolean;
+  /** Returns the scrollable diff element. Defaults to the `.diff-content` pane. */
+  getScrollEl?: () => HTMLElement | null;
+}
+
+/** ~3 text lines — a comfortable j/k nudge. */
+const LINE_STEP = 48;
+
+function isEditable(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+}
+
+/** Elements where Space/Enter means "activate", so paging should defer to them. */
+function isClickable(target: EventTarget | null): boolean {
+  const el = target as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return tag === "BUTTON" || tag === "A" || tag === "SUMMARY" || el.getAttribute("role") === "button";
+}
+
+export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: ShortcutOptions): void {
+  // Keep the latest handlers/options in a ref so the listener is registered once
+  // and never sees a stale closure as App re-renders.
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    function scrollEl(): HTMLElement | null {
+      const get = optionsRef.current.getScrollEl;
+      return get ? get() : (document.querySelector(".diff-content") as HTMLElement | null);
+    }
+    function scrollBy(delta: number) {
+      scrollEl()?.scrollBy({ top: delta });
+    }
+    function scrollToEdge(edge: "top" | "bottom") {
+      const el = scrollEl();
+      if (!el) return;
+      el.scrollTo({ top: edge === "top" ? 0 : el.scrollHeight });
+    }
+    function page(fraction: number): number {
+      const el = scrollEl();
+      return el ? el.clientHeight * fraction : 0;
+    }
+
+    function onKey(e: KeyboardEvent) {
+      const h = handlersRef.current;
+      const { enabled, overlayOpen } = optionsRef.current;
+
+      // Typing into a field never triggers shortcuts.
+      if (isEditable(e.target)) return;
+
+      // Esc is always allowed so overlays can be dismissed.
+      if (e.key === "Escape") {
+        h.onCloseOverlays();
+        return;
+      }
+
+      if (!enabled || overlayOpen) return;
+
+      const ctrl = e.ctrlKey || e.metaKey;
+
+      // Ctrl/Cmd combos — handle before bailing on modifiers below.
+      // ^f (full page down in the TUI) is intentionally omitted: it collides with
+      // find, so SearchBar's own Cmd/Ctrl+F listener owns it. PageDown covers the gap.
+      if (ctrl && !e.shiftKey && !e.altKey) {
+        switch (e.key.toLowerCase()) {
+          case "d": scrollBy(page(0.5)); e.preventDefault(); return;
+          case "u": scrollBy(-page(0.5)); e.preventDefault(); return;
+          case "b": scrollBy(-page(0.9)); e.preventDefault(); return;
+          case "r": h.onRefresh(); e.preventDefault(); return;
+        }
+      }
+
+      // Space / Shift+Space page through the diff (the laptop-friendly PageDown/Up).
+      // Skip when a clickable control is focused, where Space means "activate".
+      if (e.key === " " && !isClickable(e.target)) {
+        scrollBy(e.shiftKey ? -page(0.9) : page(0.9));
+        e.preventDefault();
+        return;
+      }
+
+      // Everything past here is a plain (unmodified) keypress.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case "]": h.onNextFile(); break;
+        case "[": h.onPrevFile(); break;
+        case "V": h.onToggleViewed(); break;
+        case "T": h.onToggleThreads(); break;
+        case "F5": h.onRefresh(); e.preventDefault(); break;
+        case "/": h.onOpenSearch(); e.preventDefault(); break;
+        case "?": h.onToggleHelp(); break;
+        case "j": scrollBy(LINE_STEP); break;
+        case "k": scrollBy(-LINE_STEP); break;
+        case "g": case "Home": scrollToEdge("top"); break;
+        case "G": case "End": scrollToEdge("bottom"); break;
+        case "PageDown": scrollBy(page(0.9)); e.preventDefault(); break;
+        case "PageUp": scrollBy(-page(0.9)); e.preventDefault(); break;
+        default: return;
+      }
+    }
+
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1742,6 +1742,69 @@ body {
   overflow-y: auto;
 }
 
+/* ─── Keyboard Help Modal ──────────────────────────────────────────────── */
+
+.kbd-help-modal {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  width: 560px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 24px;
+}
+
+.kbd-help-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.kbd-help-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.kbd-help-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.kbd-help-keys {
+  flex-shrink: 0;
+  min-width: 96px;
+  text-align: right;
+}
+
+.kbd-help-key {
+  display: inline-block;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-family: var(--font-mono, monospace);
+  font-size: 12px;
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.kbd-help-or {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.kbd-help-label {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
 /* ─── Settings Modal ───────────────────────────────────────────────────── */
 
 .settings-modal {


### PR DESCRIPTION
## Summary

Brings the CLI/TUI keybindings (`crates/cli/src/tui.rs`) into the desktop GUI as a flat, focus-aware keyboard layer. **Frontend-only — no Rust/Tauri changes.**

The TUI is fully keyboard-driven around a global line *cursor*; the GUI has no cursor concept (folding is local `DiffViewer` state, commenting is mouse-drag). So this is a **port, not a code-share** — wiring keys to the handlers that already exist. This is **Tier 1**: navigation + the actions that map cleanly. Movement keys scroll the diff pane rather than driving a cursor.

## Bindings

| Key | Action |
|---|---|
| `[` / `]` | prev / next file |
| `V` | toggle file viewed |
| `T` | toggle threads ↔ diff |
| `Ctrl+R` / `F5` | refresh PR |
| `/` | search |
| `?` | help overlay |
| `Esc` | close overlay |
| `j` / `k` | scroll |
| `Space` / `Shift+Space` | page down / up |
| `Ctrl+D` / `Ctrl+U` | half page |
| `g` / `G` / `Home` / `End` | top / bottom |

## How it works

- **`useKeyboardShortcuts`** (new hook) — one `document` keydown listener. No-ops while focus is in an input/textarea; suppresses single-key nav while an overlay is open (Esc always allowed); scrolls `.diff-content` (found via `querySelector`, robust across `DiffViewer`'s per-file remounts). `Space` defers to focused buttons so it still activates them.
- **`SearchBar`** — now `forwardRef` exposing `open(mode)` (so `/` opens it) + `onOpenChange` so App tracks it as an overlay.
- **`FileSidebar`** — emits the flat **displayed** file order for the active view (groups / category / tree), respecting filters and collapsed sections and deduping repeats, so `[`/`]` follows exactly what's on screen.
- **`KeyboardHelp`** (new) — the `?` overlay; self-closes on `?`/`q`/`Esc` to match the TUI.

## Deliberate Tier-1 scope / trade-offs

- **`Ctrl+F` full-page-down dropped** — collides with find (SearchBar owns it); `Space`/`PageDown` cover it.
- **Cursor-dependent TUI keys deferred** — `c` (comment on line), `v` (selection), `z`/`Z` (fold), `n`/`N` (finding nav), `R`→`a`/`r`/`c` (review picker), `r`/`x` (reply/resolve). These need a real line cursor (Tier 3) or anchor exposure from `DiffViewer` (Tier 2).
- **`a` / `w` skipped** — full-file view and wrap don't exist in the GUI yet.

## Testing

- `tsc --noEmit` clean; `vite build` succeeds.
- Manually exercised file nav, scrolling, viewed/threads/refresh, search, and the help overlay in the running app; file-nav order verified to follow each sidebar view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)