### PR TITLE
fix(gui): }/{ hunk nav moves the line cursor

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1856,16 +1856,21 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     if (!c) return;
     const rows = navRows();
     if (!rows.length) return;
-    // Find the next/previous hunk relative to the cursor's current line, then move
-    // the cursor onto that hunk's first navigable row (its first code line, or its
-    // fold row when collapsed) — same as j/k, just hunk-sized jumps.
+    // Step by hunk relative to the hunk the cursor is *in* (not its pixel offset),
+    // then move the cursor onto the target hunk's first navigable row (its first
+    // code line, or its fold row when collapsed) — same as j/k, hunk-sized jumps.
+    const offs = hunkOffsets(); // sorted by top
+    if (!offs.length) return;
     const curTop = offsetWithin(rows[cursorIndex(rows)], c);
-    const offs = hunkOffsets();
-    const target =
-      dir > 0
-        ? offs.find((o) => o.top > curTop + 4)
-        : [...offs].reverse().find((o) => o.top < curTop - 4);
-    if (!target) return;
+    // Current hunk = the last one anchored at/above the cursor.
+    let cur = 0;
+    for (let i = 0; i < offs.length; i++) {
+      if (offs[i].top <= curTop + 4) cur = i;
+      else break;
+    }
+    const targetPos = cur + dir;
+    if (targetPos < 0 || targetPos >= offs.length) return;
+    const target = offs[targetPos];
     const idx = rows.findIndex((r) => offsetWithin(r, c) >= target.top - 1);
     moveCursorTo(rows, idx >= 0 ? idx : (dir > 0 ? rows.length - 1 : 0));
   };

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1851,18 +1851,23 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
       .sort((a, b) => a.top - b.top);
   };
 
-  const scrollDiffTo = (top: number) =>
-    diffContentRef.current?.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
-
   const goToAdjacentHunk = (dir: 1 | -1) => {
     const c = diffContentRef.current;
     if (!c) return;
+    const rows = navRows();
+    if (!rows.length) return;
+    // Find the next/previous hunk relative to the cursor's current line, then move
+    // the cursor onto that hunk's first navigable row (its first code line, or its
+    // fold row when collapsed) — same as j/k, just hunk-sized jumps.
+    const curTop = offsetWithin(rows[cursorIndex(rows)], c);
     const offs = hunkOffsets();
     const target =
       dir > 0
-        ? offs.find((o) => o.top > c.scrollTop + 4)
-        : [...offs].reverse().find((o) => o.top < c.scrollTop - 4);
-    if (target) scrollDiffTo(target.top);
+        ? offs.find((o) => o.top > curTop + 4)
+        : [...offs].reverse().find((o) => o.top < curTop - 4);
+    if (!target) return;
+    const idx = rows.findIndex((r) => offsetWithin(r, c) >= target.top - 1);
+    moveCursorTo(rows, idx >= 0 ? idx : (dir > 0 ? rows.length - 1 : 0));
   };
   const nextHunk = () => goToAdjacentHunk(1);
   const prevHunk = () => goToAdjacentHunk(-1);


### PR DESCRIPTION
`}` / `{` (next/previous hunk) were leftover Tier 2 **scroll-only** behavior — they moved the viewport but left the keyboard cursor behind. Now they move the **cursor** like `j`/`k` do, just in hunk-sized jumps:

- Finds the next/previous hunk **relative to the cursor's current line** (not the raw scroll position).
- Moves the cursor onto that hunk's **first navigable row** — its first code line, or its **fold row** when the hunk is collapsed (so you can `}` onto a collapsed hunk and `z` to open it).
- Removed the now-unused `scrollDiffTo` helper.

`tsc` + `vite build` clean. Small, self-contained; branches off `main`.

⚠️ Not runtime-verified — worth confirming `}`/`{` land the cursor on the right hunk in split + unified, including onto collapsed hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)