### PR TITLE
feat(gui): dismiss / restore AI highlights, persisted per PR

### DIFF
--- a/app/src-tauri/crates/core/src/dismissed_highlights.rs
+++ b/app/src-tauri/crates/core/src/dismissed_highlights.rs
@@ -15,8 +15,16 @@ fn dismissed_dir() -> PathBuf {
     app_config_dir().join("dismissed")
 }
 
+/// Restrict a path component to a safe charset so a hostile `owner`/`repo` from
+/// the IPC boundary can't escape the cache dir. A no-op for real GitHub names.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' { c } else { '_' })
+        .collect()
+}
+
 fn dismissed_path(owner: &str, repo: &str, pr_number: u64) -> PathBuf {
-    dismissed_dir().join(format!("{}_{}_{}.json", owner, repo, pr_number))
+    dismissed_dir().join(format!("{}_{}_{}.json", sanitize(owner), sanitize(repo), pr_number))
 }
 
 pub fn load_dismissed(owner: &str, repo: &str, pr_number: u64) -> Option<DismissedHighlights> {

--- a/app/src-tauri/crates/core/src/dismissed_highlights.rs
+++ b/app/src-tauri/crates/core/src/dismissed_highlights.rs
@@ -1,0 +1,49 @@
+use crate::config::app_config_dir;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// Per-PR set of dismissed AI highlights. `keys` are opaque, frontend-computed
+/// stable identifiers (path + line range + comment hash) so a dismissal survives
+/// re-fetches but re-surfaces if the underlying note changes.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct DismissedHighlights {
+    pub keys: Vec<String>,
+}
+
+fn dismissed_dir() -> PathBuf {
+    app_config_dir().join("dismissed")
+}
+
+fn dismissed_path(owner: &str, repo: &str, pr_number: u64) -> PathBuf {
+    dismissed_dir().join(format!("{}_{}_{}.json", owner, repo, pr_number))
+}
+
+pub fn load_dismissed(owner: &str, repo: &str, pr_number: u64) -> Option<DismissedHighlights> {
+    let path = dismissed_path(owner, repo, pr_number);
+    let content = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn save_dismissed(
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    state: &DismissedHighlights,
+) -> Result<(), String> {
+    let dir = dismissed_dir();
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create dismissed dir: {}", e))?;
+    let path = dismissed_path(owner, repo, pr_number);
+    let json =
+        serde_json::to_string_pretty(state).map_err(|e| format!("Failed to serialize: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write dismissed state: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(&path, perms);
+    }
+
+    Ok(())
+}

--- a/app/src-tauri/crates/core/src/lib.rs
+++ b/app/src-tauri/crates/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ai;
 pub mod bedrock;
 pub mod checks_dismiss;
 pub mod config;
+pub mod dismissed_highlights;
 pub mod fetch;
 pub mod github;
 pub mod manifest_cache;

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -5,6 +5,7 @@ use marrow_core::github::GithubClient;
 use marrow_core::types::{MyReviewState, PrChecksStatus, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use marrow_core::manifest_cache::{self, CachedPrInfo};
 use marrow_core::session::{self, SessionState};
+use marrow_core::dismissed_highlights::{self, DismissedHighlights};
 use marrow_core::viewed_state::{self, ViewedFileState};
 use std::collections::HashMap;
 use std::fs;
@@ -284,6 +285,25 @@ pub fn save_viewed_files(
     state: ViewedFileState,
 ) -> Result<(), String> {
     viewed_state::save_viewed_state(&owner, &repo, pr_number, &state)
+}
+
+#[command]
+pub fn load_dismissed_highlights(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+) -> Option<DismissedHighlights> {
+    dismissed_highlights::load_dismissed(&owner, &repo, pr_number)
+}
+
+#[command]
+pub fn save_dismissed_highlights(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    state: DismissedHighlights,
+) -> Result<(), String> {
+    dismissed_highlights::save_dismissed(&owner, &repo, pr_number, &state)
 }
 
 #[command]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -92,6 +92,8 @@ pub fn run() {
             commands::fetch_gh_viewed_state,
             commands::load_viewed_files,
             commands::save_viewed_files,
+            commands::load_dismissed_highlights,
+            commands::save_dismissed_highlights,
             commands::list_cached_prs,
             commands::get_pr_checks,
             commands::dismiss_checks_warning,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -241,6 +241,7 @@ function App() {
       selectedFile: manifest.files.length > 0 ? manifest.files[0] : null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
+      dismissedHighlights: new Set(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: hasGroups ? "groups" : "category",
@@ -264,6 +265,7 @@ function App() {
       selectedFile: null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
+      dismissedHighlights: new Set(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: "category",
@@ -352,6 +354,7 @@ function App() {
 
             for (const tab of restored) {
               loadPersistedViewedState(tab);
+              loadDismissedHighlights(tab);
               fetchMyReviewState(tab.id, tab.manifest!.pr_url);
               fetchChecksStatus(tab.id, tab.manifest!.pr_url);
             }
@@ -431,6 +434,7 @@ function App() {
     setTabs((prev) => prev.map((t) => (t.id === tabId ? tab : t)));
     setError(null);
     loadPersistedViewedState(tab);
+    loadDismissedHighlights(tab);
     fetchMyReviewState(tabId, data.pr_url);
     fetchChecksStatus(tabId, data.pr_url);
     if (!isActive) {
@@ -449,6 +453,7 @@ function App() {
     setActiveTabId(tab.id);
     setError(null);
     loadPersistedViewedState(tab);
+    loadDismissedHighlights(tab);
     fetchMyReviewState(tab.id, data.pr_url);
     fetchChecksStatus(tab.id, data.pr_url);
   }
@@ -515,6 +520,29 @@ function App() {
       // Graceful degradation: if loading fails, start with empty state
     }
     syncGhViewedState(tab.id, tab.manifest.pr_url, tab.manifest.files);
+  }
+
+  async function loadDismissedHighlights(tab: Tab) {
+    if (!tab.manifest) return;
+    try {
+      const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+      const saved = await invoke<{ keys: string[] } | null>("load_dismissed_highlights", { owner, repo, prNumber: number });
+      if (saved && saved.keys.length > 0) {
+        updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: new Set(saved.keys) }));
+      }
+    } catch {
+      // Non-critical: start with nothing dismissed on failure
+    }
+  }
+
+  function toggleHighlightDismissed(key: string) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    const next = new Set(tab.dismissedHighlights);
+    if (next.has(key)) next.delete(key); else next.add(key);
+    updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: next }));
+    const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+    invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } }).catch(() => {});
   }
 
   const unlistenRef = useRef<(() => void) | null>(null);
@@ -1406,7 +1434,7 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
             ) : activeTab.manifest.summary ? (
               <div className="pr-summary">
                 <h3>PR Summary</h3>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -542,7 +542,8 @@ function App() {
     if (next.has(key)) next.delete(key); else next.add(key);
     updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: next }));
     const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
-    invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } }).catch(() => {});
+    invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } })
+      .catch(() => addToast("error", "Couldn't save — this dismissal may not persist"));
   }
 
   const unlistenRef = useRef<(() => void) | null>(null);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -19,6 +19,7 @@ import { UpdateBanner } from "./components/UpdateBanner";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
 import { parsePrUrl, extractPrRef } from "./utils";
 
@@ -1220,6 +1221,29 @@ function App() {
 
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Re-load dismissed-highlight state from disk when the window regains focus, so
+  // dismissals made outside the app (e.g. an external/AI tool writing the
+  // ~/.config/marrow/dismissed file) show up without reopening the PR.
+  useEffect(() => {
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (!focused) return;
+      for (const tab of tabsRef.current) {
+        if (!tab.manifest) continue;
+        const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+        invoke<{ keys: string[] } | null>("load_dismissed_highlights", { owner, repo, prNumber: number })
+          .then((saved) => {
+            const keys = saved?.keys ?? [];
+            updateTab(tab.id, (t) => {
+              const same = t.dismissedHighlights.size === keys.length && keys.every((k) => t.dismissedHighlights.has(k));
+              return same ? t : { ...t, dismissedHighlights: new Set(keys) };
+            });
+          })
+          .catch(() => {});
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []);
 
   // Persist session state whenever tabs or active tab change (debounced)
   useEffect(() => {

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -2,7 +2,7 @@ import { Fragment, forwardRef, memo, useEffect, useImperativeHandle, useMemo, us
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
 import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch } from "../types";
-import { timeAgo } from "../utils";
+import { timeAgo, highlightKey } from "../utils";
 
 const extToLang: Record<string, string> = {
   ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
@@ -98,6 +98,9 @@ interface DiffViewerProps {
   viewMode: DiffViewMode;
   showHunkSignificance: boolean;
   showAiNotes: boolean;
+  /** Keys (highlightKey) of AI highlights dismissed for this PR — hidden from the diff. */
+  dismissedHighlights?: Set<string>;
+  onToggleHighlightDismissed?: (key: string) => void;
   onCreateComment?: (path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") => Promise<void>;
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
@@ -1450,7 +1453,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -1613,7 +1616,14 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     [reviewThreads, file.path]
   );
 
-  const highlights = showAiNotes ? (file.highlights ?? []) : [];
+  // AI notes split into active (shown in the diff + nav) and dismissed (restorable
+  // from the summary). `highlights` is the active set everything else keys off.
+  const allNotes = showAiNotes ? (file.highlights ?? []) : [];
+  const keyFor = (h: Highlight) => highlightKey(file.path, h);
+  const dismissed = dismissedHighlights ?? new Set<string>();
+  const highlights = allNotes.filter((h) => !dismissed.has(keyFor(h)));
+  const dismissedNotes = allNotes.filter((h) => dismissed.has(keyFor(h)));
+  const [showDismissed, setShowDismissed] = useState(false);
   const isCritical =
     file.risk_level === "critical" || file.risk_level === "high";
 
@@ -1811,10 +1821,8 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   };
 
   // ── Tier 2: keyboard hunk/finding navigation + folding ────────────────────
-  const sortedFindings = useMemo(
-    () => (showAiNotes ? [...(file.highlights ?? [])] : []).sort((a, b) => a.start_line - b.start_line),
-    [file.highlights, showAiNotes],
-  );
+  // Active notes only, sorted — so n/N skips dismissed ones. (Cheap; read on keypress.)
+  const sortedFindings = highlights.slice().sort((a, b) => a.start_line - b.start_line);
   const findingIdxRef = useRef(-1);
   // Element id to scroll to + home the cursor onto after a re-render (finding nav,
   // fold-expand onto the first line, fold-collapse onto the hunk header).
@@ -2140,7 +2148,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
           </button>
         )}
       </div>
-      {highlights.length > 0 && (
+      {(highlights.length > 0 || dismissedNotes.length > 0) && (
         <div className="highlights-summary">
           {highlights.map((h, i) => (
             <div
@@ -2163,6 +2171,46 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
                   title="Post this AI note as a review comment"
                 >
                   Post as comment
+                </button>
+              )}
+              {onToggleHighlightDismissed && (
+                <button
+                  className="highlight-dismiss"
+                  onClick={(e) => { e.stopPropagation(); onToggleHighlightDismissed(keyFor(h)); }}
+                  title="Dismiss this AI note"
+                  aria-label="Dismiss AI note"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          ))}
+          {dismissedNotes.length > 0 && (
+            <button className="highlights-show-dismissed" onClick={() => setShowDismissed((v) => !v)}>
+              {showDismissed ? "Hide" : "Show"} {dismissedNotes.length} dismissed
+            </button>
+          )}
+          {showDismissed && dismissedNotes.map((h, i) => (
+            <div
+              key={`dismissed-${i}`}
+              className={`highlights-summary-item highlight-${h.severity} highlight-dismissed`}
+              style={{ cursor: "pointer" }}
+              onClick={() => {
+                const el = document.getElementById(`diff-line-${h.start_line}`);
+                el?.scrollIntoView({ behavior: "smooth", block: "center" });
+              }}
+              title="Jump to code"
+            >
+              <span className="highlight-severity-badge">{h.severity.toUpperCase()}</span>
+              <span className="highlight-lines">{formatLineRange(h.start_line, h.end_line)}</span>
+              <span className="highlight-summary-text">{h.comment}</span>
+              {onToggleHighlightDismissed && (
+                <button
+                  className="highlight-post-comment"
+                  onClick={(e) => { e.stopPropagation(); onToggleHighlightDismissed(keyFor(h)); }}
+                  title="Restore this AI note"
+                >
+                  Restore
                 </button>
               )}
             </div>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1787,6 +1787,50 @@ tr.cursor-selected td {
   border-color: var(--accent);
 }
 
+/* Dismiss (×) button on an AI note, and the dismissed-notes section. */
+.highlight-dismiss {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 7px;
+  height: 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+/* When post-comment is absent (no margin-left:auto), push dismiss to the right. */
+.highlights-summary-item > .highlight-dismiss:nth-child(4) {
+  margin-left: auto;
+}
+.highlights-summary-item:hover .highlight-dismiss {
+  opacity: 1;
+}
+.highlight-dismiss:hover {
+  background: var(--diff-remove-text, #f85149);
+  color: #fff;
+  border-color: transparent;
+}
+.highlights-summary-item.highlight-dismissed {
+  opacity: 0.5;
+}
+.highlights-show-dismissed {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 4px 2px;
+  cursor: pointer;
+  text-decoration: underline;
+}
+.highlights-show-dismissed:hover {
+  color: var(--text-primary);
+}
+
 /* Highlighted line background tint */
 .highlighted.highlighted-critical {
   background: rgba(248, 81, 73, 0.08) !important;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -119,6 +119,8 @@ export interface Tab {
   selectedFile: FileDiff | null;
   viewedFiles: Set<string>;
   staleViewedFiles: Set<string>;
+  /** Keys (see highlightKey) of AI highlights the user has dismissed for this PR. */
+  dismissedHighlights: Set<string>;
   commentThreads: CommentThreadsState;
   selectedCommentFile: string | null;
   sidebarView: SidebarView;

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -2,6 +2,25 @@ export function getFileName(path: string): string {
   return path.split("/").pop() || path;
 }
 
+// djb2 string hash → unsigned base36, for compact stable keys.
+function hashString(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Stable identifier for an AI highlight, used to persist dismissals. Includes the
+ * comment text (hashed) so a dismissal survives re-fetches but re-surfaces if the
+ * note's wording changes (i.e. the AI flagged something different).
+ */
+export function highlightKey(
+  path: string,
+  h: { start_line: number; end_line: number; comment: string },
+): string {
+  return `${path}:${h.start_line}-${h.end_line}:${hashString(h.comment)}`;
+}
+
 export function parsePrUrl(url: string): { owner: string; repo: string; number: number } {
   const match = url.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
   if (!match) throw new Error(`Invalid PR URL: ${url}`);

--- a/scripts/resolve-highlights.mjs
+++ b/scripts/resolve-highlights.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Resolve (dismiss) Marrow AI highlights from outside the app, by writing the
+// same per-PR dismissed-highlights file the desktop app reads. The app reloads
+// that file when its window regains focus, so resolutions show up by switching
+// back to Marrow.
+//
+// Usage:
+//   node scripts/resolve-highlights.mjs <pr>            resolve ALL highlights
+//   node scripts/resolve-highlights.mjs <pr> --list     show notes + status, write nothing
+//   node scripts/resolve-highlights.mjs <pr> --undo     un-resolve (restore) instead
+//   node scripts/resolve-highlights.mjs <pr> --severity=info,warning
+//   node scripts/resolve-highlights.mjs <pr> --file=commands.rs
+//   node scripts/resolve-highlights.mjs <pr> --prune    also drop stale keys (notes that no longer exist)
+//
+// <pr> may be a bare number (e.g. 126 — matched against the manifests dir), an
+// owner/repo/number or PR URL, or a path to a manifest .json.
+// Config dir defaults to ~/.config/marrow (override with MARROW_CONFIG_DIR).
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// ── highlightKey: byte-for-byte identical to app/src/utils.ts ────────────────
+function hashString(s) {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+}
+function highlightKey(filePath, h) {
+  return `${filePath}:${h.start_line}-${h.end_line}:${hashString(h.comment)}`;
+}
+
+const CONFIG_DIR = process.env.MARROW_CONFIG_DIR || path.join(os.homedir(), ".config", "marrow");
+const MANIFESTS = path.join(CONFIG_DIR, "manifests");
+const DISMISSED = path.join(CONFIG_DIR, "dismissed");
+
+function die(msg) {
+  console.error(`error: ${msg}`);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter((a) => a.startsWith("--") && !a.includes("=")));
+const opts = Object.fromEntries(
+  args.filter((a) => a.startsWith("--") && a.includes("=")).map((a) => a.slice(2).split("=")),
+);
+const positional = args.filter((a) => !a.startsWith("--"));
+if (positional.length !== 1) die("expected exactly one <pr> argument. See header for usage.");
+const target = positional[0];
+
+// ── Locate the manifest + derive owner/repo/number ──────────────────────────
+function manifestNameToParts(file) {
+  const m = path.basename(file, ".json").match(/^(.+?)_(.+?)_(\d+)$/);
+  return m ? { owner: m[1], repo: m[2], number: Number(m[3]) } : null;
+}
+
+let manifestPath, parts;
+if (fs.existsSync(target) && target.endsWith(".json")) {
+  manifestPath = target;
+  parts = manifestNameToParts(target);
+} else {
+  const url = target.match(/(?:github\.com\/)?([^/\s]+)\/([^/\s]+)\/(?:pull\/)?(\d+)/);
+  if (url) {
+    parts = { owner: url[1], repo: url[2], number: Number(url[3]) };
+    manifestPath = path.join(MANIFESTS, `${parts.owner}_${parts.repo}_${parts.number}.json`);
+  } else if (/^\d+$/.test(target)) {
+    const matches = fs
+      .readdirSync(MANIFESTS)
+      .filter((f) => f.endsWith(`_${target}.json`) && !f.endsWith(".meta.json"));
+    if (matches.length === 0) die(`no cached manifest for PR #${target} in ${MANIFESTS}`);
+    if (matches.length > 1) die(`PR #${target} is ambiguous: ${matches.join(", ")} — pass owner/repo/${target}`);
+    manifestPath = path.join(MANIFESTS, matches[0]);
+    parts = manifestNameToParts(matches[0]);
+  } else {
+    die(`could not parse <pr>="${target}"`);
+  }
+}
+if (!parts) die(`could not derive owner/repo/number from ${manifestPath}`);
+if (!fs.existsSync(manifestPath)) die(`manifest not found: ${manifestPath}`);
+
+// ── Gather highlights (with optional filters) ───────────────────────────────
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+const sevFilter = opts.severity ? new Set(opts.severity.split(",").map((s) => s.trim().toLowerCase())) : null;
+const fileFilter = opts.file || null;
+
+const notes = [];
+for (const f of manifest.files ?? []) {
+  for (const h of f.highlights ?? []) {
+    if (sevFilter && !sevFilter.has((h.severity || "").toLowerCase())) continue;
+    if (fileFilter && !f.path.includes(fileFilter)) continue;
+    notes.push({ ...h, path: f.path, severity: (h.severity || "").toUpperCase(), key: highlightKey(f.path, h) });
+  }
+}
+
+const dismissedPath = path.join(DISMISSED, `${parts.owner}_${parts.repo}_${parts.number}.json`);
+const existing = new Set(fs.existsSync(dismissedPath) ? JSON.parse(fs.readFileSync(dismissedPath, "utf8")).keys : []);
+
+const label = `${parts.owner}/${parts.repo}#${parts.number}`;
+console.log(`${label} — ${notes.length} highlight(s)${sevFilter || fileFilter ? " (filtered)" : ""}`);
+for (const n of notes) {
+  const mark = existing.has(n.key) ? "✓ resolved" : "· open";
+  console.log(`  [${n.severity.padEnd(7)}] ${n.path} L${n.start_line}-${n.end_line}  ${mark}`);
+}
+
+if (flags.has("--list")) {
+  console.log(`\n(--list) wrote nothing.`);
+  process.exit(0);
+}
+
+// ── Apply ───────────────────────────────────────────────────────────────────
+const undo = flags.has("--undo");
+const next = new Set(existing);
+let changed = 0;
+for (const n of notes) {
+  if (undo) { if (next.delete(n.key)) changed++; }
+  else if (!next.has(n.key)) { next.add(n.key); changed++; }
+}
+
+if (flags.has("--prune")) {
+  // Drop any stored key that doesn't correspond to a current highlight in this PR.
+  const live = new Set((manifest.files ?? []).flatMap((f) => (f.highlights ?? []).map((h) => highlightKey(f.path, h))));
+  for (const k of [...next]) if (!live.has(k)) { next.delete(k); changed++; }
+}
+
+fs.mkdirSync(DISMISSED, { recursive: true });
+fs.writeFileSync(dismissedPath, JSON.stringify({ keys: [...next].sort() }, null, 2));
+fs.chmodSync(dismissedPath, 0o600);
+
+console.log(
+  `\n${undo ? "un-resolved" : "resolved"} ${changed} | file now has ${next.size} key(s)\n` +
+    `→ ${dismissedPath}\n` +
+    `→ switch back to Marrow (it reloads on window focus) to see the change.`,
+);


### PR DESCRIPTION
## Summary

You asked for a way to **resolve/dismiss AI highlights** — there wasn't one (the only action was "Post as comment"). This adds it.

- Each AI note in a file's notes summary gets a **× dismiss** button.
- Dismissed notes **drop out of the diff** entirely — inline markers, line tints, **and** `n`/`N` keyboard navigation skip them.
- They collapse into a **"Show N dismissed"** section at the bottom of the summary, where each can be **Restored**.
- Dismissals **persist per PR** and survive refreshes.

## How it works

**Persistence** mirrors the existing `viewed`-files mechanism exactly:
- New core module `dismissed_highlights.rs` → `~/.config/marrow/dismissed/{owner}_{repo}_{pr}.json` (0600), with `load_dismissed_highlights` / `save_dismissed_highlights` Tauri commands.
- `Tab.dismissedHighlights: Set<string>`, loaded on PR open (alongside viewed state), saved on each toggle.

**Stable key** (`highlightKey` in `utils.ts`): `path:start-end:hash(comment)`. Including a hash of the comment text means a dismissal **survives re-fetches** but **re-surfaces if the AI note's wording changes** (i.e. the AI flagged something genuinely different on that line). Carried across refresh via the existing tab spread.

**DiffViewer** splits `file.highlights` into active vs dismissed; `highlights` (active) is what the inline markers, line tints, and `sortedFindings` (n/N) all key off, so dismissed notes vanish from the review surface but stay restorable.

## Testing

- `cargo check` clean; `tsc --noEmit` clean; `vite build` succeeds.
- ⚠️ **Not yet runtime-verified.** Worth exercising:
  - Dismiss a note → it disappears from the diff (marker + tint) and from `n`/`N` nav; "Show N dismissed" appears.
  - Restore it → it comes back everywhere.
  - Reopen the PR (or refresh) → dismissals persist; check `~/.config/marrow/dismissed/`.
  - Edit a note's text upstream (or simulate) → it re-surfaces as active (key changed).

Branches off `main` after v0.14.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)