### PR TITLE
fix(gui): syntax-highlight diffs from full file content, not stitched hunks

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -529,7 +529,12 @@ interface DiffLine {
   newLineNum: number | null;
 }
 
-function parseDiffLines(unifiedDiff: string, lang: string | undefined): DiffLine[] {
+function parseDiffLines(
+  unifiedDiff: string,
+  lang: string | undefined,
+  headContent?: string,
+  baseContent?: string,
+): DiffLine[] {
   const rawLines = unifiedDiff.split("\n");
 
   // First pass: extract old-side and new-side source lines for highlighting
@@ -569,23 +574,34 @@ function parseDiffLines(unifiedDiff: string, lang: string | undefined): DiffLine
     }
   }
 
-  // Highlight both sides
-  const oldHtml = highlightLines(oldSrc.join("\n"), lang);
-  const newHtml = highlightLines(newSrc.join("\n"), lang);
+  // Highlight from the COMPLETE file contents when available, indexing each diff
+  // line by its real line number. The diff reconstruction (oldSrc/newSrc) stitches
+  // non-contiguous hunks together — that's syntactically broken code, and on a
+  // large/scattered diff it breaks highlight.js's stateful lexer so most tokens
+  // render uncolored. The full files are valid contiguous code and highlight
+  // correctly. Fall back to the stitched reconstruction for a side whose full
+  // content isn't available (e.g. a renamed file's missing base), preserving the
+  // previous behavior there.
+  const newFull = headContent ? highlightLines(headContent, lang) : null;
+  const oldFull = baseContent ? highlightLines(baseContent, lang) : null;
+  const newStitched = newFull ? null : highlightLines(newSrc.join("\n"), lang);
+  const oldStitched = oldFull ? null : highlightLines(oldSrc.join("\n"), lang);
 
-  // Map highlighted HTML back to diff lines
+  const newHtmlOf = (e: (typeof entries)[number]): string | undefined =>
+    newFull
+      ? (e.newLineNum != null ? newFull[e.newLineNum - 1] : undefined)
+      : (e.newIdx != null ? newStitched![e.newIdx] : undefined);
+  const oldHtmlOf = (e: (typeof entries)[number]): string | undefined =>
+    oldFull
+      ? (e.oldLineNum != null ? oldFull[e.oldLineNum - 1] : undefined)
+      : (e.oldIdx != null ? oldStitched![e.oldIdx] : undefined);
+
+  // Map highlighted HTML back to diff lines (add + context use the new side).
   return entries.map((e) => {
-    let html: string;
-    if (e.type === "header") {
-      html = escapeHtml(e.content);
-    } else if (e.type === "add") {
-      html = e.newIdx !== null ? (newHtml[e.newIdx] ?? escapeHtml(e.content)) : escapeHtml(e.content);
-    } else if (e.type === "remove") {
-      html = e.oldIdx !== null ? (oldHtml[e.oldIdx] ?? escapeHtml(e.content)) : escapeHtml(e.content);
-    } else {
-      // context — use new side
-      html = e.newIdx !== null ? (newHtml[e.newIdx] ?? escapeHtml(e.content)) : escapeHtml(e.content);
-    }
+    const html =
+      e.type === "header"
+        ? escapeHtml(e.content)
+        : (e.type === "remove" ? oldHtmlOf(e) : newHtmlOf(e)) ?? escapeHtml(e.content);
     return { type: e.type, content: e.content, html, oldLineNum: e.oldLineNum, newLineNum: e.newLineNum };
   });
 }
@@ -673,7 +689,7 @@ function buildFullFileDiffLines(
   lang: string | undefined
 ): DiffLine[] {
   if (!headContent) return [];
-  const parsed = parseDiffLines(unifiedDiff, lang);
+  const parsed = parseDiffLines(unifiedDiff, lang, headContent);
   const newLines = headContent.split("\n");
   const newHtml = highlightLines(headContent, lang);
 
@@ -1436,7 +1452,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
 
     // Use hunk-based view when we have scores and a parseable unified diff
     if (hasUnifiedDiff && hunkScores.length > 0) {
-      const lines = parseDiffLines(file.unified_diff, lang);
+      const lines = parseDiffLines(file.unified_diff, lang, file.head_content, file.base_content);
       return {
         hunks: groupIntoHunks(lines, hunkScores),
         diffLines: lines,
@@ -1451,7 +1467,7 @@ export function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, 
     } else if (file.diff_type === "removed") {
       lines = buildFullFileLines(file.base_content, "remove", lang);
     } else {
-      lines = parseDiffLines(file.unified_diff, lang);
+      lines = parseDiffLines(file.unified_diff, lang, file.head_content, file.base_content);
       // Even without scores from AI, group into hunks for consistent rendering
       return {
         hunks: groupIntoHunks(lines, []),


### PR DESCRIPTION
## Summary

Large or scattered diffs render almost entirely **without syntax highlighting** (plain white text), while small diffs in the same PR highlight fine. This fixes that.

### Root cause

`parseDiffLines` reconstructed each side of the diff by concatenating the hunk lines (`oldSrc.join("\n")` / `newSrc.join("\n")`) and ran highlight.js on *that*. The reconstruction is **non-contiguous** — disjoint slices of the file stitched together — i.e. syntactically broken code. For a small change it's close enough to valid that highlight.js copes; for a large/scattered change (hunks pulled from all over the file, JSX rows yanked out of their enclosing tags, etc.) highlight.js's stateful lexer can't make sense of it and most tokens fall through as plain text.

Measured on a real ~2000-line file's diff: **10%** of lines colored via the stitched reconstruction, vs **72%** when highlighting the valid full file (App.tsx, a smaller file, was 91% stitched — which is why it looked fine).

### Fix

Highlight the complete `head_content` / `base_content` (valid, contiguous code) and index each diff line by its real `newLineNum` / `oldLineNum` — the **same approach the full-file view already uses** (`newHtml[newLineNum - 1]` in `buildFullFileDiffLines`). `parseDiffLines` was the lone holdout still highlighting the reconstruction.

Falls back to the previous stitched-reconstruction highlighting **per side** when that side's full content isn't available (e.g. a renamed file's empty `base_content`), so nothing regresses there. Header lines and any out-of-range/missing lookups still degrade to `escapeHtml` exactly as before.

## Validation

- Reproduced the exact pipeline (highlight → `splitHtmlByLines` → index) on a real diff: full-file path yields a matching line count and ~72% colored vs ~10% stitched.
- `tsc --noEmit` clean; `vite build` succeeds.

## Needs runtime verification

This touches the render path for **every** file, so it wants a manual pass in the app before merge:
- A large/scattered diff (e.g. this repo's own `DiffViewer.tsx` change) now shows syntax colors in the **diff** view, both split and unified.
- Small diffs still look right (no regression).
- A **renamed** file (often empty `base_content`) — old/removed side falls back gracefully, no crash, no worse than today.
- Pure **add** / **remove** files still render correctly.

Independent of the keyboard-shortcuts work (#122/#123) — different code path, branches cleanly off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)