### PR TITLE
feat(ai): conversational diff Q&A chat scoped to the PR (#131)

### DIFF
--- a/app/bun.lock
+++ b/app/bun.lock
@@ -11,6 +11,7 @@
         "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "diff2html": "^3.4.48",
+        "highlight.js": "^11.11.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "diff2html": "^3.4.48",
+    "highlight.js": "^11.11.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4176,6 +4176,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4188,6 +4189,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -4212,12 +4214,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -4257,7 +4261,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6306,6 +6310,19 @@ dependencies = [
  "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio-util = "0.7"
 marrow-core = { path = "crates/core" }
 
 # Read NSApplication.isActive to drive the floating mini-player: macOS delivers

--- a/app/src-tauri/crates/core/Cargo.toml
+++ b/app/src-tauri/crates/core/Cargo.toml
@@ -14,8 +14,8 @@ categories = ["development-tools"]
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-util"] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-bedrockruntime = "1"
 futures = "0.3"

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -146,6 +146,30 @@ pub enum AiBackend {
     },
 }
 
+/// Who authored a turn in a chat conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatRole {
+    User,
+    Assistant,
+}
+
+impl ChatRole {
+    /// The wire string used by the Anthropic / OpenAI message APIs.
+    fn api_str(&self) -> &'static str {
+        match self {
+            ChatRole::User => "user",
+            ChatRole::Assistant => "assistant",
+        }
+    }
+}
+
+/// One turn of a multi-turn chat conversation fed to [`AiBackend::invoke_chat_stream`].
+#[derive(Debug, Clone)]
+pub struct ChatTurn {
+    pub role: ChatRole,
+    pub content: String,
+}
+
 impl AiBackend {
     /// Build a backend from a full `Settings` (resolving keys/base-url from
     /// config + env).
@@ -228,6 +252,272 @@ impl AiBackend {
             AiBackend::ClaudeCli { model } => invoke_claude_cli(model, prompt).await,
         }
     }
+
+    /// Stream a multi-turn chat completion. `system` is the grounding/context
+    /// preamble; `turns` is the conversation so far (last turn is the user's new
+    /// message). Each text fragment is passed to `on_delta` as it arrives; the
+    /// fully assembled text is also returned.
+    pub async fn invoke_chat_stream(
+        &self,
+        system: &str,
+        turns: &[ChatTurn],
+        on_delta: &mut (dyn FnMut(String) + Send),
+    ) -> Result<String, String> {
+        match self {
+            AiBackend::Bedrock { client, model_arn } => {
+                client.converse_stream(model_arn, system, turns, on_delta).await
+            }
+            AiBackend::Anthropic { api_key, model } => {
+                stream_anthropic(api_key, model, system, turns, on_delta).await
+            }
+            AiBackend::OpenAiCompatible { base_url, api_key, model } => {
+                stream_openai_compatible(base_url, api_key, model, system, turns, on_delta).await
+            }
+            AiBackend::ClaudeCli { model } => {
+                stream_claude_cli(model, system, turns, on_delta).await
+            }
+        }
+    }
+}
+
+/// Consume a Server-Sent Events response, calling `extract` on each `data:`
+/// payload to pull out a text delta. Stops on the OpenAI `[DONE]` sentinel or
+/// end of stream. Bytes are buffered and only split on `\n` (which never falls
+/// inside a multibyte UTF-8 char), so deltas are never corrupted across chunks.
+async fn consume_sse(
+    resp: reqwest::Response,
+    mut extract: impl FnMut(&str) -> Option<String>,
+    on_delta: &mut (dyn FnMut(String) + Send),
+) -> Result<String, String> {
+    use futures::StreamExt;
+    let mut stream = resp.bytes_stream();
+    let mut buf: Vec<u8> = Vec::new();
+    let mut full = String::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("AI stream read failed: {e}"))?;
+        buf.extend_from_slice(&chunk);
+        while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
+            let line_bytes: Vec<u8> = buf.drain(..=nl).collect();
+            let line = String::from_utf8_lossy(&line_bytes);
+            let line = line.trim_end_matches(['\r', '\n']);
+            let Some(data) = line.strip_prefix("data:") else { continue };
+            let data = data.trim();
+            if data == "[DONE]" {
+                return Ok(full);
+            }
+            if let Some(delta) = extract(data) {
+                if !delta.is_empty() {
+                    full.push_str(&delta);
+                    on_delta(delta);
+                }
+            }
+        }
+    }
+    Ok(full)
+}
+
+/// Build the OpenAI/Anthropic-style `messages` array from a system preamble and
+/// the conversation turns. The `system` role is prepended (OpenAI convention);
+/// Anthropic passes `system` separately and ignores this prepend.
+fn turns_to_messages(turns: &[ChatTurn]) -> Vec<serde_json::Value> {
+    turns
+        .iter()
+        .map(|t| serde_json::json!({ "role": t.role.api_str(), "content": t.content }))
+        .collect()
+}
+
+/// Stream from the Anthropic Messages API (`stream: true`, SSE).
+async fn stream_anthropic(
+    api_key: &str,
+    model: &str,
+    system: &str,
+    turns: &[ChatTurn],
+    on_delta: &mut (dyn FnMut(String) + Send),
+) -> Result<String, String> {
+    let body = serde_json::json!({
+        "model": model,
+        "max_tokens": ANTHROPIC_MAX_TOKENS,
+        "stream": true,
+        "system": system,
+        "messages": turns_to_messages(turns),
+    });
+    let resp = reqwest::Client::new()
+        .post("https://api.anthropic.com/v1/messages")
+        .header("x-api-key", api_key)
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Anthropic API request failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!(
+            "Anthropic API error ({status}): {snippet}. Check your ANTHROPIC_API_KEY and that `{model}` is a valid model name."
+        ));
+    }
+
+    consume_sse(
+        resp,
+        |data| {
+            let json: serde_json::Value = serde_json::from_str(data).ok()?;
+            // content_block_delta events carry the streamed text.
+            if json["type"] == "content_block_delta" {
+                return json["delta"]["text"].as_str().map(str::to_string);
+            }
+            None
+        },
+        on_delta,
+    )
+    .await
+}
+
+/// Stream from an OpenAI-compatible Chat Completions endpoint (`stream: true`).
+async fn stream_openai_compatible(
+    base_url: &str,
+    api_key: &str,
+    model: &str,
+    system: &str,
+    turns: &[ChatTurn],
+    on_delta: &mut (dyn FnMut(String) + Send),
+) -> Result<String, String> {
+    let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
+    let mut messages = vec![serde_json::json!({ "role": "system", "content": system })];
+    messages.extend(turns_to_messages(turns));
+    let body = serde_json::json!({
+        "model": model,
+        "stream": true,
+        "messages": messages,
+    });
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("authorization", format!("Bearer {api_key}"))
+        .header("content-type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("OpenAI-compatible request to {url} failed: {e}"))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.text().await.unwrap_or_default();
+        let snippet: String = text.chars().take(500).collect();
+        return Err(format!(
+            "OpenAI-compatible API error ({status}) from {url}: {snippet}. Check the API key, base URL, and that `{model}` is valid there."
+        ));
+    }
+
+    consume_sse(
+        resp,
+        |data| {
+            let json: serde_json::Value = serde_json::from_str(data).ok()?;
+            json["choices"][0]["delta"]["content"].as_str().map(str::to_string)
+        },
+        on_delta,
+    )
+    .await
+}
+
+/// Stream from the `claude` CLI. The CLI is single-shot over stdin, so we flatten
+/// the system preamble + turns into one prompt and read stdout incrementally,
+/// emitting each chunk as a delta.
+async fn stream_claude_cli(
+    model: &str,
+    system: &str,
+    turns: &[ChatTurn],
+    on_delta: &mut (dyn FnMut(String) + Send),
+) -> Result<String, String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut prompt = String::new();
+    prompt.push_str("System instructions:\n");
+    prompt.push_str(system);
+    prompt.push_str("\n\n");
+    for turn in turns {
+        let label = match turn.role {
+            ChatRole::User => "User",
+            ChatRole::Assistant => "Assistant",
+        };
+        prompt.push_str(&format!("{label}: {}\n\n", turn.content));
+    }
+    prompt.push_str("Assistant:");
+
+    let mut child = Command::new(resolve_claude_binary())
+        .args(["--model", model, "--print"])
+        .env("CLAUDECODE", "") // prevent recursive Claude Code invocation
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        // If this future is dropped mid-stream (the chat was cancelled), kill the
+        // child rather than leaking a running `claude` process.
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| {
+            format!(
+                "Failed to run claude CLI: {} (os error {}). Is the `claude` command installed and on your PATH?",
+                e, e.raw_os_error().unwrap_or(-1)
+            )
+        })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| format!("Failed to write prompt to claude stdin: {}", e))?;
+        // Drop stdin to close it, signaling EOF.
+    }
+
+    let mut full = String::new();
+    if let Some(mut stdout) = child.stdout.take() {
+        let mut buf = [0u8; 4096];
+        let mut pending: Vec<u8> = Vec::new();
+        loop {
+            let n = stdout
+                .read(&mut buf)
+                .await
+                .map_err(|e| format!("Failed to read claude stdout: {}", e))?;
+            if n == 0 {
+                break;
+            }
+            pending.extend_from_slice(&buf[..n]);
+            // Emit only up to the last valid UTF-8 boundary; keep the remainder
+            // (a possibly-split multibyte char) buffered for the next read.
+            let valid = match std::str::from_utf8(&pending) {
+                Ok(s) => s.len(),
+                Err(e) => e.valid_up_to(),
+            };
+            if valid > 0 {
+                let text = String::from_utf8_lossy(&pending[..valid]).to_string();
+                pending.drain(..valid);
+                full.push_str(&text);
+                on_delta(text);
+            }
+        }
+        if !pending.is_empty() {
+            let text = String::from_utf8_lossy(&pending).to_string();
+            full.push_str(&text);
+            on_delta(text);
+        }
+    }
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|e| format!("Failed to wait for claude CLI: {}", e))?;
+    if !status.success() {
+        let mut stderr = String::new();
+        if let Some(mut err) = child.stderr.take() {
+            let _ = err.read_to_string(&mut stderr).await;
+        }
+        return Err(format!("claude CLI exited with {}: {}", status, stderr.trim()));
+    }
+    if full.trim().is_empty() {
+        return Err("claude CLI returned empty response".to_string());
+    }
+    Ok(full)
 }
 
 /// Upper bound on generated tokens for the Anthropic API (required by the API;

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -307,24 +307,45 @@ async fn consume_sse(
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(|e| format!("AI stream read failed: {e}"))?;
         buf.extend_from_slice(&chunk);
-        while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
-            let line_bytes: Vec<u8> = buf.drain(..=nl).collect();
-            let line = String::from_utf8_lossy(&line_bytes);
-            let line = line.trim_end_matches(['\r', '\n']);
-            let Some(data) = line.strip_prefix("data:") else { continue };
-            let data = data.trim();
-            if data == "[DONE]" {
-                return Ok(full);
-            }
-            if let Some(delta) = extract(data) {
-                if !delta.is_empty() {
-                    full.push_str(&delta);
-                    on(StreamUpdate::Delta(delta));
-                }
+        if sse_drain_lines(&mut buf, &mut full, &mut extract, on) {
+            return Ok(full);
+        }
+    }
+    // A spec-compliant stream terminates every line with \n, but if the server
+    // closes with a trailing partial line, don't silently drop its delta.
+    if !buf.is_empty() {
+        buf.push(b'\n');
+        sse_drain_lines(&mut buf, &mut full, &mut extract, on);
+    }
+    Ok(full)
+}
+
+/// Drain complete `\n`-terminated lines from `buf`, feeding each `data:`
+/// payload through `extract` and appending deltas to `full`. Returns true when
+/// the `[DONE]` sentinel is seen.
+fn sse_drain_lines(
+    buf: &mut Vec<u8>,
+    full: &mut String,
+    extract: &mut impl FnMut(&str) -> Option<String>,
+    on: &mut (dyn FnMut(StreamUpdate) + Send),
+) -> bool {
+    while let Some(nl) = buf.iter().position(|&b| b == b'\n') {
+        let line_bytes: Vec<u8> = buf.drain(..=nl).collect();
+        let line = String::from_utf8_lossy(&line_bytes);
+        let line = line.trim_end_matches(['\r', '\n']);
+        let Some(data) = line.strip_prefix("data:") else { continue };
+        let data = data.trim();
+        if data == "[DONE]" {
+            return true;
+        }
+        if let Some(delta) = extract(data) {
+            if !delta.is_empty() {
+                full.push_str(&delta);
+                on(StreamUpdate::Delta(delta));
             }
         }
     }
-    Ok(full)
+    false
 }
 
 /// Build the OpenAI/Anthropic-style `messages` array from a system preamble and
@@ -952,5 +973,50 @@ mod tests {
         assert_eq!(pick("some-local-model", "", true, false), Provider::OpenAiCompatible);
         // But an ARN still wins over a stray base URL.
         assert_eq!(pick("arn:aws:bedrock:...", "", true, false), Provider::Bedrock);
+    }
+}
+
+#[cfg(test)]
+mod sse_tests {
+    use super::*;
+
+    fn drain(input: &[u8]) -> (String, bool) {
+        let mut buf = input.to_vec();
+        let mut full = String::new();
+        let mut extract = |data: &str| Some(data.to_string());
+        let mut on = |_: StreamUpdate| {};
+        let done = sse_drain_lines(&mut buf, &mut full, &mut extract, &mut on);
+        (full, done)
+    }
+
+    #[test]
+    fn drains_complete_lines_and_stops_on_done() {
+        let (full, done) = drain(b"data: a\ndata: b\ndata: [DONE]\ndata: c\n");
+        assert_eq!(full, "ab");
+        assert!(done);
+    }
+
+    #[test]
+    fn trailing_partial_line_is_recovered_with_pushed_newline() {
+        // Mirrors consume_sse's end-of-stream path: a final line with no \n is
+        // left in buf by the first drain, then recovered after pushing one.
+        let mut buf = b"data: a\ndata: tail".to_vec();
+        let mut full = String::new();
+        let mut extract = |data: &str| Some(data.to_string());
+        let mut on = |_: StreamUpdate| {};
+        assert!(!sse_drain_lines(&mut buf, &mut full, &mut extract, &mut on));
+        assert_eq!(full, "a");
+        assert_eq!(buf, b"data: tail");
+        buf.push(b'\n');
+        sse_drain_lines(&mut buf, &mut full, &mut extract, &mut on);
+        assert_eq!(full, "atail");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn non_data_lines_and_crlf_are_tolerated() {
+        let (full, done) = drain(b"event: ping\r\ndata: x\r\n\r\n");
+        assert_eq!(full, "x");
+        assert!(!done);
     }
 }

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -498,7 +498,13 @@ async fn stream_claude_cli(
     // status while the agent uses tools between blocks. Splitting on `\n` never
     // bisects a multibyte char, so each complete line decodes cleanly.
     let mut full = String::new();
-    let mut last_index: Option<u64> = None;
+    // The CLI resets the content-block index to 0 for each new assistant message,
+    // so a tool call followed by more text reuses index 0 — index alone can't tell
+    // blocks apart. Instead, a new *text block start* after we've already emitted
+    // text means a gap (tool use / thinking) happened; insert a blank line before
+    // that block's text so segments don't run together.
+    let mut emitted_text = false;
+    let mut need_separator = false;
     if let Some(stdout) = child.stdout.take() {
         let mut reader = tokio::io::BufReader::new(stdout);
         let mut line = String::new();
@@ -516,16 +522,20 @@ async fn stream_claude_cli(
                 continue;
             }
             match cli_event(trimmed) {
-                Some(CliEvent::Text { index, text }) => {
-                    // A new text block after an earlier one means tool use happened
-                    // in between — separate them with a blank line.
-                    if last_index.is_some_and(|prev| prev != index) {
-                        full.push_str("\n\n");
-                        on(StreamUpdate::Delta("\n\n".to_string()));
+                Some(CliEvent::TextStart) => {
+                    if emitted_text {
+                        need_separator = true;
                     }
-                    last_index = Some(index);
+                }
+                Some(CliEvent::Text(text)) => {
                     if !text.is_empty() {
+                        if need_separator {
+                            full.push_str("\n\n");
+                            on(StreamUpdate::Delta("\n\n".to_string()));
+                            need_separator = false;
+                        }
                         full.push_str(&text);
+                        emitted_text = true;
                         on(StreamUpdate::Delta(text));
                     }
                 }
@@ -558,14 +568,16 @@ async fn stream_claude_cli(
 /// stream-json --include-partial-messages`.
 #[derive(Debug, PartialEq)]
 enum CliEvent {
-    /// A chunk of answer text in content block `index`.
-    Text { index: u64, text: String },
-    /// The agent started using a tool (between text blocks).
+    /// A text content block began (used to separate consecutive text segments).
+    TextStart,
+    /// A chunk of answer text.
+    Text(String),
+    /// The agent started using a tool (a gap between text blocks).
     ToolUse,
 }
 
 /// Parse one NDJSON line into a [`CliEvent`], or None for lines we don't surface
-/// (init, usage, thinking deltas, result, …).
+/// (init, usage, thinking deltas/blocks, result, …).
 fn cli_event(line: &str) -> Option<CliEvent> {
     let json: serde_json::Value = serde_json::from_str(line).ok()?;
     if json["type"] != "stream_event" {
@@ -573,13 +585,13 @@ fn cli_event(line: &str) -> Option<CliEvent> {
     }
     let event = &json["event"];
     match event["type"].as_str()? {
+        "content_block_start" => match event["content_block"]["type"].as_str()? {
+            "text" => Some(CliEvent::TextStart),
+            "tool_use" => Some(CliEvent::ToolUse),
+            _ => None, // thinking / other blocks
+        },
         "content_block_delta" if event["delta"]["type"] == "text_delta" => {
-            let index = event["index"].as_u64().unwrap_or(0);
-            let text = event["delta"]["text"].as_str()?.to_string();
-            Some(CliEvent::Text { index, text })
-        }
-        "content_block_start" if event["content_block"]["type"] == "tool_use" => {
-            Some(CliEvent::ToolUse)
+            Some(CliEvent::Text(event["delta"]["text"].as_str()?.to_string()))
         }
         _ => None,
     }
@@ -777,12 +789,16 @@ mod tests {
     }
 
     #[test]
-    fn cli_event_extracts_text_tool_and_ignores_rest() {
+    fn cli_event_classifies_text_textstart_tool_and_ignores_rest() {
         let d = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Hello"}}}"#;
-        assert_eq!(cli_event(d), Some(CliEvent::Text { index: 2, text: "Hello".to_string() }));
+        assert_eq!(cli_event(d), Some(CliEvent::Text("Hello".to_string())));
+        let text_start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}}"#;
+        assert_eq!(cli_event(text_start), Some(CliEvent::TextStart));
         let tool = r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"Read"}}}"#;
         assert_eq!(cli_event(tool), Some(CliEvent::ToolUse));
-        // thinking deltas, non-stream events, and init/result lines yield nothing.
+        // thinking blocks/deltas, non-stream events, and init/result lines yield nothing.
+        let thinking_start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}}"#;
+        assert_eq!(cli_event(thinking_start), None);
         let thinking = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}}"#;
         assert_eq!(cli_event(thinking), None);
         let init = r#"{"type":"system","subtype":"init"}"#;
@@ -790,6 +806,45 @@ mod tests {
         let result = r#"{"type":"result","result":"Hello"}"#;
         assert_eq!(cli_event(result), None);
         assert_eq!(cli_event("not json"), None);
+    }
+
+    // The agent reuses content-block index 0 across messages, so a tool call
+    // between two text blocks looks like (TextStart, Text, ToolUse, TextStart,
+    // Text) with the same index — the separator must come from TextStart, not
+    // the index. This mirrors the loop logic in `stream_claude_cli`.
+    #[test]
+    fn separator_inserted_between_text_blocks_across_a_tool_gap() {
+        let events = [
+            CliEvent::TextStart,
+            CliEvent::Text("first.".to_string()),
+            CliEvent::ToolUse,
+            CliEvent::TextStart,
+            CliEvent::Text("second.".to_string()),
+        ];
+        let mut out = String::new();
+        let mut emitted_text = false;
+        let mut need_separator = false;
+        for ev in events {
+            match ev {
+                CliEvent::TextStart => {
+                    if emitted_text {
+                        need_separator = true;
+                    }
+                }
+                CliEvent::Text(text) => {
+                    if !text.is_empty() {
+                        if need_separator {
+                            out.push_str("\n\n");
+                            need_separator = false;
+                        }
+                        out.push_str(&text);
+                        emitted_text = true;
+                    }
+                }
+                CliEvent::ToolUse => {}
+            }
+        }
+        assert_eq!(out, "first.\n\nsecond.");
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -170,6 +170,17 @@ pub struct ChatTurn {
     pub content: String,
 }
 
+/// An incremental update from a streaming chat call.
+#[derive(Debug, Clone)]
+pub enum StreamUpdate {
+    /// A fragment of answer text to append.
+    Delta(String),
+    /// A transient status while no answer text is being produced — e.g. the
+    /// `claude` CLI agent using tools between text blocks. `Some(label)` to show,
+    /// `None` to clear. Not part of the saved answer.
+    Status(Option<String>),
+}
+
 impl AiBackend {
     /// Build a backend from a full `Settings` (resolving keys/base-url from
     /// config + env).
@@ -261,20 +272,20 @@ impl AiBackend {
         &self,
         system: &str,
         turns: &[ChatTurn],
-        on_delta: &mut (dyn FnMut(String) + Send),
+        on: &mut (dyn FnMut(StreamUpdate) + Send),
     ) -> Result<String, String> {
         match self {
             AiBackend::Bedrock { client, model_arn } => {
-                client.converse_stream(model_arn, system, turns, on_delta).await
+                client.converse_stream(model_arn, system, turns, on).await
             }
             AiBackend::Anthropic { api_key, model } => {
-                stream_anthropic(api_key, model, system, turns, on_delta).await
+                stream_anthropic(api_key, model, system, turns, on).await
             }
             AiBackend::OpenAiCompatible { base_url, api_key, model } => {
-                stream_openai_compatible(base_url, api_key, model, system, turns, on_delta).await
+                stream_openai_compatible(base_url, api_key, model, system, turns, on).await
             }
             AiBackend::ClaudeCli { model } => {
-                stream_claude_cli(model, system, turns, on_delta).await
+                stream_claude_cli(model, system, turns, on).await
             }
         }
     }
@@ -287,7 +298,7 @@ impl AiBackend {
 async fn consume_sse(
     resp: reqwest::Response,
     mut extract: impl FnMut(&str) -> Option<String>,
-    on_delta: &mut (dyn FnMut(String) + Send),
+    on: &mut (dyn FnMut(StreamUpdate) + Send),
 ) -> Result<String, String> {
     use futures::StreamExt;
     let mut stream = resp.bytes_stream();
@@ -308,7 +319,7 @@ async fn consume_sse(
             if let Some(delta) = extract(data) {
                 if !delta.is_empty() {
                     full.push_str(&delta);
-                    on_delta(delta);
+                    on(StreamUpdate::Delta(delta));
                 }
             }
         }
@@ -332,7 +343,7 @@ async fn stream_anthropic(
     model: &str,
     system: &str,
     turns: &[ChatTurn],
-    on_delta: &mut (dyn FnMut(String) + Send),
+    on: &mut (dyn FnMut(StreamUpdate) + Send),
 ) -> Result<String, String> {
     let body = serde_json::json!({
         "model": model,
@@ -370,7 +381,7 @@ async fn stream_anthropic(
             }
             None
         },
-        on_delta,
+        on,
     )
     .await
 }
@@ -382,7 +393,7 @@ async fn stream_openai_compatible(
     model: &str,
     system: &str,
     turns: &[ChatTurn],
-    on_delta: &mut (dyn FnMut(String) + Send),
+    on: &mut (dyn FnMut(StreamUpdate) + Send),
 ) -> Result<String, String> {
     let url = format!("{}/chat/completions", base_url.trim_end_matches('/'));
     let mut messages = vec![serde_json::json!({ "role": "system", "content": system })];
@@ -416,7 +427,7 @@ async fn stream_openai_compatible(
             let json: serde_json::Value = serde_json::from_str(data).ok()?;
             json["choices"][0]["delta"]["content"].as_str().map(str::to_string)
         },
-        on_delta,
+        on,
     )
     .await
 }
@@ -428,7 +439,7 @@ async fn stream_claude_cli(
     model: &str,
     system: &str,
     turns: &[ChatTurn],
-    on_delta: &mut (dyn FnMut(String) + Send),
+    on: &mut (dyn FnMut(StreamUpdate) + Send),
 ) -> Result<String, String> {
     use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
@@ -480,11 +491,14 @@ async fn stream_claude_cli(
         // Drop stdin to close it, signaling EOF.
     }
 
-    // Read NDJSON line by line. Each `content_block_delta` with a `text_delta`
-    // carries one token chunk of the answer; everything else (init, usage,
-    // thinking deltas, result) is ignored. Splitting on `\n` never bisects a
-    // multibyte char, so each complete line decodes cleanly.
+    // Read NDJSON line by line. The CLI runs as an agent: it emits a text block,
+    // may call tools, then emits another text block. We stream `text_delta`s as
+    // answer text, insert a blank line between separate text blocks (different
+    // `index`) so they don't run together, and surface a transient "Working…"
+    // status while the agent uses tools between blocks. Splitting on `\n` never
+    // bisects a multibyte char, so each complete line decodes cleanly.
     let mut full = String::new();
+    let mut last_index: Option<u64> = None;
     if let Some(stdout) = child.stdout.take() {
         let mut reader = tokio::io::BufReader::new(stdout);
         let mut line = String::new();
@@ -501,11 +515,24 @@ async fn stream_claude_cli(
             if trimmed.is_empty() {
                 continue;
             }
-            if let Some(text) = cli_text_delta(trimmed) {
-                if !text.is_empty() {
-                    full.push_str(&text);
-                    on_delta(text);
+            match cli_event(trimmed) {
+                Some(CliEvent::Text { index, text }) => {
+                    // A new text block after an earlier one means tool use happened
+                    // in between — separate them with a blank line.
+                    if last_index.is_some_and(|prev| prev != index) {
+                        full.push_str("\n\n");
+                        on(StreamUpdate::Delta("\n\n".to_string()));
+                    }
+                    last_index = Some(index);
+                    if !text.is_empty() {
+                        full.push_str(&text);
+                        on(StreamUpdate::Delta(text));
+                    }
                 }
+                Some(CliEvent::ToolUse) => {
+                    on(StreamUpdate::Status(Some("Working…".to_string())));
+                }
+                None => {}
             }
         }
     }
@@ -527,23 +554,35 @@ async fn stream_claude_cli(
     Ok(full)
 }
 
-/// Extract the answer text from one NDJSON line of `claude --output-format
-/// stream-json --include-partial-messages`. Returns the text of a
-/// `content_block_delta` / `text_delta` event, or None for any other line.
-fn cli_text_delta(line: &str) -> Option<String> {
+/// A meaningful event parsed from one NDJSON line of `claude --output-format
+/// stream-json --include-partial-messages`.
+#[derive(Debug, PartialEq)]
+enum CliEvent {
+    /// A chunk of answer text in content block `index`.
+    Text { index: u64, text: String },
+    /// The agent started using a tool (between text blocks).
+    ToolUse,
+}
+
+/// Parse one NDJSON line into a [`CliEvent`], or None for lines we don't surface
+/// (init, usage, thinking deltas, result, …).
+fn cli_event(line: &str) -> Option<CliEvent> {
     let json: serde_json::Value = serde_json::from_str(line).ok()?;
     if json["type"] != "stream_event" {
         return None;
     }
     let event = &json["event"];
-    if event["type"] != "content_block_delta" {
-        return None;
+    match event["type"].as_str()? {
+        "content_block_delta" if event["delta"]["type"] == "text_delta" => {
+            let index = event["index"].as_u64().unwrap_or(0);
+            let text = event["delta"]["text"].as_str()?.to_string();
+            Some(CliEvent::Text { index, text })
+        }
+        "content_block_start" if event["content_block"]["type"] == "tool_use" => {
+            Some(CliEvent::ToolUse)
+        }
+        _ => None,
     }
-    let delta = &event["delta"];
-    if delta["type"] != "text_delta" {
-        return None; // skip thinking_delta and others
-    }
-    delta["text"].as_str().map(str::to_string)
 }
 
 /// Upper bound on generated tokens for the Anthropic API (required by the API;
@@ -738,17 +777,19 @@ mod tests {
     }
 
     #[test]
-    fn cli_text_delta_extracts_only_text_deltas() {
-        let d = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}"#;
-        assert_eq!(cli_text_delta(d).as_deref(), Some("Hello"));
-        // thinking deltas, non-stream events, and init lines yield nothing.
+    fn cli_event_extracts_text_tool_and_ignores_rest() {
+        let d = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Hello"}}}"#;
+        assert_eq!(cli_event(d), Some(CliEvent::Text { index: 2, text: "Hello".to_string() }));
+        let tool = r#"{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","name":"Read"}}}"#;
+        assert_eq!(cli_event(tool), Some(CliEvent::ToolUse));
+        // thinking deltas, non-stream events, and init/result lines yield nothing.
         let thinking = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}}"#;
-        assert_eq!(cli_text_delta(thinking), None);
+        assert_eq!(cli_event(thinking), None);
         let init = r#"{"type":"system","subtype":"init"}"#;
-        assert_eq!(cli_text_delta(init), None);
+        assert_eq!(cli_event(init), None);
         let result = r#"{"type":"result","result":"Hello"}"#;
-        assert_eq!(cli_text_delta(result), None);
-        assert_eq!(cli_text_delta("not json"), None);
+        assert_eq!(cli_event(result), None);
+        assert_eq!(cli_event("not json"), None);
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -430,7 +430,7 @@ async fn stream_claude_cli(
     turns: &[ChatTurn],
     on_delta: &mut (dyn FnMut(String) + Send),
 ) -> Result<String, String> {
-    use tokio::io::AsyncReadExt;
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
     let mut prompt = String::new();
     prompt.push_str("System instructions:\n");
@@ -445,8 +445,18 @@ async fn stream_claude_cli(
     }
     prompt.push_str("Assistant:");
 
+    // `stream-json` + `--include-partial-messages` makes the CLI emit NDJSON with
+    // token-level `content_block_delta` events. Plain `--print` buffers the whole
+    // answer and prints it at the end (no visible streaming), so we parse the
+    // event stream instead.
     let mut child = Command::new(resolve_claude_binary())
-        .args(["--model", model, "--print"])
+        .args([
+            "--model", model,
+            "--print",
+            "--output-format", "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+        ])
         .env("CLAUDECODE", "") // prevent recursive Claude Code invocation
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -470,36 +480,33 @@ async fn stream_claude_cli(
         // Drop stdin to close it, signaling EOF.
     }
 
+    // Read NDJSON line by line. Each `content_block_delta` with a `text_delta`
+    // carries one token chunk of the answer; everything else (init, usage,
+    // thinking deltas, result) is ignored. Splitting on `\n` never bisects a
+    // multibyte char, so each complete line decodes cleanly.
     let mut full = String::new();
-    if let Some(mut stdout) = child.stdout.take() {
-        let mut buf = [0u8; 4096];
-        let mut pending: Vec<u8> = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        let mut reader = tokio::io::BufReader::new(stdout);
+        let mut line = String::new();
         loop {
-            let n = stdout
-                .read(&mut buf)
+            line.clear();
+            let n = reader
+                .read_line(&mut line)
                 .await
                 .map_err(|e| format!("Failed to read claude stdout: {}", e))?;
             if n == 0 {
                 break;
             }
-            pending.extend_from_slice(&buf[..n]);
-            // Emit only up to the last valid UTF-8 boundary; keep the remainder
-            // (a possibly-split multibyte char) buffered for the next read.
-            let valid = match std::str::from_utf8(&pending) {
-                Ok(s) => s.len(),
-                Err(e) => e.valid_up_to(),
-            };
-            if valid > 0 {
-                let text = String::from_utf8_lossy(&pending[..valid]).to_string();
-                pending.drain(..valid);
-                full.push_str(&text);
-                on_delta(text);
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
             }
-        }
-        if !pending.is_empty() {
-            let text = String::from_utf8_lossy(&pending).to_string();
-            full.push_str(&text);
-            on_delta(text);
+            if let Some(text) = cli_text_delta(trimmed) {
+                if !text.is_empty() {
+                    full.push_str(&text);
+                    on_delta(text);
+                }
+            }
         }
     }
 
@@ -518,6 +525,25 @@ async fn stream_claude_cli(
         return Err("claude CLI returned empty response".to_string());
     }
     Ok(full)
+}
+
+/// Extract the answer text from one NDJSON line of `claude --output-format
+/// stream-json --include-partial-messages`. Returns the text of a
+/// `content_block_delta` / `text_delta` event, or None for any other line.
+fn cli_text_delta(line: &str) -> Option<String> {
+    let json: serde_json::Value = serde_json::from_str(line).ok()?;
+    if json["type"] != "stream_event" {
+        return None;
+    }
+    let event = &json["event"];
+    if event["type"] != "content_block_delta" {
+        return None;
+    }
+    let delta = &event["delta"];
+    if delta["type"] != "text_delta" {
+        return None; // skip thinking_delta and others
+    }
+    delta["text"].as_str().map(str::to_string)
 }
 
 /// Upper bound on generated tokens for the Anthropic API (required by the API;
@@ -709,6 +735,20 @@ mod tests {
     // (model, override, has_base_url, has_anthropic_key)
     fn pick(model: &str, ov: &str, base: bool, anthropic: bool) -> Provider {
         choose_provider(model, ov, base, anthropic)
+    }
+
+    #[test]
+    fn cli_text_delta_extracts_only_text_deltas() {
+        let d = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}"#;
+        assert_eq!(cli_text_delta(d).as_deref(), Some("Hello"));
+        // thinking deltas, non-stream events, and init lines yield nothing.
+        let thinking = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}}}"#;
+        assert_eq!(cli_text_delta(thinking), None);
+        let init = r#"{"type":"system","subtype":"init"}"#;
+        assert_eq!(cli_text_delta(init), None);
+        let result = r#"{"type":"result","result":"Hello"}"#;
+        assert_eq!(cli_text_delta(result), None);
+        assert_eq!(cli_text_delta("not json"), None);
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -501,10 +501,12 @@ async fn stream_claude_cli(
     // The CLI resets the content-block index to 0 for each new assistant message,
     // so a tool call followed by more text reuses index 0 — index alone can't tell
     // blocks apart. Instead, a new *text block start* after we've already emitted
-    // text means a gap (tool use / thinking) happened; insert a blank line before
-    // that block's text so segments don't run together.
+    // text means a gap (tool use / thinking) happened. When text resumes we insert
+    // a `[[thought:<secs>]]` marker (the frontend renders it as a dim "Thought for
+    // Xs" divider), timing the gap from the last emitted text token.
     let mut emitted_text = false;
     let mut need_separator = false;
+    let mut last_text_at: Option<std::time::Instant> = None;
     if let Some(stdout) = child.stdout.take() {
         let mut reader = tokio::io::BufReader::new(stdout);
         let mut line = String::new();
@@ -530,12 +532,18 @@ async fn stream_claude_cli(
                 Some(CliEvent::Text(text)) => {
                     if !text.is_empty() {
                         if need_separator {
-                            full.push_str("\n\n");
-                            on(StreamUpdate::Delta("\n\n".to_string()));
+                            let secs = last_text_at
+                                .map(|t| t.elapsed().as_secs_f64().round() as u64)
+                                .unwrap_or(0)
+                                .max(1);
+                            let marker = format!("\n\n[[thought:{secs}]]\n\n");
+                            full.push_str(&marker);
+                            on(StreamUpdate::Delta(marker));
                             need_separator = false;
                         }
                         full.push_str(&text);
                         emitted_text = true;
+                        last_text_at = Some(std::time::Instant::now());
                         on(StreamUpdate::Delta(text));
                     }
                 }
@@ -811,9 +819,10 @@ mod tests {
     // The agent reuses content-block index 0 across messages, so a tool call
     // between two text blocks looks like (TextStart, Text, ToolUse, TextStart,
     // Text) with the same index — the separator must come from TextStart, not
-    // the index. This mirrors the loop logic in `stream_claude_cli`.
+    // the index. This mirrors the loop logic in `stream_claude_cli`, using a
+    // fixed duration in place of the wall-clock timing.
     #[test]
-    fn separator_inserted_between_text_blocks_across_a_tool_gap() {
+    fn thought_marker_inserted_between_text_blocks_across_a_tool_gap() {
         let events = [
             CliEvent::TextStart,
             CliEvent::Text("first.".to_string()),
@@ -834,7 +843,7 @@ mod tests {
                 CliEvent::Text(text) => {
                     if !text.is_empty() {
                         if need_separator {
-                            out.push_str("\n\n");
+                            out.push_str("\n\n[[thought:2]]\n\n");
                             need_separator = false;
                         }
                         out.push_str(&text);
@@ -844,7 +853,7 @@ mod tests {
                 CliEvent::ToolUse => {}
             }
         }
-        assert_eq!(out, "first.\n\nsecond.");
+        assert_eq!(out, "first.\n\n[[thought:2]]\n\nsecond.");
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -507,6 +507,7 @@ async fn stream_claude_cli(
     let mut emitted_text = false;
     let mut need_separator = false;
     let mut last_text_at: Option<std::time::Instant> = None;
+    let mut cli_error: Option<String> = None;
     if let Some(stdout) = child.stdout.take() {
         let mut reader = tokio::io::BufReader::new(stdout);
         let mut line = String::new();
@@ -550,6 +551,9 @@ async fn stream_claude_cli(
                 Some(CliEvent::ToolUse) => {
                     on(StreamUpdate::Status(Some("Working…".to_string())));
                 }
+                Some(CliEvent::Error(msg)) => {
+                    cli_error = Some(msg);
+                }
                 None => {}
             }
         }
@@ -559,15 +563,26 @@ async fn stream_claude_cli(
         .wait()
         .await
         .map_err(|e| format!("Failed to wait for claude CLI: {}", e))?;
+
+    // The CLI reports failures as a JSON error event on stdout (captured above),
+    // not via stderr — prefer that message; fall back to stderr, then exit code.
+    if let Some(msg) = cli_error {
+        return Err(format!("claude CLI error: {msg}"));
+    }
     if !status.success() {
         let mut stderr = String::new();
         if let Some(mut err) = child.stderr.take() {
             let _ = err.read_to_string(&mut stderr).await;
         }
-        return Err(format!("claude CLI exited with {}: {}", status, stderr.trim()));
+        let detail = stderr.trim();
+        return Err(if detail.is_empty() {
+            format!("claude CLI exited with {status} (no error output). Check the model name in settings and that you're signed in to the claude CLI.")
+        } else {
+            format!("claude CLI exited with {status}: {detail}")
+        });
     }
     if full.trim().is_empty() {
-        return Err("claude CLI returned empty response".to_string());
+        return Err("claude CLI returned an empty response".to_string());
     }
     Ok(full)
 }
@@ -582,25 +597,42 @@ enum CliEvent {
     Text(String),
     /// The agent started using a tool (a gap between text blocks).
     ToolUse,
+    /// The CLI reported a failure (e.g. bad model, auth). The message is for the
+    /// user — the CLI emits this on stdout as JSON, not stderr.
+    Error(String),
 }
 
 /// Parse one NDJSON line into a [`CliEvent`], or None for lines we don't surface
-/// (init, usage, thinking deltas/blocks, result, …).
+/// (init, usage, thinking deltas/blocks, successful result, …).
 fn cli_event(line: &str) -> Option<CliEvent> {
     let json: serde_json::Value = serde_json::from_str(line).ok()?;
-    if json["type"] != "stream_event" {
-        return None;
-    }
-    let event = &json["event"];
-    match event["type"].as_str()? {
-        "content_block_start" => match event["content_block"]["type"].as_str()? {
-            "text" => Some(CliEvent::TextStart),
-            "tool_use" => Some(CliEvent::ToolUse),
-            _ => None, // thinking / other blocks
-        },
-        "content_block_delta" if event["delta"]["type"] == "text_delta" => {
-            Some(CliEvent::Text(event["delta"]["text"].as_str()?.to_string()))
+    match json["type"].as_str()? {
+        "stream_event" => {
+            let event = &json["event"];
+            match event["type"].as_str()? {
+                "content_block_start" => match event["content_block"]["type"].as_str()? {
+                    "text" => Some(CliEvent::TextStart),
+                    "tool_use" => Some(CliEvent::ToolUse),
+                    _ => None, // thinking / other blocks
+                },
+                "content_block_delta" if event["delta"]["type"] == "text_delta" => {
+                    Some(CliEvent::Text(event["delta"]["text"].as_str()?.to_string()))
+                }
+                _ => None,
+            }
         }
+        // A result flagged as an error carries a human message in `result`.
+        "result" if json["is_error"] == true => Some(CliEvent::Error(
+            json["result"].as_str().unwrap_or("the CLI reported an error").to_string(),
+        )),
+        // An assistant turn can carry a top-level `error` code with a text block.
+        "assistant" if json["error"].is_string() => Some(CliEvent::Error(
+            json["message"]["content"][0]["text"]
+                .as_str()
+                .or_else(|| json["error"].as_str())
+                .unwrap_or("the CLI reported an error")
+                .to_string(),
+        )),
         _ => None,
     }
 }
@@ -811,9 +843,26 @@ mod tests {
         assert_eq!(cli_event(thinking), None);
         let init = r#"{"type":"system","subtype":"init"}"#;
         assert_eq!(cli_event(init), None);
-        let result = r#"{"type":"result","result":"Hello"}"#;
+        // A successful result is not an error.
+        let result = r#"{"type":"result","is_error":false,"result":"Hello"}"#;
         assert_eq!(cli_event(result), None);
         assert_eq!(cli_event("not json"), None);
+    }
+
+    #[test]
+    fn cli_event_surfaces_error_messages() {
+        // The CLI puts the human-readable failure in `result` on an is_error event.
+        let err_result = r#"{"type":"result","subtype":"success","is_error":true,"api_error_status":404,"result":"There's an issue with the selected model (foo)."}"#;
+        assert_eq!(
+            cli_event(err_result),
+            Some(CliEvent::Error("There's an issue with the selected model (foo).".to_string()))
+        );
+        // An assistant turn carrying a top-level error code, with the text block.
+        let err_assistant = r#"{"type":"assistant","error":"model_not_found","message":{"content":[{"type":"text","text":"It may not exist or you may not have access."}]}}"#;
+        assert_eq!(
+            cli_event(err_assistant),
+            Some(CliEvent::Error("It may not exist or you may not have access.".to_string()))
+        );
     }
 
     // The agent reuses content-block index 0 across messages, so a tool call
@@ -850,7 +899,7 @@ mod tests {
                         emitted_text = true;
                     }
                 }
-                CliEvent::ToolUse => {}
+                CliEvent::ToolUse | CliEvent::Error(_) => {}
             }
         }
         assert_eq!(out, "first.\n\n[[thought:2]]\n\nsecond.");

--- a/app/src-tauri/crates/core/src/bedrock.rs
+++ b/app/src-tauri/crates/core/src/bedrock.rs
@@ -1,4 +1,4 @@
-use crate::ai::{ChatRole, ChatTurn};
+use crate::ai::{ChatRole, ChatTurn, StreamUpdate};
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::error::ProvideErrorMetadata;
 use aws_sdk_bedrockruntime::types::{
@@ -76,7 +76,7 @@ impl BedrockClient {
         model_arn: &str,
         system: &str,
         turns: &[ChatTurn],
-        on_delta: &mut (dyn FnMut(String) + Send),
+        on: &mut (dyn FnMut(StreamUpdate) + Send),
     ) -> Result<String, String> {
         let mut messages = Vec::with_capacity(turns.len());
         for turn in turns {
@@ -115,7 +115,7 @@ impl BedrockClient {
                     if let Some(ContentBlockDelta::Text(text)) = ev.delta() {
                         if !text.is_empty() {
                             full.push_str(text);
-                            on_delta(text.clone());
+                            on(StreamUpdate::Delta(text.clone()));
                         }
                     }
                 }

--- a/app/src-tauri/crates/core/src/bedrock.rs
+++ b/app/src-tauri/crates/core/src/bedrock.rs
@@ -1,6 +1,10 @@
+use crate::ai::{ChatRole, ChatTurn};
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::error::ProvideErrorMetadata;
-use aws_sdk_bedrockruntime::types::{ContentBlock, ConversationRole, Message};
+use aws_sdk_bedrockruntime::types::{
+    ContentBlock, ContentBlockDelta, ConversationRole, ConverseStreamOutput, Message,
+    SystemContentBlock,
+};
 use aws_sdk_bedrockruntime::Client;
 
 pub struct BedrockClient {
@@ -63,6 +67,64 @@ impl BedrockClient {
             }
             _ => Err("Unexpected Bedrock response type".to_string()),
         }
+    }
+
+    /// Stream a multi-turn conversation via Bedrock `ConverseStream`. Emits each
+    /// text fragment through `on_delta` and returns the full assembled text.
+    pub async fn converse_stream(
+        &self,
+        model_arn: &str,
+        system: &str,
+        turns: &[ChatTurn],
+        on_delta: &mut (dyn FnMut(String) + Send),
+    ) -> Result<String, String> {
+        let mut messages = Vec::with_capacity(turns.len());
+        for turn in turns {
+            let role = match turn.role {
+                ChatRole::User => ConversationRole::User,
+                ChatRole::Assistant => ConversationRole::Assistant,
+            };
+            let message = Message::builder()
+                .role(role)
+                .content(ContentBlock::Text(turn.content.clone()))
+                .build()
+                .map_err(|e| format!("Failed to build message: {}", e))?;
+            messages.push(message);
+        }
+
+        let mut response = self
+            .client
+            .converse_stream()
+            .model_id(model_arn)
+            .set_system(Some(vec![SystemContentBlock::Text(system.to_string())]))
+            .set_messages(Some(messages))
+            .send()
+            .await
+            .map_err(|e| {
+                let msg = e
+                    .as_service_error()
+                    .map(|se| format!("{}: {}", se.code().unwrap_or("Unknown"), se.message().unwrap_or("no details")))
+                    .unwrap_or_else(|| format!("{}", e));
+                format!("Bedrock streaming error: {}. Make sure you are logged in: aws sso login --profile claude-code-bedrock", msg)
+            })?;
+
+        let mut full = String::new();
+        loop {
+            match response.stream.recv().await {
+                Ok(Some(ConverseStreamOutput::ContentBlockDelta(ev))) => {
+                    if let Some(ContentBlockDelta::Text(text)) = ev.delta() {
+                        if !text.is_empty() {
+                            full.push_str(text);
+                            on_delta(text.clone());
+                        }
+                    }
+                }
+                Ok(Some(_)) => {} // message_start / metadata / stop events — ignore
+                Ok(None) => break, // end of stream
+                Err(e) => return Err(format!("Bedrock stream read failed: {}", e)),
+            }
+        }
+        Ok(full)
     }
 }
 

--- a/app/src-tauri/crates/core/src/chat.rs
+++ b/app/src-tauri/crates/core/src/chat.rs
@@ -1,0 +1,150 @@
+use serde::Deserialize;
+
+/// One file's diff/content supplied as grounding for the chat. `head_content` is
+/// the full post-change file (present only when the frontend chooses to include
+/// it); `unified_diff` is always present.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatFileContext {
+    pub path: String,
+    pub unified_diff: String,
+    #[serde(default)]
+    pub head_content: Option<String>,
+}
+
+/// The grounding context for a chat request: PR metadata plus the file(s) in
+/// scope (the selected file, or all relevant files when the user opts into
+/// whole-PR scope on the frontend).
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatContext {
+    pub pr_title: String,
+    #[serde(default)]
+    pub summary: String,
+    pub files: Vec<ChatFileContext>,
+}
+
+/// Per-file diff budget (chars). Matches the highlight pipeline's per-file cap.
+const PER_FILE_DIFF_BUDGET: usize = 5000;
+/// Per-file full-content budget (chars) when head content is included.
+const PER_FILE_CONTENT_BUDGET: usize = 8000;
+/// Overall ceiling on the assembled file context (chars).
+const TOTAL_CONTEXT_BUDGET: usize = 30000;
+
+/// Truncate `s` to at most `max` chars on a char boundary, appending a marker
+/// when truncated. Safe for multibyte input (unlike slicing by byte index).
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max).collect();
+    out.push_str("\n... (truncated)\n");
+    out
+}
+
+/// The review-assistant instructions that precede the grounding context.
+const CHAT_SYSTEM_PREAMBLE: &str = r#"You are a code review assistant embedded in a pull-request review tool. A reviewer is reading a diff and asking you questions about it. Answer their questions grounded in the PR context provided below.
+
+Guidelines:
+- Answer from the provided diff and file context. If the context doesn't contain enough to answer confidently (e.g. a caller outside the changed files), say so plainly rather than guessing.
+- Be concise and direct. Reviewers want fast, high-signal answers — a few sentences, not an essay.
+- When useful, reference specific files and line numbers from the diff.
+- Use Markdown. Put code in fenced code blocks.
+- You are reviewing, not writing the PR — don't propose to make edits; explain, assess risk, and surface what's worth a closer look."#;
+
+/// Assemble the system prompt: the assistant instructions followed by the PR
+/// title, AI summary, and the in-scope file diffs (budget-bounded).
+pub fn build_chat_system(ctx: &ChatContext) -> String {
+    let mut out = String::with_capacity(4096);
+    out.push_str(CHAT_SYSTEM_PREAMBLE);
+    out.push_str("\n\n--- PR CONTEXT ---\n\n");
+    out.push_str(&format!("PR Title: {}\n", ctx.pr_title));
+    if !ctx.summary.trim().is_empty() {
+        out.push_str(&format!("\nPR Summary:\n{}\n", ctx.summary.trim()));
+    }
+
+    out.push_str("\n--- FILES IN SCOPE ---\n");
+    let mut remaining = TOTAL_CONTEXT_BUDGET;
+    for file in &ctx.files {
+        if remaining == 0 {
+            out.push_str("\n... (additional files omitted to fit context budget)\n");
+            break;
+        }
+        out.push_str(&format!("\n=== FILE: {} ===\n", file.path));
+
+        let diff = truncate(&file.unified_diff, PER_FILE_DIFF_BUDGET.min(remaining));
+        remaining = remaining.saturating_sub(diff.chars().count());
+        out.push_str("Diff:\n");
+        out.push_str(&diff);
+        out.push('\n');
+
+        if let Some(content) = &file.head_content {
+            if remaining > 0 && !content.trim().is_empty() {
+                let content = truncate(content, PER_FILE_CONTENT_BUDGET.min(remaining));
+                remaining = remaining.saturating_sub(content.chars().count());
+                out.push_str("\nCurrent file contents (post-change):\n");
+                out.push_str(&content);
+                out.push('\n');
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_with(diff: &str, content: Option<&str>) -> ChatContext {
+        ChatContext {
+            pr_title: "Test PR".to_string(),
+            summary: "A summary.".to_string(),
+            files: vec![ChatFileContext {
+                path: "src/lib.rs".to_string(),
+                unified_diff: diff.to_string(),
+                head_content: content.map(str::to_string),
+            }],
+        }
+    }
+
+    #[test]
+    fn truncate_is_char_safe_and_marks() {
+        // A multibyte char repeated past the limit must not panic and must mark.
+        let s = "é".repeat(100);
+        let t = truncate(&s, 10);
+        assert!(t.contains("(truncated)"));
+        assert!(t.chars().count() < s.chars().count() + 5);
+    }
+
+    #[test]
+    fn short_text_is_untouched() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn system_includes_title_summary_and_diff() {
+        let sys = build_chat_system(&ctx_with("@@ -1 +1 @@\n-old\n+new\n", None));
+        assert!(sys.contains("Test PR"));
+        assert!(sys.contains("A summary."));
+        assert!(sys.contains("src/lib.rs"));
+        assert!(sys.contains("+new"));
+    }
+
+    #[test]
+    fn total_budget_caps_many_huge_files() {
+        let big = "x".repeat(40_000);
+        let ctx = ChatContext {
+            pr_title: "Big".to_string(),
+            summary: String::new(),
+            files: (0..10)
+                .map(|i| ChatFileContext {
+                    path: format!("f{i}.rs"),
+                    unified_diff: big.clone(),
+                    head_content: Some(big.clone()),
+                })
+                .collect(),
+        };
+        let sys = build_chat_system(&ctx);
+        // Preamble + context, but bounded well under the sum of all inputs.
+        assert!(sys.chars().count() < TOTAL_CONTEXT_BUDGET + 2000);
+    }
+}

--- a/app/src-tauri/crates/core/src/chat.rs
+++ b/app/src-tauri/crates/core/src/chat.rs
@@ -1,14 +1,27 @@
 use serde::Deserialize;
 
+/// An AI review note (highlight) on a file, surfaced to the chat so questions
+/// like "is the warning on L287-318 legitimate?" resolve against it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ChatHighlight {
+    pub start_line: u64,
+    pub end_line: u64,
+    pub severity: String,
+    pub comment: String,
+}
+
 /// One file's diff/content supplied as grounding for the chat. `head_content` is
 /// the full post-change file (present only when the frontend chooses to include
-/// it); `unified_diff` is always present.
+/// it); `unified_diff` is always present. `highlights` are the AI notes the
+/// reviewer sees inline on this file.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChatFileContext {
     pub path: String,
     pub unified_diff: String,
     #[serde(default)]
     pub head_content: Option<String>,
+    #[serde(default)]
+    pub highlights: Vec<ChatHighlight>,
 }
 
 /// The grounding context for a chat request: PR metadata plus the file(s) in
@@ -70,6 +83,20 @@ pub fn build_chat_system(ctx: &ChatContext) -> String {
         }
         out.push_str(&format!("\n=== FILE: {} ===\n", file.path));
 
+        // AI review notes the reviewer sees inline — so "the warning on L287-318"
+        // resolves to something concrete.
+        if !file.highlights.is_empty() {
+            out.push_str("AI review notes on this file:\n");
+            for h in &file.highlights {
+                let lines = if h.start_line == h.end_line {
+                    format!("L{}", h.start_line)
+                } else {
+                    format!("L{}-{}", h.start_line, h.end_line)
+                };
+                out.push_str(&format!("- [{}] {}: {}\n", h.severity, lines, h.comment));
+            }
+        }
+
         let diff = truncate(&file.unified_diff, PER_FILE_DIFF_BUDGET.min(remaining));
         remaining = remaining.saturating_sub(diff.chars().count());
         out.push_str("Diff:\n");
@@ -102,6 +129,7 @@ mod tests {
                 path: "src/lib.rs".to_string(),
                 unified_diff: diff.to_string(),
                 head_content: content.map(str::to_string),
+                highlights: vec![],
             }],
         }
     }
@@ -140,11 +168,27 @@ mod tests {
                     path: format!("f{i}.rs"),
                     unified_diff: big.clone(),
                     head_content: Some(big.clone()),
+                    highlights: vec![],
                 })
                 .collect(),
         };
         let sys = build_chat_system(&ctx);
         // Preamble + context, but bounded well under the sum of all inputs.
         assert!(sys.chars().count() < TOTAL_CONTEXT_BUDGET + 2000);
+    }
+
+    #[test]
+    fn highlights_are_rendered_with_line_ranges() {
+        let mut ctx = ctx_with("@@ -1 +1 @@\n+x\n", None);
+        ctx.files[0].highlights = vec![ChatHighlight {
+            start_line: 287,
+            end_line: 318,
+            severity: "warning".to_string(),
+            comment: "SSE parser splits on \\n only".to_string(),
+        }];
+        let sys = build_chat_system(&ctx);
+        assert!(sys.contains("AI review notes"));
+        assert!(sys.contains("L287-318"));
+        assert!(sys.contains("SSE parser splits"));
     }
 }

--- a/app/src-tauri/crates/core/src/chat_history.rs
+++ b/app/src-tauri/crates/core/src/chat_history.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 /// (None for whole-PR scope), purely for display/context — it does not affect
 /// loading.
 #[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub struct StoredMessage {
     pub role: String,
     pub content: String,

--- a/app/src-tauri/crates/core/src/chat_history.rs
+++ b/app/src-tauri/crates/core/src/chat_history.rs
@@ -1,0 +1,63 @@
+use crate::config::app_config_dir;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// One turn of the per-PR review chat. `role` is "user" or "assistant".
+/// `file_path` records which file was in focus when a user message was sent
+/// (None for whole-PR scope), purely for display/context — it does not affect
+/// loading.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StoredMessage {
+    pub role: String,
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_path: Option<String>,
+}
+
+/// Persisted conversation for a single PR. Mirrors the per-PR stores used for
+/// dismissed highlights and viewed state.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct StoredChat {
+    pub messages: Vec<StoredMessage>,
+}
+
+fn chat_dir() -> PathBuf {
+    app_config_dir().join("chat")
+}
+
+/// Restrict a path component to a safe charset so a hostile `owner`/`repo` from
+/// the IPC boundary can't escape the cache dir. A no-op for real GitHub names.
+fn sanitize(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' { c } else { '_' })
+        .collect()
+}
+
+fn chat_path(owner: &str, repo: &str, pr_number: u64) -> PathBuf {
+    chat_dir().join(format!("{}_{}_{}.json", sanitize(owner), sanitize(repo), pr_number))
+}
+
+pub fn load_chat(owner: &str, repo: &str, pr_number: u64) -> Option<StoredChat> {
+    let path = chat_path(owner, repo, pr_number);
+    let content = fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+pub fn save_chat(owner: &str, repo: &str, pr_number: u64, state: &StoredChat) -> Result<(), String> {
+    let dir = chat_dir();
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create chat dir: {}", e))?;
+    let path = chat_path(owner, repo, pr_number);
+    let json =
+        serde_json::to_string_pretty(state).map_err(|e| format!("Failed to serialize: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write chat history: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(&path, perms);
+    }
+
+    Ok(())
+}

--- a/app/src-tauri/crates/core/src/lib.rs
+++ b/app/src-tauri/crates/core/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod activity;
 pub mod ai;
 pub mod bedrock;
+pub mod chat;
+pub mod chat_history;
 pub mod checks_dismiss;
 pub mod config;
 pub mod dismissed_highlights;

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -569,6 +569,8 @@ pub struct ChatRequest {
 pub enum ChatStreamEvent {
     /// A fragment of the assistant's answer.
     Delta { text: String },
+    /// A transient status (e.g. the CLI agent using tools); `label` None clears it.
+    Status { label: Option<String> },
     /// The stream finished cleanly; `content` is the full assembled answer.
     Done { content: String },
     /// The stream failed; `message` is a human-readable error.
@@ -611,9 +613,13 @@ pub async fn chat_send(
     let request_id = request.request_id.clone();
     state.chat_cancels.lock().unwrap().insert(request_id.clone(), token.clone());
 
-    let delta_channel = channel.clone();
-    let mut on_delta = move |text: String| {
-        let _ = delta_channel.send(ChatStreamEvent::Delta { text });
+    let update_channel = channel.clone();
+    let mut on_update = move |u: marrow_core::ai::StreamUpdate| {
+        let ev = match u {
+            marrow_core::ai::StreamUpdate::Delta(text) => ChatStreamEvent::Delta { text },
+            marrow_core::ai::StreamUpdate::Status(label) => ChatStreamEvent::Status { label },
+        };
+        let _ = update_channel.send(ev);
     };
 
     // Race the streaming call against cancellation. On cancel, the select drops
@@ -621,7 +627,7 @@ pub async fn chat_send(
     // killing the `claude` child, which is spawned with kill_on_drop) — and we
     // send nothing further. The frontend keeps the partial answer it streamed.
     tokio::select! {
-        result = backend.invoke_chat_stream(&system, &turns, &mut on_delta) => {
+        result = backend.invoke_chat_stream(&system, &turns, &mut on_update) => {
             match result {
                 Ok(content) => { let _ = channel.send(ChatStreamEvent::Done { content }); }
                 Err(message) => { let _ = channel.send(ChatStreamEvent::Error { message }); }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1,4 +1,7 @@
+use marrow_core::ai::{AiBackend, ChatRole, ChatTurn};
 use marrow_core::bedrock::{region_from_arn, BedrockClient};
+use marrow_core::chat::{build_chat_system, ChatContext};
+use marrow_core::chat_history::{self, StoredChat};
 use marrow_core::config::{load_settings, resolve_github_token, save_settings_to_disk};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
@@ -9,10 +12,13 @@ use marrow_core::dismissed_highlights::{self, DismissedHighlights};
 use marrow_core::viewed_state::{self, ViewedFileState};
 use marrow_core::activity::{self, Observed};
 use marrow_core::watches::{self, Watch};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::sync::Mutex;
+use tauri::ipc::Channel;
 use tauri::{command, State};
+use tokio_util::sync::CancellationToken;
 
 pub struct AppState {
     pub manifest_path: Mutex<Option<String>>,
@@ -23,6 +29,9 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
+    // In-flight chat requests, keyed by a frontend-generated request id. Firing
+    // a token aborts the corresponding streaming `chat_send` (see `chat_cancel`).
+    pub chat_cancels: Mutex<HashMap<String, CancellationToken>>,
 }
 
 fn github_client() -> GithubClient {
@@ -533,6 +542,122 @@ pub fn load_cached_manifest_by_pr(pr_url: String) -> Result<Option<ReviewManifes
         &parsed.repo,
         parsed.number,
     ))
+}
+
+/// One prior turn of the conversation, as sent from the frontend.
+#[derive(Debug, Deserialize)]
+pub struct ChatTurnDto {
+    pub role: String,
+    pub content: String,
+}
+
+/// A chat request: a unique id (so the stream can be cancelled), the grounding
+/// context, the conversation so far, and the new user message.
+#[derive(Debug, Deserialize)]
+pub struct ChatRequest {
+    pub request_id: String,
+    pub context: ChatContext,
+    #[serde(default)]
+    pub history: Vec<ChatTurnDto>,
+    pub message: String,
+}
+
+/// Streaming events sent back over the IPC channel while a chat answer is
+/// generated.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ChatStreamEvent {
+    /// A fragment of the assistant's answer.
+    Delta { text: String },
+    /// The stream finished cleanly; `content` is the full assembled answer.
+    Done { content: String },
+    /// The stream failed; `message` is a human-readable error.
+    Error { message: String },
+}
+
+fn dto_role(role: &str) -> ChatRole {
+    match role {
+        "assistant" => ChatRole::Assistant,
+        _ => ChatRole::User,
+    }
+}
+
+#[command]
+pub async fn chat_send(
+    state: State<'_, AppState>,
+    channel: Channel<ChatStreamEvent>,
+    request: ChatRequest,
+) -> Result<(), String> {
+    let settings = load_settings();
+    let backend = match AiBackend::from_settings(&settings).await {
+        Ok(b) => b,
+        Err(e) => {
+            let _ = channel.send(ChatStreamEvent::Error { message: e });
+            return Ok(());
+        }
+    };
+
+    let system = build_chat_system(&request.context);
+    let mut turns: Vec<ChatTurn> = request
+        .history
+        .iter()
+        .map(|t| ChatTurn { role: dto_role(&t.role), content: t.content.clone() })
+        .collect();
+    turns.push(ChatTurn { role: ChatRole::User, content: request.message });
+
+    // Register a cancellation token so `chat_cancel` can abort this stream. The
+    // std Mutex guard must be dropped before any await (it isn't Send).
+    let token = CancellationToken::new();
+    let request_id = request.request_id.clone();
+    state.chat_cancels.lock().unwrap().insert(request_id.clone(), token.clone());
+
+    let delta_channel = channel.clone();
+    let mut on_delta = move |text: String| {
+        let _ = delta_channel.send(ChatStreamEvent::Delta { text });
+    };
+
+    // Race the streaming call against cancellation. On cancel, the select drops
+    // the `invoke_chat_stream` future — closing the HTTP/Bedrock stream (and
+    // killing the `claude` child, which is spawned with kill_on_drop) — and we
+    // send nothing further. The frontend keeps the partial answer it streamed.
+    tokio::select! {
+        result = backend.invoke_chat_stream(&system, &turns, &mut on_delta) => {
+            match result {
+                Ok(content) => { let _ = channel.send(ChatStreamEvent::Done { content }); }
+                Err(message) => { let _ = channel.send(ChatStreamEvent::Error { message }); }
+            }
+        }
+        _ = token.cancelled() => {
+            // Aborted by the user; the partial answer already lives on the frontend.
+        }
+    }
+
+    state.chat_cancels.lock().unwrap().remove(&request_id);
+    Ok(())
+}
+
+/// Abort an in-flight [`chat_send`] identified by `request_id`. A no-op if the
+/// request already finished or never existed.
+#[command]
+pub fn chat_cancel(state: State<AppState>, request_id: String) {
+    if let Some(token) = state.chat_cancels.lock().unwrap().get(&request_id) {
+        token.cancel();
+    }
+}
+
+#[command]
+pub fn load_chat_history(owner: String, repo: String, pr_number: u64) -> Option<StoredChat> {
+    chat_history::load_chat(&owner, &repo, pr_number)
+}
+
+#[command]
+pub fn save_chat_history(
+    owner: String,
+    repo: String,
+    pr_number: u64,
+    state: StoredChat,
+) -> Result<(), String> {
+    chat_history::save_chat(&owner, &repo, pr_number, &state)
 }
 
 #[command]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
+            chat_cancels: Mutex::new(HashMap::new()),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -254,6 +255,10 @@ pub fn run() {
             commands::set_mini_player_enabled,
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
+            commands::chat_send,
+            commands::chat_cancel,
+            commands::load_chat_history,
+            commands::save_chat_history,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -591,16 +591,18 @@ function App() {
   const chatRequestIdRef = useRef<Record<string, string>>({});
 
   /** The diff/content context for the chat, scoped to the selected file or the
-   * whole PR (relevant files only). Whole-PR omits full contents to save budget. */
-  function buildChatFiles(tab: Tab): Array<{ path: string; unified_diff: string; head_content?: string }> {
+   * whole PR (relevant files only). Whole-PR omits full contents to save budget.
+   * AI highlights (the inline notes) ride along so questions about "the warning
+   * on L287-318" resolve against them. */
+  function buildChatFiles(tab: Tab): Array<{ path: string; unified_diff: string; head_content?: string; highlights: FileDiff["highlights"] }> {
     const manifest = tab.manifest!;
     if (tab.chat.includeWholePr) {
       const relevant = manifest.files.filter((f) => f.classification === "RELEVANT");
       const files = relevant.length > 0 ? relevant : manifest.files;
-      return files.map((f) => ({ path: f.path, unified_diff: f.unified_diff }));
+      return files.map((f) => ({ path: f.path, unified_diff: f.unified_diff, highlights: f.highlights }));
     }
     const f = tab.selectedFile;
-    return f ? [{ path: f.path, unified_diff: f.unified_diff, head_content: f.head_content }] : [];
+    return f ? [{ path: f.path, unified_diff: f.unified_diff, head_content: f.head_content, highlights: f.highlights }] : [];
   }
 
   /** Append the assistant's answer, return the chat to idle, and persist. */

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -21,12 +21,19 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, ChatState, ChatMessage, ChatStreamEvent } from "./types";
+import { Channel } from "@tauri-apps/api/core";
+import { ChatPanel } from "./components/ChatPanel";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
 function isOpenerTab(tab: Tab): boolean {
   return !tab.manifest && !tab.loading && !tab.error;
+}
+
+/** A fresh, closed chat panel for a new tab. */
+function emptyChatState(): ChatState {
+  return { messages: [], status: "idle", streamingText: "", includeWholePr: false, open: false };
 }
 
 function App() {
@@ -235,6 +242,7 @@ function App() {
       onReply: () => diffViewerRef.current?.replyAtCursor(),
       onResolve: () => diffViewerRef.current?.resolveAtCursor(),
       onReviewPicker: () => { if (activeTab?.manifest) setReviewPickerOpen(true); },
+      onToggleChat: () => { if (activeTab?.manifest) toggleChatOpen(); },
     },
     {
       enabled: !!activeTab?.manifest,
@@ -252,6 +260,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: hasGroups ? "groups" : "category",
@@ -276,6 +285,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: "category",
@@ -365,6 +375,7 @@ function App() {
             for (const tab of restored) {
               loadPersistedViewedState(tab);
               loadDismissedHighlights(tab);
+              loadChatHistory(tab);
               fetchMyReviewState(tab.id, tab.manifest!.pr_url);
               fetchChecksStatus(tab.id, tab.manifest!.pr_url);
             }
@@ -445,6 +456,7 @@ function App() {
     setError(null);
     loadPersistedViewedState(tab);
     loadDismissedHighlights(tab);
+    loadChatHistory(tab);
     fetchMyReviewState(tabId, data.pr_url);
     fetchChecksStatus(tabId, data.pr_url);
     if (!isActive) {
@@ -464,6 +476,7 @@ function App() {
     setError(null);
     loadPersistedViewedState(tab);
     loadDismissedHighlights(tab);
+    loadChatHistory(tab);
     fetchMyReviewState(tab.id, data.pr_url);
     fetchChecksStatus(tab.id, data.pr_url);
   }
@@ -545,6 +558,19 @@ function App() {
     }
   }
 
+  async function loadChatHistory(tab: Tab) {
+    if (!tab.manifest) return;
+    try {
+      const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+      const saved = await invoke<{ messages: ChatMessage[] } | null>("load_chat_history", { owner, repo, prNumber: number });
+      if (saved && saved.messages.length > 0) {
+        updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, messages: saved.messages } }));
+      }
+    } catch {
+      // Non-critical: start with an empty conversation on failure
+    }
+  }
+
   function toggleHighlightDismissed(key: string) {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab || !tab.manifest) return;
@@ -554,6 +580,130 @@ function App() {
     const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
     invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } })
       .catch(() => addToast("error", "Couldn't save — this dismissal may not persist"));
+  }
+
+  // ---- Conversational diff Q&A (chat) ----
+
+  // Per-tab flag: when true, in-flight stream events for that tab are ignored
+  // (the user pressed Stop, cleared the chat, or sent a fresh message).
+  const chatCancelRef = useRef<Record<string, boolean>>({});
+  // Per-tab id of the in-flight chat request, so Stop can abort it server-side.
+  const chatRequestIdRef = useRef<Record<string, string>>({});
+
+  /** The diff/content context for the chat, scoped to the selected file or the
+   * whole PR (relevant files only). Whole-PR omits full contents to save budget. */
+  function buildChatFiles(tab: Tab): Array<{ path: string; unified_diff: string; head_content?: string }> {
+    const manifest = tab.manifest!;
+    if (tab.chat.includeWholePr) {
+      const relevant = manifest.files.filter((f) => f.classification === "RELEVANT");
+      const files = relevant.length > 0 ? relevant : manifest.files;
+      return files.map((f) => ({ path: f.path, unified_diff: f.unified_diff }));
+    }
+    const f = tab.selectedFile;
+    return f ? [{ path: f.path, unified_diff: f.unified_diff, head_content: f.head_content }] : [];
+  }
+
+  /** Append the assistant's answer, return the chat to idle, and persist. */
+  function finalizeChat(tabId: string, prUrl: string, content: string) {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    const messages: ChatMessage[] = [...(tab?.chat.messages ?? []), { role: "assistant", content }];
+    updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, messages, status: "idle", streamingText: "" } }));
+    try {
+      const { owner, repo, number } = parsePrUrl(prUrl);
+      invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages } }).catch(() => {});
+    } catch {
+      // Non-critical: an unparseable URL just means this turn isn't persisted.
+    }
+  }
+
+  function handleChatSend(message: string) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    const tabId = tab.id;
+    const manifest = tab.manifest;
+    const files = buildChatFiles(tab);
+    if (files.length === 0) {
+      addToast("error", "Select a file or enable “Include whole PR” to ask a question");
+      return;
+    }
+    const userMsg: ChatMessage = {
+      role: "user",
+      content: message,
+      filePath: tab.chat.includeWholePr ? undefined : tab.selectedFile?.path,
+    };
+    const history = tab.chat.messages.map((m) => ({ role: m.role, content: m.content }));
+    const requestId = crypto.randomUUID();
+
+    chatCancelRef.current[tabId] = false;
+    chatRequestIdRef.current[tabId] = requestId;
+    updateTab(tabId, (t) => ({
+      ...t,
+      chat: { ...t.chat, messages: [...t.chat.messages, userMsg], status: "streaming", streamingText: "", error: undefined },
+    }));
+
+    const channel = new Channel<ChatStreamEvent>();
+    channel.onmessage = (ev) => {
+      if (chatCancelRef.current[tabId]) return;
+      if (ev.type === "delta") {
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingText: t.chat.streamingText + ev.text } }));
+      } else if (ev.type === "done") {
+        finalizeChat(tabId, manifest.pr_url, ev.content);
+      } else if (ev.type === "error") {
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", error: ev.message } }));
+      }
+    };
+
+    invoke("chat_send", {
+      channel,
+      request: { request_id: requestId, context: { pr_title: manifest.pr_title, summary: manifest.summary, files }, history, message },
+    }).catch((err) => {
+      if (chatCancelRef.current[tabId]) return;
+      updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", error: String(err) } }));
+    });
+  }
+
+  /** Abort the in-flight stream (server-side too) and keep whatever streamed so far. */
+  function handleChatStop() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    chatCancelRef.current[tab.id] = true;
+    const requestId = chatRequestIdRef.current[tab.id];
+    if (requestId) invoke("chat_cancel", { requestId }).catch(() => {});
+    const partial = tab.chat.streamingText.trim();
+    if (partial) {
+      finalizeChat(tab.id, tab.manifest.pr_url, partial);
+    } else {
+      updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "" } }));
+    }
+  }
+
+  function handleChatClear() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    chatCancelRef.current[tab.id] = true;
+    if (tab.chat.status === "streaming") {
+      const requestId = chatRequestIdRef.current[tab.id];
+      if (requestId) invoke("chat_cancel", { requestId }).catch(() => {});
+    }
+    updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, messages: [], status: "idle", streamingText: "", error: undefined } }));
+    try {
+      const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+      invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages: [] } }).catch(() => {});
+    } catch {
+      // Non-critical.
+    }
+  }
+
+  function setChatOpen(open: boolean) {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open } }));
+  }
+
+  function toggleChatOpen() {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open: !t.chat.open } }));
+  }
+
+  function handleChatToggleWholePr(value: boolean) {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, includeWholePr: value } }));
   }
 
   const unlistenRef = useRef<(() => void) | null>(null);
@@ -1493,6 +1643,8 @@ function App() {
         myReviewState={activeTab?.myReviewState}
         checksBlocking={showChecksModal}
         onCheckForUpdates={() => checkForUpdates(false)}
+        chatOpen={activeTab?.chat.open ?? false}
+        onToggleChat={activeTab?.manifest ? toggleChatOpen : undefined}
       />
       <SettingsModal
         open={settingsOpen}
@@ -1607,6 +1759,17 @@ function App() {
               <div className="no-file-selected">Select a file to review</div>
             )}
           </div>
+          {activeTab.chat.open && (
+            <ChatPanel
+              chat={activeTab.chat}
+              selectedFilePath={activeTab.selectedFile?.path ?? null}
+              onSend={handleChatSend}
+              onStop={handleChatStop}
+              onClose={() => setChatOpen(false)}
+              onClear={handleChatClear}
+              onToggleWholePr={handleChatToggleWholePr}
+            />
+          )}
         </div>
         </div>
       )}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -33,7 +33,7 @@ function isOpenerTab(tab: Tab): boolean {
 
 /** A fresh, closed chat panel for a new tab. */
 function emptyChatState(): ChatState {
-  return { messages: [], status: "idle", streamingText: "", includeWholePr: false, open: false };
+  return { messages: [], status: "idle", streamingText: "", streamingStatus: null, includeWholePr: false, open: false };
 }
 
 function App() {
@@ -609,7 +609,7 @@ function App() {
   function finalizeChat(tabId: string, prUrl: string, content: string) {
     const tab = tabsRef.current.find((t) => t.id === tabId);
     const messages: ChatMessage[] = [...(tab?.chat.messages ?? []), { role: "assistant", content }];
-    updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, messages, status: "idle", streamingText: "" } }));
+    updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, messages, status: "idle", streamingText: "", streamingStatus: null } }));
     try {
       const { owner, repo, number } = parsePrUrl(prUrl);
       invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages } }).catch(() => {});
@@ -640,18 +640,21 @@ function App() {
     chatRequestIdRef.current[tabId] = requestId;
     updateTab(tabId, (t) => ({
       ...t,
-      chat: { ...t.chat, messages: [...t.chat.messages, userMsg], status: "streaming", streamingText: "", error: undefined },
+      chat: { ...t.chat, messages: [...t.chat.messages, userMsg], status: "streaming", streamingText: "", streamingStatus: null, error: undefined },
     }));
 
     const channel = new Channel<ChatStreamEvent>();
     channel.onmessage = (ev) => {
       if (chatCancelRef.current[tabId]) return;
       if (ev.type === "delta") {
-        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingText: t.chat.streamingText + ev.text } }));
+        // Any text clears a pending "Working…" status.
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingText: t.chat.streamingText + ev.text, streamingStatus: null } }));
+      } else if (ev.type === "status") {
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingStatus: ev.label } }));
       } else if (ev.type === "done") {
         finalizeChat(tabId, manifest.pr_url, ev.content);
       } else if (ev.type === "error") {
-        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", error: ev.message } }));
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", streamingStatus: null, error: ev.message } }));
       }
     };
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, Channel } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
 import { DiffViewer, detectLanguage, type DiffViewerHandle } from "./components/DiffViewer";
@@ -19,18 +19,24 @@ import { ReviewPicker } from "./components/ReviewPicker";
 import { ToastContainer, createToast, type ToastData } from "./components/Toast";
 import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
 import { WelcomeSetup } from "./components/WelcomeSetup";
+import { ChatPanel } from "./components/ChatPanel";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
 function isOpenerTab(tab: Tab): boolean {
   return !tab.manifest && !tab.loading && !tab.error;
+}
+
+/** A fresh, closed chat panel for a new tab. */
+function emptyChatState(): ChatState {
+  return { messages: [], status: "idle", streamingText: "", streamingStatus: null, includeWholePr: false, open: false };
 }
 
 function App() {
@@ -307,6 +313,7 @@ function App() {
       onReply: () => diffViewerRef.current?.replyAtCursor(),
       onResolve: () => diffViewerRef.current?.resolveAtCursor(),
       onReviewPicker: () => { if (activeTab?.manifest) setReviewPickerOpen(true); },
+      onToggleChat: () => { if (!welcomeOpen) toggleChatOpen(); },
     },
     {
       enabled: !!activeTab?.manifest,
@@ -326,6 +333,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: hasGroups ? "groups" : "category",
@@ -350,6 +358,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
       sidebarView: "category",
@@ -439,6 +448,7 @@ function App() {
             for (const tab of restored) {
               loadPersistedViewedState(tab);
               loadDismissedHighlights(tab);
+              loadChatHistory(tab);
               fetchMyReviewState(tab.id, tab.manifest!.pr_url);
               fetchChecksStatus(tab.id, tab.manifest!.pr_url);
             }
@@ -528,6 +538,7 @@ function App() {
     setError(null);
     loadPersistedViewedState(tab);
     loadDismissedHighlights(tab);
+    loadChatHistory(tab);
     fetchMyReviewState(tabId, data.pr_url);
     fetchChecksStatus(tabId, data.pr_url);
     if (!isActive) {
@@ -547,6 +558,7 @@ function App() {
     setError(null);
     loadPersistedViewedState(tab);
     loadDismissedHighlights(tab);
+    loadChatHistory(tab);
     fetchMyReviewState(tab.id, data.pr_url);
     fetchChecksStatus(tab.id, data.pr_url);
   }
@@ -637,6 +649,164 @@ function App() {
     const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
     invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } })
       .catch(() => addToast("error", "Couldn't save — this dismissal may not persist"));
+  }
+
+  async function loadChatHistory(tab: Tab) {
+    if (!tab.manifest) return;
+    try {
+      const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+      const saved = await invoke<{ messages: ChatMessage[] } | null>("load_chat_history", { owner, repo, prNumber: number });
+      if (saved && saved.messages.length > 0) {
+        updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, messages: saved.messages } }));
+      }
+    } catch {
+      // Non-critical: start with an empty conversation on failure
+    }
+  }
+
+  // ---- Conversational diff Q&A (chat) ----
+
+  // Per-tab flag: when true, in-flight stream events for that tab are ignored
+  // (the user pressed Stop, cleared the chat, or sent a fresh message).
+  const chatCancelRef = useRef<Record<string, boolean>>({});
+  // Per-tab id of the in-flight chat request, so Stop can abort it server-side.
+  const chatRequestIdRef = useRef<Record<string, string>>({});
+
+  /** The diff/content context for the chat. Effective scope is the whole PR
+   * (relevant files only) when `includeWholePr` is set OR no file is selected
+   * (the overview) — auto-scope means there's no "select a file first" error
+   * path. Whole-PR omits full contents to save budget. AI highlights ride
+   * along so questions about "the warning on L287-318" resolve against them. */
+  function buildChatFiles(tab: Tab): Array<{ path: string; unified_diff: string; head_content?: string; highlights: FileDiff["highlights"] }> {
+    const manifest = tab.manifest!;
+    if (tab.chat.includeWholePr || !tab.selectedFile) {
+      const relevant = manifest.files.filter((f) => f.classification === "RELEVANT");
+      const files = relevant.length > 0 ? relevant : manifest.files;
+      return files.map((f) => ({ path: f.path, unified_diff: f.unified_diff, highlights: f.highlights }));
+    }
+    const f = tab.selectedFile;
+    return [{ path: f.path, unified_diff: f.unified_diff, head_content: f.head_content, highlights: f.highlights }];
+  }
+
+  /** Append the assistant's answer, return the chat to idle, and persist. */
+  function finalizeChat(tabId: string, prUrl: string, content: string) {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    const messages: ChatMessage[] = [...(tab?.chat.messages ?? []), { role: "assistant", content }];
+    updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, messages, status: "idle", streamingText: "", streamingStatus: null } }));
+    try {
+      const { owner, repo, number } = parsePrUrl(prUrl);
+      invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages } }).catch(() => {});
+    } catch {
+      // Non-critical: an unparseable URL just means this turn isn't persisted.
+    }
+  }
+
+  function handleChatSend(message: string) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    const tabId = tab.id;
+    const manifest = tab.manifest;
+    const files = buildChatFiles(tab);
+    if (files.length === 0) return;
+    const userMsg: ChatMessage = {
+      role: "user",
+      content: message,
+      filePath: tab.chat.includeWholePr ? undefined : tab.selectedFile?.path,
+    };
+    // Cap the history sent to the model — full history still renders and persists.
+    const history = tab.chat.messages.slice(-12).map((m) => ({ role: m.role, content: m.content }));
+    const requestId = crypto.randomUUID();
+
+    chatCancelRef.current[tabId] = false;
+    chatRequestIdRef.current[tabId] = requestId;
+    updateTab(tabId, (t) => ({
+      ...t,
+      chat: { ...t.chat, messages: [...t.chat.messages, userMsg], status: "streaming", streamingText: "", streamingStatus: null, error: undefined },
+    }));
+
+    const channel = new Channel<ChatStreamEvent>();
+    channel.onmessage = (ev) => {
+      // Drop events from a cancelled request AND from a superseded one: after
+      // Stop → new send, stragglers from the old stream can still arrive
+      // (chat_cancel is fire-and-forget) and must not touch the new request.
+      if (chatCancelRef.current[tabId] || chatRequestIdRef.current[tabId] !== requestId) return;
+      if (ev.type === "delta") {
+        // Any text clears a pending "Working…" status.
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingText: t.chat.streamingText + ev.text, streamingStatus: null } }));
+      } else if (ev.type === "status") {
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, streamingStatus: ev.label } }));
+      } else if (ev.type === "done") {
+        finalizeChat(tabId, manifest.pr_url, ev.content);
+      } else if (ev.type === "error") {
+        updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", streamingStatus: null, error: ev.message } }));
+      }
+    };
+
+    invoke("chat_send", {
+      channel,
+      request: { request_id: requestId, context: { pr_title: manifest.pr_title, summary: manifest.summary, files }, history, message },
+    }).catch((err) => {
+      if (chatCancelRef.current[tabId] || chatRequestIdRef.current[tabId] !== requestId) return;
+      updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "", error: String(err) } }));
+    });
+  }
+
+  /** Abort the in-flight stream (server-side too) and keep whatever streamed so far. */
+  function handleChatStop() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    chatCancelRef.current[tab.id] = true;
+    const requestId = chatRequestIdRef.current[tab.id];
+    if (requestId) invoke("chat_cancel", { requestId }).catch(() => {});
+    const partial = tab.chat.streamingText.trim();
+    if (partial) {
+      finalizeChat(tab.id, tab.manifest.pr_url, partial);
+    } else {
+      updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, status: "idle", streamingText: "" } }));
+    }
+  }
+
+  function handleChatClear() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    chatCancelRef.current[tab.id] = true;
+    if (tab.chat.status === "streaming") {
+      const requestId = chatRequestIdRef.current[tab.id];
+      if (requestId) invoke("chat_cancel", { requestId }).catch(() => {});
+    }
+    updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, messages: [], status: "idle", streamingText: "", error: undefined } }));
+    try {
+      const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+      invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages: [] } }).catch(() => {});
+    } catch {
+      // Non-critical.
+    }
+  }
+
+  function setChatOpen(open: boolean) {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open } }));
+  }
+
+  function toggleChatOpen() {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open: !t.chat.open } }));
+  }
+
+  function handleChatToggleWholePr(value: boolean) {
+    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, includeWholePr: value } }));
+  }
+
+  /** Resolve a file mention from the chat (exact path, or a unique suffix
+   * match against the manifest) and select it. No absolute-line scroll API
+   * exists on DiffViewerHandle (only relative cursor movement), so this is a
+   * file-level jump only — the line number is accepted but unused. */
+  function handleChatOpenFile(path: string, _line?: number) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab?.manifest) return;
+    const files = tab.manifest.files;
+    const exact = files.find((f) => f.path === path);
+    if (exact) { setSelectedFile(exact); return; }
+    const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
+    if (suffixMatches.length === 1) setSelectedFile(suffixMatches[0]);
   }
 
   const unlistenRef = useRef<(() => void) | null>(null);
@@ -1530,6 +1700,7 @@ function App() {
       { id: "threads", section: "Review", title: "Toggle threads view", keys: "T", run: toggleThreadsView },
       { id: "refresh", section: "Review", title: "Refresh PR", keys: "⌃R", run: handleRefreshPr },
       { id: "github", section: "Review", title: "Open PR on GitHub", run: () => { openUrl(m.pr_url); } },
+      { id: "ask-ai", section: "Review", title: "Ask AI about this change", keys: "⌘J", run: toggleChatOpen },
       { id: "view-split", section: "View", title: "Split diff view", run: () => setViewMode("split") },
       { id: "view-unified", section: "View", title: "Unified diff view", run: () => setViewMode("unified") },
       { id: "toggle-sig", section: "View", title: showHunkSignificance ? "Hide hunk significance" : "Show hunk significance", run: () => setShowHunkSignificance((v) => !v) },
@@ -1627,6 +1798,8 @@ function App() {
         checksBlocking={showChecksModal}
         onCheckForUpdates={() => checkForUpdates(false)}
         onOpenPalette={() => setPaletteOpen(true)}
+        chatOpen={activeTab?.chat.open ?? false}
+        onToggleChat={activeTab?.manifest ? toggleChatOpen : undefined}
       />
       <SettingsModal
         open={settingsOpen}
@@ -1810,6 +1983,19 @@ function App() {
             )}
           </div>
           </>
+          )}
+          {activeTab.chat.open && (
+            <ChatPanel
+              chat={activeTab.chat}
+              selectedFilePath={activeTab.selectedFile?.path ?? null}
+              filePaths={activeTab.manifest.files.map((f) => f.path)}
+              onSend={handleChatSend}
+              onStop={handleChatStop}
+              onClose={() => setChatOpen(false)}
+              onClear={handleChatClear}
+              onToggleWholePr={handleChatToggleWholePr}
+              onOpenFile={handleChatOpenFile}
+            />
           )}
         </div>
         </div>

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import hljs from "highlight.js";
+import type { ChatState } from "../types";
+
+interface ChatPanelProps {
+  chat: ChatState;
+  /** Path of the file currently in focus (drives the default grounding scope). */
+  selectedFilePath: string | null;
+  onSend: (message: string) => void;
+  onStop: () => void;
+  onClose: () => void;
+  onClear: () => void;
+  onToggleWholePr: (value: boolean) => void;
+}
+
+/** Render a fenced code block with highlight.js. */
+function CodeBlock({ code, lang }: { code: string; lang?: string }) {
+  const html = useMemo(() => {
+    try {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(code, { language: lang }).value;
+      }
+      return hljs.highlightAuto(code).value;
+    } catch {
+      return escapeHtml(code);
+    }
+  }, [code, lang]);
+  return (
+    <pre className="chat-code">
+      <code dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** Render inline `code` spans and **bold** within a single text run. */
+function renderInline(text: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  // Split on inline code first; bold is handled within non-code runs.
+  const parts = text.split(/(`[^`]+`)/g);
+  parts.forEach((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
+      nodes.push(<code key={i} className="chat-inline-code">{part.slice(1, -1)}</code>);
+      return;
+    }
+    const boldParts = part.split(/(\*\*[^*]+\*\*)/g);
+    boldParts.forEach((bp, j) => {
+      if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 2) {
+        nodes.push(<strong key={`${i}-${j}`}>{bp.slice(2, -2)}</strong>);
+      } else if (bp) {
+        nodes.push(<span key={`${i}-${j}`}>{bp}</span>);
+      }
+    });
+  });
+  return nodes;
+}
+
+/**
+ * Minimal Markdown rendering: fenced ```code``` blocks (highlighted with
+ * highlight.js) plus paragraphs with inline code and bold. Deliberately small —
+ * the project has no Markdown dependency.
+ */
+function ChatMarkdown({ content }: { content: string }) {
+  // Split on fenced code blocks, keeping the fences as delimiters.
+  const segments = content.split(/(```[\s\S]*?```)/g);
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const fence = seg.match(/^```([\w+-]*)\n?([\s\S]*?)```$/);
+        if (fence) {
+          return <CodeBlock key={i} lang={fence[1] || undefined} code={fence[2].replace(/\n$/, "")} />;
+        }
+        return seg
+          .split(/\n\n+/)
+          .filter((p) => p.trim().length > 0)
+          .map((para, j) => (
+            <p key={`${i}-${j}`} className="chat-para">
+              {renderInline(para)}
+            </p>
+          ));
+      })}
+    </>
+  );
+}
+
+export function ChatPanel({
+  chat,
+  selectedFilePath,
+  onSend,
+  onStop,
+  onClose,
+  onClear,
+  onToggleWholePr,
+}: ChatPanelProps) {
+  const [draft, setDraft] = useState("");
+  const listRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const streaming = chat.status === "streaming";
+
+  // Keep the transcript pinned to the bottom as content streams in.
+  useEffect(() => {
+    const el = listRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [chat.messages, chat.streamingText]);
+
+  function submit() {
+    const text = draft.trim();
+    if (!text || streaming) return;
+    onSend(text);
+    setDraft("");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  const scopeLabel = chat.includeWholePr
+    ? "Whole PR"
+    : selectedFilePath
+      ? selectedFilePath.split("/").pop()
+      : "No file selected";
+
+  return (
+    <div className="chat-panel">
+      <div className="chat-header">
+        <span className="chat-title">Ask about this change</span>
+        <div className="chat-header-actions">
+          <button className="chat-icon-btn" onClick={onClear} title="Clear conversation" disabled={chat.messages.length === 0 && !streaming}>
+            Clear
+          </button>
+          <button className="chat-icon-btn" onClick={onClose} title="Close chat (closes the panel)">
+            ✕
+          </button>
+        </div>
+      </div>
+
+      <div className="chat-scope">
+        <label className="chat-scope-toggle" title="Ground answers in every changed file instead of just the selected one">
+          <input
+            type="checkbox"
+            checked={chat.includeWholePr}
+            onChange={(e) => onToggleWholePr(e.target.checked)}
+          />
+          Include whole PR
+        </label>
+        <span className="chat-scope-indicator" title="Files in scope for grounding">
+          Scope: {scopeLabel}
+        </span>
+      </div>
+
+      <div className="chat-messages" ref={listRef}>
+        {chat.messages.length === 0 && !streaming && (
+          <div className="chat-empty">
+            <p>Ask a question about this diff — for example:</p>
+            <ul>
+              <li>What's the blast radius of this change?</li>
+              <li>Is the null/empty case handled?</li>
+              <li>What calls this now?</li>
+            </ul>
+          </div>
+        )}
+        {chat.messages.map((m, i) => (
+          <div key={i} className={`chat-msg chat-msg-${m.role}`}>
+            <div className="chat-msg-role">{m.role === "user" ? "You" : "AI"}</div>
+            <div className="chat-msg-body">
+              {m.role === "assistant" ? <ChatMarkdown content={m.content} /> : <span className="chat-user-text">{m.content}</span>}
+            </div>
+          </div>
+        ))}
+        {streaming && (
+          <div className="chat-msg chat-msg-assistant">
+            <div className="chat-msg-role">AI</div>
+            <div className="chat-msg-body">
+              {chat.streamingText ? (
+                <ChatMarkdown content={chat.streamingText} />
+              ) : (
+                <span className="chat-thinking">Thinking…</span>
+              )}
+            </div>
+          </div>
+        )}
+        {chat.error && <div className="chat-error" role="alert">{chat.error}</div>}
+      </div>
+
+      <div className="chat-input-row">
+        <textarea
+          ref={inputRef}
+          className="chat-input"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={streaming ? "Generating answer…" : "Ask about this change…  (Enter to send, Shift+Enter for newline)"}
+          rows={3}
+          disabled={streaming}
+        />
+        {streaming ? (
+          <button className="chat-send-btn chat-stop-btn" onClick={onStop}>
+            Stop
+          </button>
+        ) : (
+          <button className="chat-send-btn" onClick={submit} disabled={!draft.trim()}>
+            Send
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -61,12 +61,21 @@ function renderInline(text: string): React.ReactNode[] {
   return nodes;
 }
 
-/**
- * Minimal Markdown rendering: fenced ```code``` blocks (highlighted with
- * highlight.js) plus paragraphs with inline code and bold. Deliberately small —
- * the project has no Markdown dependency.
- */
-function ChatMarkdown({ content }: { content: string }) {
+/** A dim divider marking a gap where the AI used tools / thought between
+ * answer segments. Backed by a `[[thought:<secs>]]` marker in the content. */
+function ThoughtDivider({ seconds }: { seconds: number }) {
+  return (
+    <div className="chat-thought" aria-label={`Thought for ${seconds} seconds`}>
+      <span className="chat-thought-rule" />
+      <span className="chat-thought-label">Thought for {seconds}s</span>
+      <span className="chat-thought-rule" />
+    </div>
+  );
+}
+
+/** Fenced ```code``` blocks (highlighted with highlight.js) plus paragraphs with
+ * inline code and bold. Deliberately small — the project has no Markdown dep. */
+function RichText({ content }: { content: string }) {
   // Split on fenced code blocks, keeping the fences as delimiters.
   const segments = content.split(/(```[\s\S]*?```)/g);
   return (
@@ -85,6 +94,27 @@ function ChatMarkdown({ content }: { content: string }) {
             </p>
           ));
       })}
+    </>
+  );
+}
+
+/**
+ * Renders assistant content: splits out `[[thought:<secs>]]` markers (rendered as
+ * dim "Thought for Xs" dividers) and renders the text spans between them as
+ * minimal Markdown.
+ */
+function ChatMarkdown({ content }: { content: string }) {
+  // Capturing split → [text, secs, text, secs, text, …].
+  const parts = content.split(/\[\[thought:(\d+)\]\]/g);
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 === 1 ? (
+          <ThoughtDivider key={i} seconds={Number(part)} />
+        ) : part ? (
+          <RichText key={i} content={part} />
+        ) : null,
+      )}
     </>
   );
 }

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -6,11 +6,15 @@ interface ChatPanelProps {
   chat: ChatState;
   /** Path of the file currently in focus (drives the default grounding scope). */
   selectedFilePath: string | null;
+  /** Manifest file paths — used to recognize in-scope file mentions in answers. */
+  filePaths: string[];
   onSend: (message: string) => void;
   onStop: () => void;
   onClose: () => void;
   onClear: () => void;
   onToggleWholePr: (value: boolean) => void;
+  /** Jump to a file (and, when supported, a line) mentioned in an answer. */
+  onOpenFile?: (path: string, line?: number) => void;
 }
 
 /** Render a fenced code block with highlight.js. */
@@ -39,14 +43,51 @@ function escapeHtml(s: string): string {
     .replace(/>/g, "&gt;");
 }
 
-/** Render inline `code` spans and **bold** within a single text run. */
-function renderInline(text: string): React.ReactNode[] {
+// Matches `path/to/file.ext` or `path/to/file.ext:123` — a bare file mention,
+// optionally with a line number, as the AI tends to write them inline.
+const FILE_REF_RE = /^([\w./-]+\.\w+)(?::(\d+))?$/;
+
+/** Resolve a file mention against the in-scope manifest paths: an exact match,
+ * or a unique suffix match (so `foo/bar.rs` matches `crates/foo/bar.rs`). */
+function resolveFileRef(candidate: string, filePaths: string[]): string | null {
+  if (filePaths.includes(candidate)) return candidate;
+  const matches = filePaths.filter((p) => p.endsWith("/" + candidate));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function parseFileRef(text: string, filePaths: string[]): { path: string; line?: number } | null {
+  const m = text.match(FILE_REF_RE);
+  if (!m) return null;
+  const resolved = resolveFileRef(m[1], filePaths);
+  if (!resolved) return null;
+  return { path: resolved, line: m[2] ? Number(m[2]) : undefined };
+}
+
+/** Render inline `code` spans (recognizing in-scope file:line mentions as
+ * clickable links) and **bold** within a single text run. */
+function renderInline(text: string, filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
   // Split on inline code first; bold is handled within non-code runs.
   const parts = text.split(/(`[^`]+`)/g);
   parts.forEach((part, i) => {
     if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
-      nodes.push(<code key={i} className="chat-inline-code">{part.slice(1, -1)}</code>);
+      const inner = part.slice(1, -1);
+      const ref = filePaths.length > 0 ? parseFileRef(inner, filePaths) : null;
+      if (ref && onOpenFile) {
+        nodes.push(
+          <button
+            key={i}
+            type="button"
+            className="chat-file-link"
+            onClick={() => onOpenFile(ref.path, ref.line)}
+            title={`Open ${ref.path}${ref.line ? `:${ref.line}` : ""}`}
+          >
+            {inner}
+          </button>,
+        );
+      } else {
+        nodes.push(<code key={i} className="chat-inline-code">{inner}</code>);
+      }
       return;
     }
     const boldParts = part.split(/(\*\*[^*]+\*\*)/g);
@@ -75,7 +116,7 @@ function ThoughtDivider({ seconds }: { seconds: number }) {
 
 /** Fenced ```code``` blocks (highlighted with highlight.js) plus paragraphs with
  * inline code and bold. Deliberately small — the project has no Markdown dep. */
-function RichText({ content }: { content: string }) {
+function RichText({ content, filePaths, onOpenFile }: { content: string; filePaths: string[]; onOpenFile?: (path: string, line?: number) => void }) {
   // Split on fenced code blocks, keeping the fences as delimiters.
   const segments = content.split(/(```[\s\S]*?```)/g);
   return (
@@ -90,7 +131,7 @@ function RichText({ content }: { content: string }) {
           .filter((p) => p.trim().length > 0)
           .map((para, j) => (
             <p key={`${i}-${j}`} className="chat-para">
-              {renderInline(para)}
+              {renderInline(para, filePaths, onOpenFile)}
             </p>
           ));
       })}
@@ -103,7 +144,7 @@ function RichText({ content }: { content: string }) {
  * dim "Thought for Xs" dividers) and renders the text spans between them as
  * minimal Markdown.
  */
-function ChatMarkdown({ content }: { content: string }) {
+function ChatMarkdown({ content, filePaths, onOpenFile }: { content: string; filePaths: string[]; onOpenFile?: (path: string, line?: number) => void }) {
   // Capturing split → [text, secs, text, secs, text, …].
   const parts = content.split(/\[\[thought:(\d+)\]\]/g);
   return (
@@ -112,7 +153,7 @@ function ChatMarkdown({ content }: { content: string }) {
         i % 2 === 1 ? (
           <ThoughtDivider key={i} seconds={Number(part)} />
         ) : part ? (
-          <RichText key={i} content={part} />
+          <RichText key={i} content={part} filePaths={filePaths} onOpenFile={onOpenFile} />
         ) : null,
       )}
     </>
@@ -122,11 +163,13 @@ function ChatMarkdown({ content }: { content: string }) {
 export function ChatPanel({
   chat,
   selectedFilePath,
+  filePaths,
   onSend,
   onStop,
   onClose,
   onClear,
   onToggleWholePr,
+  onOpenFile,
 }: ChatPanelProps) {
   const [draft, setDraft] = useState("");
   const listRef = useRef<HTMLDivElement>(null);
@@ -158,7 +201,7 @@ export function ChatPanel({
     ? "Whole PR"
     : selectedFilePath
       ? selectedFilePath.split("/").pop()
-      : "No file selected";
+      : "Whole PR";
 
   return (
     <div className="chat-panel">
@@ -175,17 +218,25 @@ export function ChatPanel({
       </div>
 
       <div className="chat-scope">
-        <label className="chat-scope-toggle" title="Ground answers in every changed file instead of just the selected one">
-          <input
-            type="checkbox"
-            checked={chat.includeWholePr}
-            onChange={(e) => onToggleWholePr(e.target.checked)}
-          />
-          Include whole PR
-        </label>
-        <span className="chat-scope-indicator" title="Files in scope for grounding">
-          Scope: {scopeLabel}
-        </span>
+        {selectedFilePath ? (
+          <>
+            <label className="chat-scope-toggle" title="Ground answers in every changed file instead of just the selected one">
+              <input
+                type="checkbox"
+                checked={chat.includeWholePr}
+                onChange={(e) => onToggleWholePr(e.target.checked)}
+              />
+              Include whole PR
+            </label>
+            <span className="chat-scope-indicator" title="Files in scope for grounding">
+              Scope: {scopeLabel}
+            </span>
+          </>
+        ) : (
+          <span className="chat-scope-indicator chat-scope-indicator--fixed" title="No file selected — grounding in every changed file">
+            Scope: Whole PR
+          </span>
+        )}
       </div>
 
       <div className="chat-messages" ref={listRef}>
@@ -193,17 +244,22 @@ export function ChatPanel({
           <div className="chat-empty">
             <p>Ask a question about this diff — for example:</p>
             <ul>
-              <li>What's the blast radius of this change?</li>
-              <li>Is the null/empty case handled?</li>
-              <li>What calls this now?</li>
+              <li>What's the riskiest part of this change?</li>
+              <li>Walk me through this diff at a high level</li>
+              <li>Are there edge cases these changes miss?</li>
             </ul>
           </div>
         )}
         {chat.messages.map((m, i) => (
           <div key={i} className={`chat-msg chat-msg-${m.role}`}>
-            <div className="chat-msg-role">{m.role === "user" ? "You" : "AI"}</div>
+            <div className="chat-msg-role">
+              {m.role === "user" ? "You" : "AI"}
+              {m.role === "user" && m.filePath && (
+                <span className="chat-msg-scope">{m.filePath.split("/").pop()}</span>
+              )}
+            </div>
             <div className="chat-msg-body">
-              {m.role === "assistant" ? <ChatMarkdown content={m.content} /> : <span className="chat-user-text">{m.content}</span>}
+              {m.role === "assistant" ? <ChatMarkdown content={m.content} filePaths={filePaths} onOpenFile={onOpenFile} /> : <span className="chat-user-text">{m.content}</span>}
             </div>
           </div>
         ))}
@@ -211,7 +267,7 @@ export function ChatPanel({
           <div className="chat-msg chat-msg-assistant">
             <div className="chat-msg-role">AI</div>
             <div className="chat-msg-body">
-              {chat.streamingText && <ChatMarkdown content={chat.streamingText} />}
+              {chat.streamingText && <ChatMarkdown content={chat.streamingText} filePaths={filePaths} onOpenFile={onOpenFile} />}
               {chat.streamingStatus ? (
                 <span className="chat-working"><span className="chat-working-spinner" aria-hidden="true">↻</span> {chat.streamingStatus}</span>
               ) : chat.streamingText ? (
@@ -232,9 +288,8 @@ export function ChatPanel({
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder={streaming ? "Generating answer…" : "Ask about this change…  (Enter to send, Shift+Enter for newline)"}
+          placeholder="Ask about this change…  (Enter to send, Shift+Enter for newline)"
           rows={3}
-          disabled={streaming}
         />
         {streaming ? (
           <button className="chat-send-btn chat-stop-btn" onClick={onStop}>

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -181,11 +181,11 @@ export function ChatPanel({
           <div className="chat-msg chat-msg-assistant">
             <div className="chat-msg-role">AI</div>
             <div className="chat-msg-body">
-              {chat.streamingText ? (
-                <>
-                  <ChatMarkdown content={chat.streamingText} />
-                  <span className="chat-caret" aria-hidden="true" />
-                </>
+              {chat.streamingText && <ChatMarkdown content={chat.streamingText} />}
+              {chat.streamingStatus ? (
+                <span className="chat-working"><span className="chat-working-spinner" aria-hidden="true">↻</span> {chat.streamingStatus}</span>
+              ) : chat.streamingText ? (
+                <span className="chat-caret" aria-hidden="true" />
               ) : (
                 <span className="chat-thinking">Thinking…</span>
               )}

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -182,7 +182,10 @@ export function ChatPanel({
             <div className="chat-msg-role">AI</div>
             <div className="chat-msg-body">
               {chat.streamingText ? (
-                <ChatMarkdown content={chat.streamingText} />
+                <>
+                  <ChatMarkdown content={chat.streamingText} />
+                  <span className="chat-caret" aria-hidden="true" />
+                </>
               ) : (
                 <span className="chat-thinking">Thinking…</span>
               )}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -55,6 +55,8 @@ interface HeaderProps {
   myReviewState?: MyReviewState;
   checksBlocking?: boolean;
   onCheckForUpdates: () => void;
+  chatOpen?: boolean;
+  onToggleChat?: () => void;
 }
 
 export function Header({
@@ -80,6 +82,8 @@ export function Header({
   myReviewState,
   checksBlocking,
   onCheckForUpdates,
+  chatOpen,
+  onToggleChat,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -178,6 +182,15 @@ export function Header({
             )}
           </div>
           <div className="header-right">
+            {onToggleChat && (
+              <button
+                className={`chat-toggle${chatOpen ? " active" : ""}`}
+                onClick={onToggleChat}
+                title="Ask the AI about this change (⌘/Ctrl+J)"
+              >
+                Ask AI
+              </button>
+            )}
             {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} myReviewState={myReviewState} checksBlocking={checksBlocking} />}
             <ToolbarMenu
               viewMode={viewMode}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -54,6 +54,8 @@ interface HeaderProps {
   checksBlocking?: boolean;
   onCheckForUpdates: () => void;
   onOpenPalette: () => void;
+  chatOpen?: boolean;
+  onToggleChat?: () => void;
 }
 
 export function Header({
@@ -78,6 +80,8 @@ export function Header({
   checksBlocking,
   onCheckForUpdates,
   onOpenPalette,
+  chatOpen,
+  onToggleChat,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -179,6 +183,15 @@ export function Header({
             )}
           </div>
           <div className="header-right">
+            {onToggleChat && (
+              <button
+                className={`chat-toggle${chatOpen ? " active" : ""}`}
+                onClick={onToggleChat}
+                title="Ask the AI about this change (⌘/Ctrl+J)"
+              >
+                Ask AI
+              </button>
+            )}
             {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} myReviewState={myReviewState} checksBlocking={checksBlocking} />}
             <ToolbarMenu
               onOpenPalette={onOpenPalette}

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -45,6 +45,8 @@ export interface ShortcutHandlers {
   onReviewPicker: () => void;
   onReply: () => void;
   onResolve: () => void;
+  /** Toggle the conversational diff Q&A panel (Cmd/Ctrl+J). */
+  onToggleChat: () => void;
 }
 
 export interface ShortcutOptions {
@@ -102,6 +104,17 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
           if (!isEditable(e.target)) h.onCloseTab();
           return;
         }
+      }
+
+      // Cmd/Ctrl+J toggles the chat panel. Handled before the typing guard so it
+      // also closes the panel while the chat input is focused. Gated on `enabled`
+      // (no chat on the opener tab) but allowed with an overlay open.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "j") {
+        if (enabled) {
+          h.onToggleChat();
+          e.preventDefault();
+        }
+        return;
       }
 
       // Typing into a field never triggers shortcuts.

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -47,6 +47,8 @@ export interface ShortcutHandlers {
   onResolve: () => void;
   /** Toggle the command palette (Cmd/Ctrl+K) — works everywhere, even in fields. */
   onTogglePalette: () => void;
+  /** Toggle the conversational diff Q&A panel (Cmd/Ctrl+J). */
+  onToggleChat: () => void;
 }
 
 export interface ShortcutOptions {
@@ -111,6 +113,14 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
       if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "k") {
         e.preventDefault();
         h.onTogglePalette();
+        return;
+      }
+
+      // Cmd/Ctrl+J toggles the chat panel — same pattern as the palette chord:
+      // works from anywhere, including from inside inputs.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "j") {
+        e.preventDefault();
+        h.onToggleChat();
         return;
       }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4496,3 +4496,21 @@ mark.search-highlight-current {
   display: inline-block;
   animation: spin 1.2s linear infinite;
 }
+
+.chat-thought {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+}
+.chat-thought-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.chat-thought-label {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-muted);
+  white-space: nowrap;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4470,3 +4470,17 @@ mark.search-highlight-current {
 }
 .chat-send-btn:disabled { opacity: 0.4; cursor: default; }
 .chat-stop-btn { background: var(--diff-remove-text, #f85149); color: #fff; }
+
+.chat-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  background: var(--accent);
+  animation: chat-caret-blink 1s steps(2, start) infinite;
+}
+@keyframes chat-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4484,3 +4484,15 @@ mark.search-highlight-current {
   0%, 50% { opacity: 1; }
   50.01%, 100% { opacity: 0; }
 }
+
+.chat-working {
+  display: block;
+  margin-top: 8px;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.chat-working-spinner {
+  display: inline-block;
+  animation: spin 1.2s linear infinite;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4306,3 +4306,167 @@ mark.search-highlight-current {
   0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); }
   50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent), 0 8px 24px rgba(0, 0, 0, 0.45); }
 }
+/* ─── Conversational diff Q&A (chat) ────────────────────────────────────── */
+.chat-toggle {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.chat-toggle:hover { background: var(--border); }
+.chat-toggle.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.chat-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.chat-header-actions { display: flex; gap: 6px; }
+.chat-icon-btn {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 2px 8px;
+  font-size: 11px;
+  cursor: pointer;
+}
+.chat-icon-btn:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-tertiary); }
+.chat-icon-btn:disabled { opacity: 0.4; cursor: default; }
+
+.chat-scope {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.chat-scope-toggle { display: flex; align-items: center; gap: 5px; cursor: pointer; }
+.chat-scope-indicator {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.chat-empty { color: var(--text-muted); font-size: 12px; }
+.chat-empty ul { margin: 6px 0 0; padding-left: 18px; }
+.chat-empty li { margin: 3px 0; }
+
+.chat-msg { display: flex; flex-direction: column; gap: 3px; }
+.chat-msg-role {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.chat-msg-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+.chat-msg-user .chat-msg-body {
+  background: var(--bg-tertiary);
+  align-self: flex-start;
+}
+.chat-msg-assistant .chat-msg-body { background: var(--bg-primary); }
+.chat-user-text { white-space: pre-wrap; }
+.chat-para { margin: 0 0 8px; }
+.chat-para:last-child { margin-bottom: 0; }
+.chat-thinking { color: var(--text-muted); font-style: italic; }
+
+.chat-inline-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  background: var(--bg-tertiary);
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+.chat-code {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  overflow-x: auto;
+  margin: 0 0 8px;
+}
+.chat-code code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  background: none;
+}
+
+.chat-error {
+  color: var(--diff-remove-text, #f85149);
+  font-size: 12px;
+  border: 1px solid var(--diff-remove-text, #f85149);
+  border-radius: 6px;
+  padding: 6px 8px;
+}
+
+.chat-input-row {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+  align-items: flex-end;
+}
+.chat-input {
+  flex: 1;
+  resize: none;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+.chat-input:focus { outline: none; border-color: var(--accent); }
+.chat-input:disabled { opacity: 0.6; }
+.chat-send-btn {
+  background: var(--accent);
+  color: #0d1117;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.chat-send-btn:disabled { opacity: 0.4; cursor: default; }
+.chat-stop-btn { background: var(--diff-remove-text, #f85149); color: #fff; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5257,3 +5257,251 @@ mark.search-highlight-current {
 .next-bar-ghost:hover {
   color: var(--text-primary);
 }
+
+/* ─── Conversational diff Q&A (chat) ────────────────────────────────────── */
+.chat-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  padding: 3px 10px;
+  flex-shrink: 0;
+  transition: color 0.15s, border-color 0.15s;
+}
+.chat-toggle:hover { color: var(--text-primary); border-color: var(--text-muted); }
+.chat-toggle.active {
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
+}
+
+.chat-panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--chip-border);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--chip-border);
+}
+.chat-title { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.chat-header-actions { display: flex; gap: var(--space-1); }
+.chat-icon-btn {
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--space-2);
+  font-size: 11px;
+  cursor: pointer;
+}
+.chat-icon-btn:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-tertiary); }
+.chat-icon-btn:disabled { opacity: 0.4; cursor: default; }
+
+.chat-scope {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--chip-border);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.chat-scope-toggle { display: flex; align-items: center; gap: 5px; cursor: pointer; }
+.chat-scope-indicator {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 50%;
+}
+.chat-scope-indicator--fixed { max-width: 100%; }
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.chat-empty { color: var(--text-muted); font-size: 12px; }
+.chat-empty ul { margin: var(--space-2) 0 0; padding-left: 18px; }
+.chat-empty li { margin: 3px 0; }
+
+.chat-msg { display: flex; flex-direction: column; gap: 3px; }
+.chat-msg-role {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+.chat-msg-scope {
+  text-transform: none;
+  letter-spacing: normal;
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 0 var(--space-2);
+}
+.chat-msg-body {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+.chat-msg-user .chat-msg-body {
+  background: var(--bg-tertiary);
+  align-self: flex-start;
+}
+.chat-msg-assistant .chat-msg-body { background: var(--bg-primary); }
+.chat-user-text { white-space: pre-wrap; }
+.chat-para { margin: 0 0 var(--space-2); }
+.chat-para:last-child { margin-bottom: 0; }
+.chat-thinking { color: var(--text-muted); font-style: italic; }
+
+.chat-inline-code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--chip-bg);
+  border-radius: var(--radius-sm);
+  padding: 1px 4px;
+}
+.chat-file-link {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--accent-bg);
+  color: var(--accent-strong);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 1px 4px;
+  cursor: pointer;
+}
+.chat-file-link:hover {
+  color: var(--accent-strong-hover);
+  text-decoration: underline;
+}
+.chat-code {
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  overflow-x: auto;
+  margin: 0 0 var(--space-2);
+}
+.chat-code code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: none;
+}
+
+.chat-error {
+  color: var(--diff-remove-text);
+  font-size: 12px;
+  border: 1px solid var(--diff-remove-text);
+  border-radius: var(--radius-md);
+  padding: var(--space-1) var(--space-2);
+}
+
+.chat-input-row {
+  display: flex;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-top: 1px solid var(--chip-border);
+  align-items: flex-end;
+}
+.chat-input {
+  flex: 1;
+  resize: none;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-2);
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.4;
+}
+.chat-input:focus { outline: none; border-color: var(--accent-strong); }
+.chat-send-btn {
+  background: var(--accent-strong);
+  color: var(--white);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.chat-send-btn:hover:not(:disabled) { background: var(--accent-strong-hover); }
+.chat-send-btn:disabled { opacity: 0.4; cursor: default; }
+.chat-stop-btn {
+  background: var(--diff-remove-bg);
+  border: 1px solid var(--diff-remove-text);
+  color: var(--diff-remove-text);
+}
+.chat-stop-btn:hover {
+  background: var(--diff-remove-text);
+  color: var(--white);
+}
+
+.chat-caret {
+  display: inline-block;
+  width: 7px;
+  height: 1em;
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  background: var(--accent-strong);
+  animation: chat-caret-blink 1s steps(2, start) infinite;
+}
+@keyframes chat-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+.chat-working {
+  display: block;
+  margin-top: var(--space-2);
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.chat-working-spinner {
+  display: inline-block;
+  animation: spin 1.2s linear infinite;
+}
+
+.chat-thought {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
+}
+.chat-thought-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--chip-border);
+}
+.chat-thought-label {
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-muted);
+  white-space: nowrap;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -108,6 +108,9 @@ export interface ChatState {
   status: "idle" | "streaming";
   /** The in-progress assistant answer accumulated from stream deltas. */
   streamingText: string;
+  /** Transient status shown while the AI is working but not emitting text
+   * (e.g. the CLI agent using tools between blocks); null when none. */
+  streamingStatus: string | null;
   /** When true, ground answers in the whole PR rather than the selected file. */
   includeWholePr: boolean;
   /** Whether the chat dock is open. */
@@ -119,6 +122,7 @@ export interface ChatState {
 /** Streaming events sent from the backend `chat_send` command over the IPC channel. */
 export type ChatStreamEvent =
   | { type: "delta"; text: string }
+  | { type: "status"; label: string | null }
   | { type: "done"; content: string }
   | { type: "error"; message: string };
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -93,6 +93,35 @@ export type CommentThreadsState =
   | { status: "loaded"; threads: ReviewThread[] }
   | { status: "error"; message: string };
 
+/** One turn of the per-PR review chat. `filePath` records which file was in
+ * focus when a user message was sent (for display); undefined for whole-PR scope. */
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+  filePath?: string;
+}
+
+/** Tab-scoped state for the conversational diff Q&A panel. */
+export interface ChatState {
+  messages: ChatMessage[];
+  /** "idle" between turns; "streaming" while an answer is being generated. */
+  status: "idle" | "streaming";
+  /** The in-progress assistant answer accumulated from stream deltas. */
+  streamingText: string;
+  /** When true, ground answers in the whole PR rather than the selected file. */
+  includeWholePr: boolean;
+  /** Whether the chat dock is open. */
+  open: boolean;
+  /** Last error message from a failed request, if any. */
+  error?: string;
+}
+
+/** Streaming events sent from the backend `chat_send` command over the IPC channel. */
+export type ChatStreamEvent =
+  | { type: "delta"; text: string }
+  | { type: "done"; content: string }
+  | { type: "error"; message: string };
+
 export type SidebarView = "groups" | "comments" | "category" | "tree";
 
 export type DiffViewMode = "split" | "unified";
@@ -121,6 +150,8 @@ export interface Tab {
   staleViewedFiles: Set<string>;
   /** Keys (see highlightKey) of AI highlights the user has dismissed for this PR. */
   dismissedHighlights: Set<string>;
+  /** Conversational diff Q&A state for this PR. */
+  chat: ChatState;
   commentThreads: CommentThreadsState;
   selectedCommentFile: string | null;
   sidebarView: SidebarView;


### PR DESCRIPTION
## Summary
- Adds a **pull-based, in-review chat** scoped to the current PR/diff (closes #131) — reviewers ask questions ("what's the blast radius?", "is the null case handled?", "what calls this now?") and get answers grounded in the diff, complementing the existing pushed AI highlights.
- **Streams from day one** across all four AI providers, reusing the existing `AiBackend` dispatch.
- Conversations **persist per PR** on disk and restore on reopen.
- Supports **true abort** — Stop actually cancels the in-flight request server-side.

## Changes

**Backend (Rust)**
- `crates/core/src/chat_history.rs` *(new)* — per-PR persisted conversations (`{owner}_{repo}_{pr}.json`, 0600 perms), mirroring `dismissed_highlights`/`viewed_state`.
- `crates/core/src/chat.rs` *(new)* — `build_chat_system()` assembles a review-assistant prompt with PR title/summary + in-scope file diffs, budget-bounded with char-safe truncation. Unit-tested.
- `crates/core/src/ai.rs` — `AiBackend::invoke_chat_stream()` with streaming for Anthropic SSE, OpenAI-compatible SSE (shared byte-safe `consume_sse` parser), and `claude` CLI incremental stdout (`kill_on_drop`).
- `crates/core/src/bedrock.rs` — `converse_stream()` via Bedrock `ConverseStream`.
- `src/commands.rs` / `src/lib.rs` — `chat_send` (streams `ChatStreamEvent` over a `tauri::ipc::Channel`), `chat_cancel`, `load_chat_history`, `save_chat_history`; `AppState.chat_cancels` holds per-request `CancellationToken`s.
- `Cargo.toml` — enable reqwest `stream` feature; add `tokio-util`.

**Frontend (React/TS)**
- `components/ChatPanel.tsx` *(new)* — right-dock panel: streaming bubble, minimal Markdown (fenced code via highlight.js), include-whole-PR toggle, Clear, Stop, Enter-to-send.
- `App.tsx` — channel-based streaming, per-tab cancel handling, context built from the in-memory manifest, persistence on each turn, history load on PR open.
- `Header.tsx` — "Ask AI" toggle; `useKeyboardShortcuts.ts` — Cmd/Ctrl+J.
- `types.ts` / `styles.css` — `ChatMessage`/`ChatState`/`ChatStreamEvent` + tab state; panel styling.

## Test Plan
- [x] `cargo build` / `cargo test --workspace` (50 tests pass) / `cargo clippy` (no new warnings)
- [x] `npm run build` (tsc + vite) clean
- [ ] Launch the app, open a PR, hit **Ask AI** (or Cmd+J); confirm tokens stream live and the answer references the selected file
- [ ] Toggle **Include whole PR** and confirm cross-file answers
- [ ] Press **Stop** mid-answer; confirm generation halts and the partial answer is kept
- [ ] Close & reopen the tab; confirm the conversation restores from disk
- [ ] Spot-check a non-Bedrock provider (e.g. `provider=anthropic` with `ANTHROPIC_API_KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)