### PR TITLE
feat(ai): triage-first fastest review path for large PRs (#129)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4176,6 +4176,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -39,7 +39,8 @@ tauri-plugin-deep-link = "2"
 tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "process"] }
+tokio-util = "0.7"
 marrow-core = { path = "crates/core" }
 
 # Read NSApplication.isActive to drive the floating mini-player: macOS delivers

--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -2233,6 +2233,7 @@ mod tests {
             head_sha: "bbb".to_string(),
             summary: String::new(),
             change_groups: Vec::new(),
+            triage: None,
             files: vec![
                 file("pkg/low.go", "low", "@@ -1,1 +1,1 @@\n-a\n+b\n"),
                 file("pkg/high.go", "high", "@@ -1,1 +1,2 @@\n a\n+b\n"),

--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -49,6 +49,42 @@ pub fn extract_json_array(text: &str) -> Result<serde_json::Value, String> {
     ))
 }
 
+/// Extract a JSON object from text that may contain markdown fences or preamble.
+/// Mirror of [`extract_json_array`] for the triage pass, which returns an object.
+pub fn extract_json_object(text: &str) -> Result<serde_json::Value, String> {
+    // Try direct parse.
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+        if val.is_object() {
+            return Ok(val);
+        }
+    }
+
+    // Try to find a JSON object in the text (first '{' to last '}').
+    if let (Some(start), Some(end)) = (text.find('{'), text.rfind('}')) {
+        if end > start {
+            let candidate = &text[start..=end];
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(candidate) {
+                if val.is_object() {
+                    return Ok(val);
+                }
+            }
+        }
+    }
+
+    // Try stripping markdown code fences.
+    let stripped = text.replace("```json", "").replace("```", "");
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(stripped.trim()) {
+        if val.is_object() {
+            return Ok(val);
+        }
+    }
+
+    Err(format!(
+        "Could not extract JSON object from AI response. Raw response:\n{}",
+        &text[..text.len().min(500)]
+    ))
+}
+
 /// The AI provider a config resolves to. A pure decision, separated from
 /// construction so it's testable without hitting AWS/network.
 #[derive(Debug, PartialEq, Eq)]
@@ -419,6 +455,20 @@ mod tests {
     // (model, override, has_base_url, has_anthropic_key)
     fn pick(model: &str, ov: &str, base: bool, anthropic: bool) -> Provider {
         choose_provider(model, ov, base, anthropic)
+    }
+
+    #[test]
+    fn extract_json_object_handles_fences_and_preamble() {
+        // Direct object.
+        assert!(extract_json_object(r#"{"a":1}"#).unwrap().is_object());
+        // Markdown-fenced.
+        let fenced = "```json\n{\"a\": 1}\n```";
+        assert_eq!(extract_json_object(fenced).unwrap()["a"], 1);
+        // Preamble + object.
+        let preamble = "Here is the result:\n{\"a\": 2}\nThanks!";
+        assert_eq!(extract_json_object(preamble).unwrap()["a"], 2);
+        // An array is not an object.
+        assert!(extract_json_object("[1,2,3]").is_err());
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -105,6 +105,9 @@ fn default_settings() -> Settings {
         activity_mini_player: true,
         show_approved_prs: false,
         expand_all_hunks: true,
+        tts_muted: false,
+        tts_voice: String::new(),
+        tts_rate: 1.0,
     }
 }
 
@@ -137,6 +140,9 @@ pub fn load_settings() -> Settings {
     let mut activity_mini_player = true;
     let mut show_approved_prs = false;
     let mut expand_all_hunks = true;
+    let mut tts_muted = false;
+    let mut tts_voice = String::new();
+    let mut tts_rate: f32 = 1.0;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -177,6 +183,12 @@ pub fn load_settings() -> Settings {
             show_approved_prs = val == "true";
         } else if let Some(val) = line.strip_prefix("expand_all_hunks=") {
             expand_all_hunks = val == "true";
+        } else if let Some(val) = line.strip_prefix("tts_muted=") {
+            tts_muted = val == "true";
+        } else if let Some(val) = line.strip_prefix("tts_voice=") {
+            tts_voice = val.to_string();
+        } else if let Some(val) = line.strip_prefix("tts_rate=") {
+            tts_rate = val.parse().unwrap_or(1.0);
         }
     }
 
@@ -199,6 +211,9 @@ pub fn load_settings() -> Settings {
         activity_mini_player,
         show_approved_prs,
         expand_all_hunks,
+        tts_muted,
+        tts_voice,
+        tts_rate,
     }
 }
 
@@ -247,6 +262,9 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     ));
     content.push_str(&format!("show_approved_prs={}\n", settings.show_approved_prs));
     content.push_str(&format!("expand_all_hunks={}\n", settings.expand_all_hunks));
+    content.push_str(&format!("tts_muted={}\n", settings.tts_muted));
+    content.push_str(&format!("tts_voice={}\n", settings.tts_voice));
+    content.push_str(&format!("tts_rate={}\n", settings.tts_rate));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -104,6 +104,7 @@ fn default_settings() -> Settings {
         activity_per_watch_cap: 50,
         activity_mini_player: true,
         show_approved_prs: false,
+        expand_all_hunks: false,
     }
 }
 
@@ -135,6 +136,7 @@ pub fn load_settings() -> Settings {
     let mut activity_per_watch_cap = 50u64;
     let mut activity_mini_player = true;
     let mut show_approved_prs = false;
+    let mut expand_all_hunks = false;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -173,6 +175,8 @@ pub fn load_settings() -> Settings {
             activity_mini_player = val == "true";
         } else if let Some(val) = line.strip_prefix("show_approved_prs=") {
             show_approved_prs = val == "true";
+        } else if let Some(val) = line.strip_prefix("expand_all_hunks=") {
+            expand_all_hunks = val == "true";
         }
     }
 
@@ -194,6 +198,7 @@ pub fn load_settings() -> Settings {
         activity_per_watch_cap,
         activity_mini_player,
         show_approved_prs,
+        expand_all_hunks,
     }
 }
 
@@ -241,6 +246,7 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
         settings.activity_mini_player
     ));
     content.push_str(&format!("show_approved_prs={}\n", settings.show_approved_prs));
+    content.push_str(&format!("expand_all_hunks={}\n", settings.expand_all_hunks));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -104,7 +104,7 @@ fn default_settings() -> Settings {
         activity_per_watch_cap: 50,
         activity_mini_player: true,
         show_approved_prs: false,
-        expand_all_hunks: false,
+        expand_all_hunks: true,
     }
 }
 
@@ -136,7 +136,7 @@ pub fn load_settings() -> Settings {
     let mut activity_per_watch_cap = 50u64;
     let mut activity_mini_player = true;
     let mut show_approved_prs = false;
-    let mut expand_all_hunks = false;
+    let mut expand_all_hunks = true;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -1,11 +1,11 @@
-use crate::ai::{extract_json_array, AiBackend};
+use crate::ai::{extract_json_array, extract_json_object, AiBackend};
 use crate::config::resolve_github_token;
 use crate::github::GithubClient;
 use crate::manifest_cache;
 use crate::pr_parser::parse_pr_ref;
-use crate::prompts::{build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt};
+use crate::prompts::{build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt, build_triage_prompt};
 use crate::types::{
-    ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, Settings,
+    ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, ReviewOrderItem, Settings, TopRisk, TriageReport,
 };
 use futures::stream::{FuturesUnordered, StreamExt};
 use sha2::{Sha256, Digest};
@@ -118,36 +118,55 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let mut highlights_by_path: HashMap<String, Vec<Highlight>> = HashMap::new();
     let mut summary = String::new();
     let mut change_groups: Vec<ChangeGroup> = Vec::new();
+    // Triage guidance (top risks + contract-first order). Only computed for large
+    // PRs (see the gate below); None means the UI falls back to its normal views.
+    let mut triage: Option<TriageReport> = None;
     // Fetched full contents (base, head), keyed by path — only relevant files,
     // so NOT_RELEVANT files show their diff but not a full-file view.
     let mut content_by_path: HashMap<String, (String, String)> = HashMap::new();
 
     if !relevant.is_empty() {
-        // Step 4: AI highlight analysis + summary + grouping (parallel)
-        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
+        // Step 4: AI highlight analysis + summary + grouping (+ triage for large
+        // PRs), in parallel. The triage pass (top risks + contract-first order) is
+        // gated on size — small PRs don't need a guided path.
+        let run_triage = relevant.len() >= TRIAGE_MIN_FILES;
+        let ai_total: u32 = if run_triage { 4 } else { 3 };
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, ai_total)));
         let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
         let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
 
         let summary_prompt = build_summary_prompt(&pr_title, &relevant);
         let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
+        let triage_prompt = if run_triage {
+            build_triage_prompt(&pr_title, &relevant, &per_file_diffs)
+        } else {
+            String::new()
+        };
 
-        let mut ai_stream: FuturesUnordered<_> = [
+        let mut tasks = vec![
             ("highlights", ai.invoke(&highlight_prompt)),
             ("summary", ai.invoke(&summary_prompt)),
             ("grouping", ai.invoke(&grouping_prompt)),
-        ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
+        ];
+        if run_triage {
+            tasks.push(("triage", ai.invoke(&triage_prompt)));
+        }
+        let mut ai_stream: FuturesUnordered<_> =
+            tasks.into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
 
         let mut highlights_raw = Err("not started".to_string());
         let mut summary_raw = Err("not started".to_string());
         let mut grouping_raw = Err("not started".to_string());
+        let mut triage_raw = Err("not started".to_string());
         let mut ai_done: u32 = 0;
         while let Some((name, result)) = ai_stream.next().await {
             ai_done += 1;
-            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
+            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, ai_total)));
             match name {
                 "highlights" => highlights_raw = result,
                 "summary" => summary_raw = result,
                 "grouping" => grouping_raw = result,
+                "triage" => triage_raw = result,
                 _ => {}
             }
         }
@@ -181,6 +200,20 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
                     severity: h.severity,
                     comment: h.comment,
                 });
+        }
+
+        // Assemble triage: parse the AI object, else fall back to a deterministic
+        // risk-ordered report. Either way, finalize so it references only real
+        // files and covers every relevant file.
+        if run_triage {
+            let parsed = triage_raw
+                .ok()
+                .and_then(|raw| extract_json_object(&raw).ok())
+                .and_then(|json| serde_json::from_value::<TriageReport>(json).ok())
+                .filter(|t| !t.review_order.is_empty());
+            let mut report = parsed.unwrap_or_else(|| fallback_triage(&relevant, &highlights_by_path));
+            finalize_triage(&mut report, &relevant);
+            triage = Some(report);
         }
 
         // Step 5: Fetch file contents for all relevant files concurrently
@@ -316,12 +349,76 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         head_sha,
         summary,
         change_groups,
+        triage,
         files: file_diffs,
     };
 
     let _ = manifest_cache::save_cached_manifest(&parsed.owner, &parsed.repo, parsed.number, &manifest);
 
     Ok(manifest)
+}
+
+/// Minimum number of relevant files before the triage pass runs. Small PRs are
+/// fast to review flat and don't need a guided path.
+const TRIAGE_MIN_FILES: usize = 5;
+
+/// Rank a risk level for ordering (lower = riskier, comes first).
+fn risk_rank(level: &str) -> u8 {
+    match level {
+        "critical" => 0,
+        "high" => 1,
+        "medium" => 2,
+        _ => 3,
+    }
+}
+
+/// Deterministic triage for when the AI pass is unavailable: order relevant files
+/// by risk (critical first), and surface the critical/high files as top risks,
+/// using each file's first highlight (or its classification reason) as the detail.
+fn fallback_triage(
+    relevant: &[&FileClassification],
+    highlights_by_path: &HashMap<String, Vec<Highlight>>,
+) -> TriageReport {
+    let mut ordered: Vec<&FileClassification> = relevant.to_vec();
+    ordered.sort_by_key(|f| risk_rank(&f.risk_level));
+    let review_order = ordered
+        .iter()
+        .map(|f| ReviewOrderItem { path: f.path.clone(), rationale: String::new() })
+        .collect();
+
+    let top_risks = relevant
+        .iter()
+        .filter(|f| f.risk_level == "critical" || f.risk_level == "high")
+        .take(3)
+        .map(|f| {
+            let first = highlights_by_path.get(&f.path).and_then(|h| h.first());
+            TopRisk {
+                title: format!("{} ({})", f.path, f.risk_level),
+                detail: first.map(|h| h.comment.clone()).unwrap_or_else(|| f.reason.clone()),
+                path: f.path.clone(),
+                start_line: first.map(|h| h.start_line),
+            }
+        })
+        .collect();
+
+    TriageReport { top_risks, review_order }
+}
+
+/// Keep triage output honest regardless of source: drop top_risks / order entries
+/// that point at files not in this PR (AI hallucinations), and append any relevant
+/// file the AI left out of the order so `[`/`]` navigation still covers everything.
+fn finalize_triage(report: &mut TriageReport, relevant: &[&FileClassification]) {
+    use std::collections::HashSet;
+    let known: HashSet<&str> = relevant.iter().map(|f| f.path.as_str()).collect();
+    report.top_risks.retain(|r| known.contains(r.path.as_str()));
+    report.review_order.retain(|r| known.contains(r.path.as_str()));
+
+    let ordered: HashSet<String> = report.review_order.iter().map(|r| r.path.clone()).collect();
+    for f in relevant {
+        if !ordered.contains(&f.path) {
+            report.review_order.push(ReviewOrderItem { path: f.path.clone(), rationale: String::new() });
+        }
+    }
 }
 
 /// Extract per-file diffs for the relevant files from a pre-built diff map.
@@ -917,5 +1014,60 @@ mod tests {
         assert_eq!(classify_diff_type(None, true, false), "added");
         assert_eq!(classify_diff_type(None, false, true), "removed");
         assert_eq!(classify_diff_type(None, false, false), "modified");
+    }
+
+    use super::{fallback_triage, finalize_triage};
+    use crate::types::{FileClassification, Highlight, ReviewOrderItem, TopRisk, TriageReport};
+    use std::collections::HashMap;
+
+    fn fc(path: &str, risk: &str) -> FileClassification {
+        FileClassification {
+            path: path.to_string(),
+            classification: "RELEVANT".to_string(),
+            category: "Business Logic".to_string(),
+            risk_level: risk.to_string(),
+            reason: format!("reason for {path}"),
+        }
+    }
+
+    #[test]
+    fn fallback_triage_orders_by_risk_and_surfaces_top_risks() {
+        let files = [fc("a.rs", "low"), fc("b.rs", "critical"), fc("c.rs", "high")];
+        let relevant: Vec<&FileClassification> = files.iter().collect();
+        let mut highlights = HashMap::new();
+        highlights.insert(
+            "b.rs".to_string(),
+            vec![Highlight { start_line: 42, end_line: 50, severity: "critical".into(), comment: "auth check removed".into() }],
+        );
+
+        let report = fallback_triage(&relevant, &highlights);
+        // Risk-first ordering: critical, high, low.
+        let order: Vec<&str> = report.review_order.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(order, vec!["b.rs", "c.rs", "a.rs"]);
+        // Top risks are the critical/high files; the highlight drives detail+line.
+        assert_eq!(report.top_risks.len(), 2);
+        let b = report.top_risks.iter().find(|r| r.path == "b.rs").unwrap();
+        assert_eq!(b.detail, "auth check removed");
+        assert_eq!(b.start_line, Some(42));
+    }
+
+    #[test]
+    fn finalize_triage_drops_unknown_and_appends_missing() {
+        let files = [fc("a.rs", "high"), fc("b.rs", "low")];
+        let relevant: Vec<&FileClassification> = files.iter().collect();
+        // AI returned an order missing b.rs and a hallucinated ghost.rs, plus a
+        // top risk pointing at a file not in the PR.
+        let mut report = TriageReport {
+            top_risks: vec![TopRisk { title: "x".into(), detail: "y".into(), path: "ghost.rs".into(), start_line: None }],
+            review_order: vec![
+                ReviewOrderItem { path: "a.rs".into(), rationale: "defines it".into() },
+                ReviewOrderItem { path: "ghost.rs".into(), rationale: "nope".into() },
+            ],
+        };
+        finalize_triage(&mut report, &relevant);
+        // ghost.rs dropped from both; b.rs appended to the order.
+        assert!(report.top_risks.is_empty());
+        let order: Vec<&str> = report.review_order.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(order, vec!["a.rs", "b.rs"]);
     }
 }

--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -80,15 +80,13 @@ For each highlight, provide:
 Respond with ONLY a valid JSON array of these highlight objects. If there are no notable changes, return an empty array [].
 Do NOT include any text before or after the JSON array. Just the JSON."#;
 
-pub const SUMMARY_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and AI-generated reasons, write a concise executive summary for a code reviewer.
+pub const SUMMARY_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and AI-generated reasons, write a SHORT orienting summary for a code reviewer.
 
-The summary should:
-1. Start with a 1-2 sentence overview of what this PR does
-2. Call out the most important areas to focus on (security-sensitive changes, API contract changes, infra changes)
-3. Note any patterns across the changes (e.g., "Most changes are in the payment service" or "This is primarily a refactor with one behavioral change in X")
-4. Be 3-5 short paragraphs — enough to orient the reviewer, not a full analysis
+Keep it tight — at most 3-4 sentences total (one short paragraph, or two at most). Cover only:
+1. What this PR does, in one or two sentences.
+2. The single most important thing to focus on, or the overall shape (e.g. "mostly a refactor with one behavioral change in X").
 
-Format the summary as separate paragraphs separated by blank lines. Each paragraph should cover a distinct aspect (overview, critical areas, patterns, etc.). No JSON, no markdown headers, no bullet points — just well-structured prose paragraphs."#;
+Do not enumerate files, restate per-file reasons, or list every risk — a separate triage step already surfaces the specific risks. Be brief; the reviewer wants orientation, not analysis. No JSON, no markdown headers, no bullet points — just one or two short prose paragraphs."#;
 
 pub const GROUPING_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and reasons, group the files into logical change sets.
 

--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -110,6 +110,71 @@ Respond with ONLY a valid JSON array. Each element must be an object with:
 
 Do NOT include any text before or after the JSON array. Just the JSON."#;
 
+pub const TRIAGE_PROMPT: &str = r#"You are a code review assistant helping a reviewer triage a large pull request so they can review the risky parts first, in the order that's easiest to understand.
+
+Produce two things:
+
+1. "top_risks": the 2-3 changes in this PR that carry the most real risk — security/auth changes, removed safety checks, data/permission changes, breaking API/contract changes, concurrency. NOT style, renames, or routine additions. For each: a short "title", a one-sentence "detail" on why it matters, the "path" it lives in, and "start_line" (the line in the NEW version where it starts) when you can tell from the diff. If nothing carries real risk, return an empty array.
+
+2. "review_order": ALL of the relevant files, ordered "contract-first" so the reviewer builds understanding with the fewest jumps back: first the files that DEFINE things (types, schemas, interfaces, API contracts), then the PRODUCERS that implement them, then the CONSUMERS that use them, then tests/config last. Each entry has the "path" and a "rationale" of at most ~12 words explaining why it's here in the order (e.g. "defines the ReviewMode shape the rest consumes"). Every relevant file must appear exactly once.
+
+Respond with ONLY a valid JSON object of this exact shape:
+{
+  "top_risks": [{"title": "...", "detail": "...", "path": "...", "start_line": 123}],
+  "review_order": [{"path": "...", "rationale": "..."}]
+}
+Do NOT include any text before or after the JSON object. Just the JSON."#;
+
+/// Build the triage prompt: structured per-file info (path, category, risk,
+/// reason) plus compact diff snippets so the model can reason about contracts and
+/// dependencies for ordering. Diffs are budgeted tighter than the highlight pass
+/// since ordering needs signatures/imports, not full bodies.
+pub fn build_triage_prompt(
+    pr_title: &str,
+    relevant_files: &[&FileClassification],
+    per_file_diffs: &[(String, String)],
+) -> String {
+    const PER_FILE_BUDGET: usize = 1500;
+    const TOTAL_BUDGET: usize = 20000;
+
+    let mut file_info = String::new();
+    for f in relevant_files {
+        file_info.push_str(&format!(
+            "- {} [{}] [{}] — {}\n",
+            f.path, f.category, f.risk_level, f.reason
+        ));
+    }
+
+    let mut diffs = String::new();
+    let mut remaining = TOTAL_BUDGET;
+    for (path, diff) in per_file_diffs {
+        if remaining == 0 {
+            break;
+        }
+        diffs.push_str(&format!("=== FILE: {} ===\n", path));
+        let cap = PER_FILE_BUDGET.min(remaining);
+        if diff.chars().count() > cap {
+            let snippet: String = diff.chars().take(cap).collect();
+            diffs.push_str(&snippet);
+            diffs.push_str("\n... (truncated)\n");
+            remaining = remaining.saturating_sub(cap);
+        } else {
+            diffs.push_str(diff);
+            remaining = remaining.saturating_sub(diff.chars().count());
+        }
+        diffs.push_str("\n\n");
+    }
+
+    format!(
+        "{}\n\n---\n\nPR Title: {}\n\nRelevant files ({} total):\n\n{}\n\n=== DIFFS ===\n\n{}",
+        TRIAGE_PROMPT,
+        pr_title,
+        relevant_files.len(),
+        file_info,
+        diffs
+    )
+}
+
 pub fn build_summary_prompt(
     pr_title: &str,
     relevant_files: &[&FileClassification],

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -167,9 +167,9 @@ pub struct Settings {
     /// once you approve a PR, it drops out of the feed.
     #[serde(default)]
     pub show_approved_prs: bool,
-    /// When true, files open with every hunk expanded instead of auto-collapsing
-    /// low-significance hunks (issue #55).
-    #[serde(default)]
+    /// When true (the default), files open with every hunk expanded; turn it off
+    /// to auto-collapse low-significance hunks (issue #55).
+    #[serde(default = "default_true")]
     pub expand_all_hunks: bool,
 }
 

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -171,6 +171,19 @@ pub struct Settings {
     /// to auto-collapse low-significance hunks (issue #55).
     #[serde(default = "default_true")]
     pub expand_all_hunks: bool,
+    /// Mute the guided tour's spoken narration by default.
+    #[serde(default)]
+    pub tts_muted: bool,
+    /// Preferred speech-synthesis voice name for tour narration ("" = system default).
+    #[serde(default)]
+    pub tts_voice: String,
+    /// Tour narration speaking rate (1.0 = normal).
+    #[serde(default = "default_tts_rate")]
+    pub tts_rate: f32,
+}
+
+fn default_tts_rate() -> f32 {
+    1.0
 }
 
 fn default_true() -> bool {

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -64,6 +64,39 @@ pub struct ChangeGroup {
     pub file_paths: Vec<String>,
 }
 
+/// One of the 2-3 highest-risk changes, surfaced in the top-of-review triage card.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TopRisk {
+    /// Short headline (e.g. "Admin-only check removed on /users").
+    pub title: String,
+    /// One sentence on why it carries risk.
+    pub detail: String,
+    /// File the reviewer should jump to.
+    pub path: String,
+    /// Line (in the head version) to scroll to, when known.
+    #[serde(default)]
+    pub start_line: Option<u64>,
+}
+
+/// One file in the contract-first "fastest path" ordering, with a one-line
+/// rationale ("defines the shape the rest consumes").
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReviewOrderItem {
+    pub path: String,
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// Triage guidance for large PRs: what to review first and in what order.
+/// Absent for small PRs (see the gate in `fetch`).
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct TriageReport {
+    #[serde(default)]
+    pub top_risks: Vec<TopRisk>,
+    #[serde(default)]
+    pub review_order: Vec<ReviewOrderItem>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewManifest {
     pub pr_title: String,
@@ -77,6 +110,10 @@ pub struct ReviewManifest {
     pub summary: String,
     #[serde(default)]
     pub change_groups: Vec<ChangeGroup>,
+    /// Triage-first guidance (top risks + contract-first order). `None` for small
+    /// PRs or when the triage AI pass fails without a usable fallback.
+    #[serde(default)]
+    pub triage: Option<TriageReport>,
     pub files: Vec<FileDiff>,
 }
 
@@ -130,6 +167,10 @@ pub struct Settings {
     /// once you approve a PR, it drops out of the feed.
     #[serde(default)]
     pub show_approved_prs: bool,
+    /// When true, files open with every hunk expanded instead of auto-collapsing
+    /// low-significance hunks (issue #55).
+    #[serde(default)]
+    pub expand_all_hunks: bool,
 }
 
 fn default_true() -> bool {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -537,52 +537,101 @@ pub fn load_cached_manifest_by_pr(pr_url: String) -> Result<Option<ReviewManifes
     ))
 }
 
-/// One candidate stop for the guided tour, built by the frontend from the
-/// triage order + important highlights. `kind` is "intro" (arriving at a file) or
-/// "note" (a specific change); `seed` is the terse note the AI rewrites.
+/// A flagged issue (AI highlight) on a file, with its line range, passed into the
+/// tour so the AI can narrate it in place.
 #[derive(Debug, Deserialize)]
-pub struct TourSeed {
+pub struct TourHighlight {
+    pub start_line: u64,
+    pub end_line: u64,
+    pub severity: String,
+    pub comment: String,
+}
+
+/// A significant file the tour should walk through. `diff` is annotated with
+/// head-side line numbers (`[L52] + ...`) so the AI can reference exact lines.
+#[derive(Debug, Deserialize)]
+pub struct TourFile {
     pub path: String,
-    pub kind: String,
-    pub seed: String,
     #[serde(default)]
-    pub severity: Option<String>,
+    pub rationale: String,
+    #[serde(default)]
+    pub risk_level: String,
+    pub diff: String,
+    #[serde(default)]
+    pub highlights: Vec<TourHighlight>,
 }
 
-/// Narration for a tour: a one-line opening plus one string per seed (in order).
+/// One stop the AI emitted: a file, an optional line range to focus, a kind, and
+/// the narration. `kind` is "intro" | "walk" | "note".
+#[derive(Debug, Clone, Serialize)]
+pub struct TourStopOut {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_line: Option<u64>,
+    pub kind: String,
+    pub narration: String,
+}
+
+/// The generated tour: an opening rundown plus an ordered list of stops.
 #[derive(Debug, Serialize)]
-pub struct TourNarration {
+pub struct TourOut {
     pub opening: String,
-    pub narrations: Vec<String>,
+    pub stops: Vec<TourStopOut>,
 }
 
-fn build_tour_prompt(pr_title: &str, summary: &str, seeds: &[TourSeed]) -> String {
-    let mut stops = String::new();
-    for (i, s) in seeds.iter().enumerate() {
-        let tag = match s.severity.as_deref() {
-            Some(sev) if s.kind == "note" => format!("note/{sev}"),
-            _ => s.kind.clone(),
-        };
-        stops.push_str(&format!("{}. [{}] {} — {}\n", i + 1, tag, s.path, s.seed));
+fn build_tour_prompt(pr_title: &str, summary: &str, files: &[TourFile]) -> String {
+    const PER_FILE_BUDGET: usize = 2600;
+    let mut files_block = String::new();
+    for f in files {
+        files_block.push_str(&format!("\n=== FILE: {} [{}] ===\n", f.path, f.risk_level));
+        if !f.rationale.trim().is_empty() {
+            files_block.push_str(&format!("Role: {}\n", f.rationale));
+        }
+        if !f.highlights.is_empty() {
+            files_block.push_str("Flagged issues:\n");
+            for h in &f.highlights {
+                files_block.push_str(&format!(
+                    "- L{}-{} [{}]: {}\n",
+                    h.start_line, h.end_line, h.severity, h.comment
+                ));
+            }
+        }
+        files_block.push_str("Diff (head-side line numbers in [Lnn]):\n");
+        let diff: String = f.diff.chars().take(PER_FILE_BUDGET).collect();
+        files_block.push_str(&diff);
+        files_block.push('\n');
     }
+
     format!(
-        r#"You are narrating a calm, guided walkthrough of a pull request for a code reviewer — think a gentle museum audio guide, not a lecture. You are given the tour stops IN ORDER. Each stop has a file path, a kind ("intro" = arriving at a new file, "note" = a specific change to look at), and a terse seed note.
+        r#"You are the narrator of a calm, cinematic guided tour of a pull request, for a reviewer who wants to be walked through the important code hands-free. Think a thoughtful senior engineer pair-reviewing, not a lecture.
 
-Write a SHORT narration for each stop — 1 to 2 sentences, warm and clear but never chatty — that flows as a sequence (use light connective phrasing like "First,", "Next,", "Here,", "Now," where it reads naturally). For "intro" stops, orient the reviewer to the file's role in one sentence. For "note" stops, say what to notice and why it matters. Keep each concise so the reviewer is never overwhelmed. Don't restate the file path. Don't invent details beyond the seed and PR context.
+For EACH file below, in order, produce a small sequence of stops:
+1. ONE "intro" stop (no line numbers) — one sentence on the file's role in the change.
+2. A few "walk" stops that take the reviewer THROUGH the substantive code that makes this file significant. Focus a tight line range (use the [Lnn] head-side numbers). Explain what the code does and why it matters. For the 1-2 most important spots, you may go essentially line-by-line (single-line or 2-3 line ranges), discussing what each part does. This is the heart of the tour — show, don't just summarize.
+3. A "note" stop for each flagged issue, at its line range, explaining the concern.
 
-Also write an "opening": a 2-3 sentence high-level rundown, from the author's perspective, of what this PR sets out to accomplish and the broad approach it takes — the goal and shape of the change before we dive into specific files. Warm and orienting, not a list.
+Rules:
+- Each narration is 1-2 sentences, warm and clear, flowing as a sequence ("First," / "Here," / "Notice," / "Now,"). Never chatty; never overwhelming.
+- start_line/end_line MUST be head-side numbers that actually appear as [Lnn] in that file's diff. Prefer tight ranges. "intro" stops omit line numbers.
+- Don't invent code or details not in the diff. Don't restate the file path.
+- Keep the total reasonable — a handful of stops per file, weighted toward the significant ones.
 
-Respond with ONLY a JSON object: {{"opening": "...", "stops": ["narration 1", "narration 2", ...]}} with EXACTLY {n} strings in "stops", in the given order.
+Also write an "opening": a 2-3 sentence high-level rundown, from the author's perspective, of what this PR sets out to accomplish and its broad approach — before diving into files.
+
+Respond with ONLY a JSON object:
+{{"opening": "...", "stops": [{{"path": "...", "start_line": 52, "end_line": 60, "kind": "walk", "narration": "..."}}, ...]}}
+"intro" stops omit start_line/end_line. Stops must be grouped by file in the given file order.
 
 PR Title: {title}
 Summary: {summary}
 
-Stops:
-{stops}"#,
-        n = seeds.len(),
+Files:
+{files_block}"#,
         title = pr_title,
         summary = if summary.trim().is_empty() { "(none)" } else { summary },
-        stops = stops,
+        files_block = files_block,
     )
 }
 
@@ -590,19 +639,38 @@ Stops:
 pub async fn generate_tour(
     pr_title: String,
     summary: String,
-    seeds: Vec<TourSeed>,
-) -> Result<TourNarration, String> {
-    if seeds.is_empty() {
-        return Ok(TourNarration { opening: String::new(), narrations: vec![] });
+    files: Vec<TourFile>,
+) -> Result<TourOut, String> {
+    if files.is_empty() {
+        return Ok(TourOut { opening: String::new(), stops: vec![] });
     }
     let settings = load_settings();
     let backend = AiBackend::from_settings(&settings).await?;
-    let prompt = build_tour_prompt(&pr_title, &summary, &seeds);
+    let prompt = build_tour_prompt(&pr_title, &summary, &files);
 
-    // Fallback narration if the AI call/parse fails: the seed text itself.
-    let fallback = || TourNarration {
-        opening: String::new(),
-        narrations: seeds.iter().map(|s| s.seed.clone()).collect(),
+    // Fallback if the AI call/parse fails: an intro per file + its issues, using
+    // the seed text directly so the tour still runs.
+    let fallback = || {
+        let mut stops = Vec::new();
+        for f in &files {
+            stops.push(TourStopOut {
+                path: f.path.clone(),
+                start_line: None,
+                end_line: None,
+                kind: "intro".to_string(),
+                narration: f.rationale.clone(),
+            });
+            for h in &f.highlights {
+                stops.push(TourStopOut {
+                    path: f.path.clone(),
+                    start_line: Some(h.start_line),
+                    end_line: Some(h.end_line),
+                    kind: "note".to_string(),
+                    narration: h.comment.clone(),
+                });
+            }
+        }
+        TourOut { opening: String::new(), stops }
     };
 
     let raw = match backend.invoke(&prompt).await {
@@ -615,19 +683,32 @@ pub async fn generate_tour(
     };
 
     let opening = json["opening"].as_str().unwrap_or_default().to_string();
-    let mut narrations: Vec<String> = json["stops"]
+    let stops: Vec<TourStopOut> = json["stops"]
         .as_array()
-        .map(|arr| arr.iter().map(|v| v.as_str().unwrap_or_default().to_string()).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| {
+                    let path = v["path"].as_str()?.to_string();
+                    let narration = v["narration"].as_str().unwrap_or_default().to_string();
+                    if narration.trim().is_empty() {
+                        return None;
+                    }
+                    Some(TourStopOut {
+                        path,
+                        start_line: v["start_line"].as_u64(),
+                        end_line: v["end_line"].as_u64(),
+                        kind: v["kind"].as_str().unwrap_or("walk").to_string(),
+                        narration,
+                    })
+                })
+                .collect()
+        })
         .unwrap_or_default();
-    // Align to the seeds: pad short, truncate long, and fill blanks from the seed.
-    narrations.resize(seeds.len(), String::new());
-    for (i, s) in seeds.iter().enumerate() {
-        if narrations[i].trim().is_empty() {
-            narrations[i] = s.seed.clone();
-        }
-    }
 
-    Ok(TourNarration { opening, narrations })
+    if stops.is_empty() {
+        return Ok(fallback());
+    }
+    Ok(TourOut { opening, stops })
 }
 
 #[command]

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::sync::Mutex;
 use tauri::{command, State};
+use tokio_util::sync::CancellationToken;
 
 pub struct AppState {
     pub manifest_path: Mutex<Option<String>>,
@@ -25,6 +26,8 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
+    // Cancels the in-flight tour-narration `say` process (see speak_tts/stop_tts).
+    pub tts_cancel: Mutex<Option<CancellationToken>>,
 }
 
 fn github_client() -> GithubClient {
@@ -709,6 +712,95 @@ pub async fn generate_tour(
         return Ok(fallback());
     }
     Ok(TourOut { opening, stops })
+}
+
+/// A system speech voice available to the macOS `say` command.
+#[derive(Debug, Serialize)]
+pub struct TtsVoice {
+    pub name: String,
+    pub lang: String,
+}
+
+/// List the system speech voices via `say -v '?'` (macOS). These include the
+/// high-quality enhanced/premium voices the WebView's Web Speech API can't reach.
+/// Returns empty on non-macOS or if `say` is unavailable.
+#[command]
+pub fn list_tts_voices() -> Vec<TtsVoice> {
+    #[cfg(target_os = "macos")]
+    {
+        let Ok(out) = std::process::Command::new("say").args(["-v", "?"]).output() else {
+            return Vec::new();
+        };
+        let text = String::from_utf8_lossy(&out.stdout);
+        let mut voices = Vec::new();
+        for line in text.lines() {
+            // "Ava (Enhanced)      en_US    # comment". The locale is the last
+            // whitespace token before the '#'; the name is everything before it.
+            let head = line.split('#').next().unwrap_or("");
+            let Some(lang) = head.split_whitespace().next_back() else { continue };
+            let name = match head.rfind(lang) {
+                Some(idx) => head[..idx].trim().to_string(),
+                None => continue,
+            };
+            if !name.is_empty() && lang.contains('_') {
+                voices.push(TtsVoice { name, lang: lang.to_string() });
+            }
+        }
+        // English voices first (most relevant for an English code review), then by name.
+        voices.sort_by(|a, b| {
+            let ord = |l: &str| if l.starts_with("en") { 0 } else { 1 };
+            ord(&a.lang).cmp(&ord(&b.lang)).then(a.name.cmp(&b.name))
+        });
+        return voices;
+    }
+    #[allow(unreachable_code)]
+    Vec::new()
+}
+
+/// Speak `text` via the macOS `say` command using `voice` at `rate_wpm` words per
+/// minute. Resolves `true` when speech finishes, `false` if cancelled by
+/// `stop_tts`. The frontend advances the tour on `true`.
+#[command]
+pub async fn speak_tts(
+    state: State<'_, AppState>,
+    text: String,
+    voice: String,
+    rate_wpm: u32,
+) -> Result<bool, String> {
+    // Replace any in-flight speech with this one.
+    let token = CancellationToken::new();
+    {
+        let mut guard = state.tts_cancel.lock().unwrap();
+        if let Some(prev) = guard.take() {
+            prev.cancel();
+        }
+        *guard = Some(token.clone());
+    }
+
+    let mut cmd = tokio::process::Command::new("say");
+    if !voice.is_empty() {
+        cmd.arg("-v").arg(&voice);
+    }
+    if rate_wpm > 0 {
+        cmd.arg("-r").arg(rate_wpm.to_string());
+    }
+    cmd.arg(&text);
+    cmd.kill_on_drop(true); // dropping the future on cancel kills `say`
+
+    let mut child = cmd.spawn().map_err(|e| format!("Failed to run `say`: {e}"))?;
+    let finished = tokio::select! {
+        res = child.wait() => { res.map_err(|e| format!("`say` failed: {e}"))?; true }
+        _ = token.cancelled() => false,
+    };
+    Ok(finished)
+}
+
+/// Stop the current tour narration (kills the `say` process).
+#[command]
+pub fn stop_tts(state: State<AppState>) {
+    if let Some(token) = state.tts_cancel.lock().unwrap().take() {
+        token.cancel();
+    }
 }
 
 #[command]

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -1,5 +1,7 @@
+use marrow_core::ai::{extract_json_object, AiBackend};
 use marrow_core::bedrock::{region_from_arn, BedrockClient};
 use marrow_core::config::{load_settings, resolve_github_token, save_settings_to_disk};
+use serde::{Deserialize, Serialize};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
 use marrow_core::types::{MyReviewState, PrChecksStatus, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
@@ -533,6 +535,99 @@ pub fn load_cached_manifest_by_pr(pr_url: String) -> Result<Option<ReviewManifes
         &parsed.repo,
         parsed.number,
     ))
+}
+
+/// One candidate stop for the guided tour, built by the frontend from the
+/// triage order + important highlights. `kind` is "intro" (arriving at a file) or
+/// "note" (a specific change); `seed` is the terse note the AI rewrites.
+#[derive(Debug, Deserialize)]
+pub struct TourSeed {
+    pub path: String,
+    pub kind: String,
+    pub seed: String,
+    #[serde(default)]
+    pub severity: Option<String>,
+}
+
+/// Narration for a tour: a one-line opening plus one string per seed (in order).
+#[derive(Debug, Serialize)]
+pub struct TourNarration {
+    pub opening: String,
+    pub narrations: Vec<String>,
+}
+
+fn build_tour_prompt(pr_title: &str, summary: &str, seeds: &[TourSeed]) -> String {
+    let mut stops = String::new();
+    for (i, s) in seeds.iter().enumerate() {
+        let tag = match s.severity.as_deref() {
+            Some(sev) if s.kind == "note" => format!("note/{sev}"),
+            _ => s.kind.clone(),
+        };
+        stops.push_str(&format!("{}. [{}] {} — {}\n", i + 1, tag, s.path, s.seed));
+    }
+    format!(
+        r#"You are narrating a calm, guided walkthrough of a pull request for a code reviewer — think a gentle museum audio guide, not a lecture. You are given the tour stops IN ORDER. Each stop has a file path, a kind ("intro" = arriving at a new file, "note" = a specific change to look at), and a terse seed note.
+
+Write a SHORT narration for each stop — 1 to 2 sentences, warm and clear but never chatty — that flows as a sequence (use light connective phrasing like "First,", "Next,", "Here,", "Now," where it reads naturally). For "intro" stops, orient the reviewer to the file's role in one sentence. For "note" stops, say what to notice and why it matters. Keep each concise so the reviewer is never overwhelmed. Don't restate the file path. Don't invent details beyond the seed and PR context.
+
+Also write a single-sentence "opening" that sets up the walkthrough.
+
+Respond with ONLY a JSON object: {{"opening": "...", "stops": ["narration 1", "narration 2", ...]}} with EXACTLY {n} strings in "stops", in the given order.
+
+PR Title: {title}
+Summary: {summary}
+
+Stops:
+{stops}"#,
+        n = seeds.len(),
+        title = pr_title,
+        summary = if summary.trim().is_empty() { "(none)" } else { summary },
+        stops = stops,
+    )
+}
+
+#[command]
+pub async fn generate_tour(
+    pr_title: String,
+    summary: String,
+    seeds: Vec<TourSeed>,
+) -> Result<TourNarration, String> {
+    if seeds.is_empty() {
+        return Ok(TourNarration { opening: String::new(), narrations: vec![] });
+    }
+    let settings = load_settings();
+    let backend = AiBackend::from_settings(&settings).await?;
+    let prompt = build_tour_prompt(&pr_title, &summary, &seeds);
+
+    // Fallback narration if the AI call/parse fails: the seed text itself.
+    let fallback = || TourNarration {
+        opening: String::new(),
+        narrations: seeds.iter().map(|s| s.seed.clone()).collect(),
+    };
+
+    let raw = match backend.invoke(&prompt).await {
+        Ok(r) => r,
+        Err(_) => return Ok(fallback()),
+    };
+    let json = match extract_json_object(&raw) {
+        Ok(j) => j,
+        Err(_) => return Ok(fallback()),
+    };
+
+    let opening = json["opening"].as_str().unwrap_or_default().to_string();
+    let mut narrations: Vec<String> = json["stops"]
+        .as_array()
+        .map(|arr| arr.iter().map(|v| v.as_str().unwrap_or_default().to_string()).collect())
+        .unwrap_or_default();
+    // Align to the seeds: pad short, truncate long, and fill blanks from the seed.
+    narrations.resize(seeds.len(), String::new());
+    for (i, s) in seeds.iter().enumerate() {
+        if narrations[i].trim().is_empty() {
+            narrations[i] = s.seed.clone();
+        }
+    }
+
+    Ok(TourNarration { opening, narrations })
 }
 
 #[command]

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -570,7 +570,7 @@ fn build_tour_prompt(pr_title: &str, summary: &str, seeds: &[TourSeed]) -> Strin
 
 Write a SHORT narration for each stop — 1 to 2 sentences, warm and clear but never chatty — that flows as a sequence (use light connective phrasing like "First,", "Next,", "Here,", "Now," where it reads naturally). For "intro" stops, orient the reviewer to the file's role in one sentence. For "note" stops, say what to notice and why it matters. Keep each concise so the reviewer is never overwhelmed. Don't restate the file path. Don't invent details beyond the seed and PR context.
 
-Also write a single-sentence "opening" that sets up the walkthrough.
+Also write an "opening": a 2-3 sentence high-level rundown, from the author's perspective, of what this PR sets out to accomplish and the broad approach it takes — the goal and shape of the change before we dive into specific files. Warm and orienting, not a list.
 
 Respond with ONLY a JSON object: {{"opening": "...", "stops": ["narration 1", "narration 2", ...]}} with EXACTLY {n} strings in "stops", in the given order.
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -87,6 +87,7 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
+            tts_cancel: Mutex::new(None),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -230,6 +231,9 @@ pub fn run() {
             commands::submit_review,
             commands::generate_review_body,
             commands::generate_tour,
+            commands::list_tts_voices,
+            commands::speak_tts,
+            commands::stop_tts,
             commands::update_review_comment,
             commands::create_review_comment,
             commands::toggle_reaction,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -229,6 +229,7 @@ pub fn run() {
             commands::get_my_review_state,
             commands::submit_review,
             commands::generate_review_body,
+            commands::generate_tour,
             commands::update_review_comment,
             commands::create_review_comment,
             commands::toggle_reaction,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -40,6 +40,77 @@ function tourDwellMs(narration: string): number {
   return Math.max(4500, Math.min(13000, 2800 + words * 320));
 }
 
+/** A stop as returned by the generate_tour command (line numbers are the AI's). */
+interface RawTourStop {
+  path: string;
+  start_line?: number | null;
+  end_line?: number | null;
+  kind: string;
+  narration: string;
+}
+
+/** Snap an AI-chosen line to the nearest real changed line (within 6), or null
+ * if it's too far off to trust. */
+function snapToValid(valid: number[], line: number): number | null {
+  if (valid.length === 0) return line;
+  let best = valid[0];
+  let bestD = Math.abs(valid[0] - line);
+  for (const v of valid) {
+    const d = Math.abs(v - line);
+    if (d < bestD) { best = v; bestD = d; }
+  }
+  return bestD <= 6 ? best : null;
+}
+
+/** Validate + assemble the AI's stops into the final tour: ground each line range
+ * against real lines, keep contract-first file order, guarantee an intro per file
+ * and that every flagged highlight gets a stop, and order stops top-to-bottom. */
+function assembleTourStops(
+  raw: RawTourStop[],
+  files: FileDiff[],
+  validByPath: Map<string, number[]>,
+  highlightsByPath: Map<string, FileDiff["highlights"]>,
+  rationale: Map<string, string>,
+): TourStop[] {
+  const fileSet = new Set(files.map((f) => f.path));
+  const groups = new Map<string, TourStop[]>();
+  const groupFor = (p: string) => {
+    let g = groups.get(p);
+    if (!g) { g = []; groups.set(p, g); }
+    return g;
+  };
+
+  for (const s of raw) {
+    if (!fileSet.has(s.path)) continue;
+    const g = groupFor(s.path);
+    if (s.kind === "intro" || s.start_line == null) {
+      g.push({ path: s.path, line: null, kind: "intro", narration: s.narration });
+      continue;
+    }
+    const valid = validByPath.get(s.path) ?? [];
+    const start = snapToValid(valid, s.start_line);
+    if (start == null) continue; // can't ground it to a real line — drop
+    const maxLine = valid.length ? valid[valid.length - 1] : start;
+    const end = Math.max(start, Math.min(s.end_line ?? start, maxLine));
+    g.push({ path: s.path, line: start, endLine: end, kind: s.kind === "note" ? "note" : "walk", narration: s.narration });
+  }
+
+  const out: TourStop[] = [];
+  for (const f of files) {
+    const g = groupFor(f.path);
+    // Guarantee every flagged highlight has a stop (the issues are "good to keep").
+    for (const h of highlightsByPath.get(f.path) ?? []) {
+      const covered = g.some((st) => st.line != null && st.line >= h.start_line - 2 && st.line <= h.end_line + 2);
+      if (!covered) g.push({ path: f.path, line: h.start_line, endLine: h.end_line, kind: "note", severity: h.severity, narration: h.comment });
+    }
+    const intro = g.find((s) => s.kind === "intro")
+      ?? { path: f.path, line: null, kind: "intro" as const, narration: rationale.get(f.path) || "" };
+    const rest = g.filter((s) => s.kind !== "intro").sort((a, b) => (a.line ?? 0) - (b.line ?? 0));
+    if (rest.length > 0) out.push(intro, ...rest); // skip files the AI gave nothing for
+  }
+  return out;
+}
+
 function App() {
   const nextTabId = useRef(1);
   const [tabs, setTabs] = useState<Tab[]>([]);
@@ -860,67 +931,98 @@ function App() {
   }
 
   // ─── Cinematic guided tour ──────────────────────────────────────────────
-  type TourCandidate = { path: string; line: number | null; endLine?: number | null; kind: "intro" | "note"; severity?: string; seed: string };
 
-  // Build the tour's stops (important parts only): walk the contract-first order;
-  // for each file that carries a critical/warning note or is high-risk, add a
-  // brief intro then a stop at each important highlight.
-  function buildTourCandidates(manifest: ReviewManifest): TourCandidate[] {
+  // Annotate a unified diff with head-side line numbers so the AI can reference
+  // exact lines ("[L52] + ..."). Returns the annotated text and the set of valid
+  // head lines (added + context) for validating the AI's chosen ranges.
+  function annotateDiff(diff: string): { text: string; valid: number[] } {
+    const out: string[] = [];
+    const valid: number[] = [];
+    let head = 0;
+    for (const line of diff.split("\n")) {
+      if (line.startsWith("@@")) {
+        const m = line.match(/\+(\d+)/);
+        if (m) head = parseInt(m[1], 10);
+        out.push(line);
+      } else if (line.startsWith("+")) {
+        out.push(`[L${head}] ${line}`);
+        valid.push(head);
+        head++;
+      } else if (line.startsWith("-")) {
+        out.push(`[del] ${line}`);
+      } else {
+        out.push(`[L${head}] ${line}`);
+        valid.push(head);
+        head++;
+      }
+    }
+    return { text: out.join("\n"), valid };
+  }
+
+  // The significant files to tour (contract-first order, capped): high-risk
+  // files or files with a critical/warning highlight.
+  function tourFilesFor(manifest: ReviewManifest): FileDiff[] {
     const order = manifest.triage?.review_order ?? [];
-    const rationale = new Map(order.map((o) => [o.path, o.rationale]));
-    const candidates: TourCandidate[] = [];
+    const out: FileDiff[] = [];
     for (const item of order) {
       const file = manifest.files.find((f) => f.path === item.path);
       if (!file) continue;
-      const important = (file.highlights ?? [])
-        .filter((h) => h.severity === "critical" || h.severity === "warning")
-        .sort((a, b) => a.start_line - b.start_line);
+      const hasImportant = (file.highlights ?? []).some((h) => h.severity === "critical" || h.severity === "warning");
       const highRisk = file.risk_level === "critical" || file.risk_level === "high";
-      if (important.length === 0 && !highRisk) continue;
-      // Intro lands at the top of the file (line: null) — the reviewer gets
-      // oriented before the tour pans down into the specific changes.
-      candidates.push({
-        path: file.path,
-        line: null,
-        kind: "intro",
-        seed: rationale.get(file.path) || `${file.category}: ${file.reason}`,
-      });
-      for (const h of important) {
-        candidates.push({ path: file.path, line: h.start_line, endLine: h.end_line, kind: "note", severity: h.severity, seed: h.comment });
-      }
+      if (hasImportant || highRisk) out.push(file);
+      if (out.length >= 7) break;
     }
-    return candidates;
+    return out;
   }
 
   async function handleStartTour() {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
     const manifest = tab.manifest;
-    const candidates = buildTourCandidates(manifest);
-    if (candidates.length === 0) {
+    const order = manifest.triage?.review_order ?? [];
+    const rationale = new Map(order.map((o) => [o.path, o.rationale]));
+    const files = tourFilesFor(manifest);
+    if (files.length === 0) {
       addToast("info", "Nothing stands out to tour — use the guided list to review in order");
       return;
     }
+
+    // Per-file valid head lines (for snapping the AI's ranges to real lines) and
+    // the important highlights we guarantee are kept.
+    const validByPath = new Map<string, number[]>();
+    const highlightsByPath = new Map<string, FileDiff["highlights"]>();
+    const reqFiles = files.map((f) => {
+      const { text, valid } = annotateDiff(f.unified_diff);
+      validByPath.set(f.path, valid);
+      const important = (f.highlights ?? [])
+        .filter((h) => h.severity === "critical" || h.severity === "warning")
+        .sort((a, b) => a.start_line - b.start_line);
+      highlightsByPath.set(f.path, important);
+      return {
+        path: f.path,
+        rationale: rationale.get(f.path) || `${f.category}: ${f.reason}`,
+        risk_level: f.risk_level,
+        diff: text,
+        highlights: important.map((h) => ({ start_line: h.start_line, end_line: h.end_line, severity: h.severity, comment: h.comment })),
+      };
+    });
+
     updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided" }));
     setTour({ ...IDLE_TOUR, status: "loading" });
     try {
-      const result = await invoke<{ opening: string; narrations: string[] }>("generate_tour", {
+      const result = await invoke<{ opening: string; stops: RawTourStop[] }>("generate_tour", {
         prTitle: manifest.pr_title,
         summary: manifest.summary,
-        seeds: candidates.map((c) => ({ path: c.path, kind: c.kind, seed: c.seed, severity: c.severity ?? null })),
+        files: reqFiles,
       });
-      const stops: TourStop[] = candidates.map((c, i) => ({
-        path: c.path,
-        line: c.line,
-        endLine: c.endLine,
-        kind: c.kind,
-        severity: c.severity,
-        narration: result.narrations[i] || c.seed,
-      }));
-      // Lead with the opening rundown as its own stop on the overview card
-      // (empty path = show the triage overview, not a file).
+      const stops = assembleTourStops(result.stops, files, validByPath, highlightsByPath, rationale);
       if (result.opening.trim()) {
         stops.unshift({ path: "", line: null, kind: "intro", narration: result.opening });
+      }
+      if (stops.length === 0) {
+        setTour(IDLE_TOUR);
+        addToast("error", "The tour came back empty — try again");
+        return;
       }
       setTour({ status: "active", stops, index: 0, playing: true, opening: result.opening });
     } catch (err) {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -125,8 +125,11 @@ function App() {
   const [pendingJump, setPendingJump] = useState<{ path: string; line: number; endLine?: number } | null>(null);
   // The cinematic guided tour (auto-playing walkthrough of the active PR).
   const [tour, setTour] = useState<TourState>(IDLE_TOUR);
-  // Spoken narration (Web Speech API). On by default; toggled in the player.
+  // Spoken narration (Web Speech API). Defaults come from settings; the player
+  // mute toggle overrides for the session.
   const [ttsEnabled, setTtsEnabled] = useState(true);
+  const [ttsVoice, setTtsVoice] = useState("");
+  const [ttsRate, setTtsRate] = useState(1);
   const ttsSupported = typeof window !== "undefined" && "speechSynthesis" in window;
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -168,6 +171,9 @@ function App() {
       // Re-apply settings that drive live rendering so changes take effect without
       // a restart (the next file open picks up expand_all_hunks).
       setExpandAllHunks(s.expand_all_hunks ?? true);
+      setTtsEnabled(!(s.tts_muted ?? false));
+      setTtsVoice(s.tts_voice ?? "");
+      setTtsRate(s.tts_rate ?? 1);
     }).catch(() => {});
   }, []);
 
@@ -416,6 +422,9 @@ function App() {
         setShowAiNotes(settings.show_ai_notes ?? true);
         setHunkFilter(settings.hunk_filter || "all");
         setExpandAllHunks(settings.expand_all_hunks ?? true);
+        setTtsEnabled(!(settings.tts_muted ?? false));
+        setTtsVoice(settings.tts_voice ?? "");
+        setTtsRate(settings.tts_rate ?? 1);
       } catch {
         // Use defaults on failure
       }
@@ -1108,7 +1117,11 @@ function App() {
     if (!text) return;
     const atEnd = tour.index >= tour.stops.length - 1;
     const utter = new SpeechSynthesisUtterance(text);
-    utter.rate = 0.98;
+    utter.rate = ttsRate;
+    if (ttsVoice) {
+      const voice = synth.getVoices().find((v) => v.name === ttsVoice);
+      if (voice) utter.voice = voice;
+    }
     utter.onend = () => {
       if (atEnd) return;
       // Small breath between stops, then advance.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -48,7 +48,7 @@ function App() {
   const [showHunkSignificance, setShowHunkSignificance] = useState(true);
   const [showAiNotes, setShowAiNotes] = useState(true);
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
-  const [expandAllHunks, setExpandAllHunks] = useState(false);
+  const [expandAllHunks, setExpandAllHunks] = useState(true);
   // Set when jumping from the triage card / tour so the diff scrolls to a line
   // (and flashes through `endLine` when a range is given).
   const [pendingJump, setPendingJump] = useState<{ path: string; line: number; endLine?: number } | null>(null);
@@ -93,7 +93,7 @@ function App() {
       settingsRef.current = s;
       // Re-apply settings that drive live rendering so changes take effect without
       // a restart (the next file open picks up expand_all_hunks).
-      setExpandAllHunks(s.expand_all_hunks ?? false);
+      setExpandAllHunks(s.expand_all_hunks ?? true);
     }).catch(() => {});
   }, []);
 
@@ -341,7 +341,7 @@ function App() {
         setShowHunkSignificance(settings.show_hunk_significance ?? true);
         setShowAiNotes(settings.show_ai_notes ?? true);
         setHunkFilter(settings.hunk_filter || "all");
-        setExpandAllHunks(settings.expand_all_hunks ?? false);
+        setExpandAllHunks(settings.expand_all_hunks ?? true);
       } catch {
         // Use defaults on failure
       }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -125,6 +125,9 @@ function App() {
   const [pendingJump, setPendingJump] = useState<{ path: string; line: number; endLine?: number } | null>(null);
   // The cinematic guided tour (auto-playing walkthrough of the active PR).
   const [tour, setTour] = useState<TourState>(IDLE_TOUR);
+  // Spoken narration (Web Speech API). On by default; toggled in the player.
+  const [ttsEnabled, setTtsEnabled] = useState(true);
+  const ttsSupported = typeof window !== "undefined" && "speechSynthesis" in window;
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -979,6 +982,15 @@ function App() {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
     const manifest = tab.manifest;
+    // Unlock speech synthesis within this click gesture (WebKit may otherwise
+    // stay silent until a user interaction), since the real speak() fires later.
+    if (ttsSupported && ttsEnabled) {
+      try {
+        const warm = new SpeechSynthesisUtterance(" ");
+        warm.volume = 0;
+        window.speechSynthesis.speak(warm);
+      } catch { /* best-effort */ }
+    }
     const order = manifest.triage?.review_order ?? [];
     const rationale = new Map(order.map((o) => [o.path, o.rationale]));
     const files = tourFilesFor(manifest);
@@ -1031,7 +1043,10 @@ function App() {
     }
   }
 
-  function exitTour() { setTour(IDLE_TOUR); }
+  function exitTour() {
+    if (ttsSupported) window.speechSynthesis.cancel();
+    setTour(IDLE_TOUR);
+  }
   function tourPrev() { setTour((t) => (t.status === "active" ? { ...t, index: Math.max(0, t.index - 1), playing: false } : t)); }
   function tourNext() { setTour((t) => (t.status === "active" ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t)); }
   function tourPlayPause() { setTour((t) => (t.status === "active" ? { ...t, playing: !t.playing } : t)); }
@@ -1070,13 +1085,42 @@ function App() {
     tourStop && tourStop.path && tourStop.line != null
       ? { line: tourStop.line, endLine: tourStop.endLine ?? tourStop.line, durationMs: stopDwell || 6500, seq: tour.index }
       : null;
+  // When narration is spoken, advancement is driven by speech ending (below);
+  // otherwise fall back to the reading-time timer.
+  const ttsActive = ttsEnabled && ttsSupported;
   useEffect(() => {
-    if (tour.status !== "active" || !tour.playing || stopDwell <= 0) return;
+    if (ttsActive || tour.status !== "active" || !tour.playing || stopDwell <= 0) return;
     const timer = setTimeout(() => {
       setTour((t) => (t.status === "active" ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t));
     }, stopDwell);
     return () => clearTimeout(timer);
-  }, [tour.status, tour.playing, tour.index, stopDwell]);
+  }, [ttsActive, tour.status, tour.playing, tour.index, stopDwell]);
+
+  // Speak the current stop; advance when it finishes. Re-runs on stop/play/mute
+  // changes (resuming re-speaks the current line, which is fine — they're short).
+  useEffect(() => {
+    if (!ttsSupported) return;
+    const synth = window.speechSynthesis;
+    synth.cancel();
+    if (!ttsActive || tour.status !== "active" || !tour.playing) return;
+    const stop = tour.stops[tour.index];
+    const text = stop?.narration?.trim();
+    if (!text) return;
+    const atEnd = tour.index >= tour.stops.length - 1;
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.rate = 0.98;
+    utter.onend = () => {
+      if (atEnd) return;
+      // Small breath between stops, then advance.
+      window.setTimeout(() => {
+        setTour((t) => (t.status === "active" && t.playing ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t));
+      }, 550);
+    };
+    // Voices can load late; speak on the next tick so a chosen voice is available.
+    synth.speak(utter);
+    return () => synth.cancel();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ttsActive, tour.status, tour.playing, tour.index]);
 
   // Leave the tour if the user switches tabs (its stops point at the old PR).
   useEffect(() => {
@@ -1950,6 +1994,10 @@ function App() {
             <TourPlayer
               tour={tour}
               dwellMs={stopDwell}
+              ttsDriven={ttsActive}
+              muted={!ttsEnabled}
+              ttsSupported={ttsSupported}
+              onToggleMute={() => setTtsEnabled((v) => !v)}
               onPrev={tourPrev}
               onNext={tourNext}
               onPlayPause={tourPlayPause}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -754,9 +754,12 @@ function App() {
         viewedFiles: preservedViewed,
         staleViewedFiles: newStale,
         selectedFile:
-          tab.selectedFile && newPaths.has(tab.selectedFile.path)
-            ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? newManifest.files[0] ?? null
-            : newManifest.files[0] ?? null,
+          // No file was selected (sitting on the triage/overview card) — stay there.
+          !tab.selectedFile
+            ? null
+            : newPaths.has(tab.selectedFile.path)
+              ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? newManifest.files[0] ?? null
+              : newManifest.files[0] ?? null,
         commentThreads: { status: "idle" },
       };
 
@@ -809,6 +812,11 @@ function App() {
 
   function setSelectedFile(file: FileDiff) {
     updateTab(activeTabId,(t) => ({ ...t, selectedFile: file }));
+  }
+
+  // Deselect the file to return to the triage "what to review first" overview.
+  function handleShowOverview() {
+    updateTab(activeTabId, (t) => ({ ...t, selectedFile: null }));
   }
 
   // Jump from the triage card to a flagged risk: select the file and (when known)
@@ -1600,6 +1608,7 @@ function App() {
             files={activeTab.manifest.files}
             changeGroups={activeTab.manifest.change_groups ?? []}
             triage={activeTab.manifest.triage}
+            onShowOverview={handleShowOverview}
             selectedFile={activeTab.selectedFile}
             onSelectFile={setSelectedFile}
             viewedFiles={activeTab.viewedFiles}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -49,9 +49,12 @@ function App() {
   const searchRef = useRef<SearchBarHandle>(null);
   const diffViewerRef = useRef<DiffViewerHandle>(null);
   // Visible file order from the sidebar, used by the [ / ] navigation shortcuts.
+  // Mirrored into state so the guided nav bar can show "file N of M" reactively.
   const visibleOrderRef = useRef<string[]>([]);
+  const [visibleOrder, setVisibleOrder] = useState<string[]>([]);
   const handleVisibleFilesChange = useCallback((paths: string[]) => {
     visibleOrderRef.current = paths;
+    setVisibleOrder(paths);
   }, []);
   const [searchMatches, setSearchMatches] = useState<SearchMatch[]>([]);
   const [searchCurrentIndex, setSearchCurrentIndex] = useState(0);
@@ -1625,6 +1628,33 @@ function App() {
             onVisibleFilesChange={handleVisibleFilesChange}
           />
           <div className="diff-pane">
+            {activeTab.sidebarView === "guided" && activeTab.selectedFile && (() => {
+              const idx = visibleOrder.indexOf(activeTab.selectedFile.path);
+              const total = visibleOrder.length;
+              return (
+                <div className="guided-nav">
+                  <button
+                    className="guided-nav-btn"
+                    onClick={() => selectAdjacentFile(-1)}
+                    disabled={idx <= 0}
+                    title="Previous file in the guided path ([)"
+                  >
+                    &larr; Prev
+                  </button>
+                  <span className="guided-nav-pos">
+                    {idx >= 0 ? `File ${idx + 1} of ${total}` : `${total} files`}
+                  </span>
+                  <button
+                    className="guided-nav-btn"
+                    onClick={() => selectAdjacentFile(1)}
+                    disabled={idx < 0 || idx >= total - 1}
+                    title="Next file in the guided path (])"
+                  >
+                    Next &rarr;
+                  </button>
+                </div>
+              );
+            })()}
             {activeTab.sidebarView === "comments" ? (
               activeTab.commentThreads.status === "loading" ? (
                 <div className="no-file-selected">Loading review threads...</div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,6 +12,7 @@ import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
+import { TriageCard } from "./components/TriageCard";
 import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ReviewPicker } from "./components/ReviewPicker";
@@ -37,6 +38,9 @@ function App() {
   const [showHunkSignificance, setShowHunkSignificance] = useState(true);
   const [showAiNotes, setShowAiNotes] = useState(true);
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
+  const [expandAllHunks, setExpandAllHunks] = useState(false);
+  // Set when jumping from the triage card so the diff scrolls to the risk's line.
+  const [pendingJump, setPendingJump] = useState<{ path: string; line: number } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -69,7 +73,12 @@ function App() {
 
   const handleSettingsClose = useCallback(() => {
     setSettingsOpen(false);
-    invoke<Settings>("get_settings").then((s) => { settingsRef.current = s; }).catch(() => {});
+    invoke<Settings>("get_settings").then((s) => {
+      settingsRef.current = s;
+      // Re-apply settings that drive live rendering so changes take effect without
+      // a restart (the next file open picks up expand_all_hunks).
+      setExpandAllHunks(s.expand_all_hunks ?? false);
+    }).catch(() => {});
   }, []);
 
   const addToast = useCallback((type: ToastData["type"], message: string) => {
@@ -165,11 +174,18 @@ function App() {
 
   // ── Keyboard shortcuts (ported from the CLI/TUI; see useKeyboardShortcuts) ──
   function selectAdjacentFile(delta: 1 | -1) {
-    if (!activeTab?.manifest || !activeTab.selectedFile) return;
+    if (!activeTab?.manifest) return;
     const order = visibleOrderRef.current.length
       ? visibleOrderRef.current
       : activeTab.manifest.files.map((f) => f.path);
     const byPath = (p: string) => activeTab.manifest!.files.find((f) => f.path === p);
+    // No file selected yet (e.g. sitting on the triage card) — start at the top
+    // of the current order so ] / [ begin the guided walk.
+    if (!activeTab.selectedFile) {
+      const first = byPath(order[0]);
+      if (first) setSelectedFile(first);
+      return;
+    }
     const i = order.indexOf(activeTab.selectedFile.path);
     if (i === -1) {
       // Current file is filtered out of the list — jump to the first visible one.
@@ -244,17 +260,20 @@ function App() {
 
   function buildReviewTab(id: string, manifest: ReviewManifest): Tab {
     const hasGroups = (manifest.change_groups ?? []).length > 0;
+    const hasTriage = (manifest.triage?.review_order ?? []).length > 0;
     return {
       id,
       manifest,
       loading: null,
-      selectedFile: manifest.files.length > 0 ? manifest.files[0] : null,
+      // Large PRs default to the guided fastest-path view; no file pre-selected so
+      // the triage card shows first.
+      selectedFile: hasTriage ? null : manifest.files.length > 0 ? manifest.files[0] : null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
-      sidebarView: hasGroups ? "groups" : "category",
+      sidebarView: hasTriage ? "guided" : hasGroups ? "groups" : "category",
       isRefreshing: false,
       lastCommentCount: 0,
     };
@@ -306,6 +325,7 @@ function App() {
         setShowHunkSignificance(settings.show_hunk_significance ?? true);
         setShowAiNotes(settings.show_ai_notes ?? true);
         setHunkFilter(settings.hunk_filter || "all");
+        setExpandAllHunks(settings.expand_all_hunks ?? false);
       } catch {
         // Use defaults on failure
       }
@@ -789,6 +809,25 @@ function App() {
 
   function setSelectedFile(file: FileDiff) {
     updateTab(activeTabId,(t) => ({ ...t, selectedFile: file }));
+  }
+
+  // Jump from the triage card to a flagged risk: select the file and (when known)
+  // scroll the diff to the risk's line.
+  function handleTriageJump(path: string, startLine?: number | null) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    const file = tab?.manifest?.files.find((f) => f.path === path);
+    if (!file) return;
+    setSelectedFile(file);
+    setPendingJump(startLine ? { path, line: startLine } : null);
+  }
+
+  // Enter the guided path: switch to the Guided view and open its first file.
+  function handleStartGuided() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    const order = tab?.manifest?.triage?.review_order ?? [];
+    const first = order.map((o) => tab!.manifest!.files.find((f) => f.path === o.path)).find(Boolean) ?? null;
+    updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided", selectedFile: first ?? t.selectedFile }));
+    setPendingJump(null);
   }
 
   function toggleViewed(filePath: string) {
@@ -1560,6 +1599,7 @@ function App() {
           <FileSidebar
             files={activeTab.manifest.files}
             changeGroups={activeTab.manifest.change_groups ?? []}
+            triage={activeTab.manifest.triage}
             selectedFile={activeTab.selectedFile}
             onSelectFile={setSelectedFile}
             viewedFiles={activeTab.viewedFiles}
@@ -1597,11 +1637,22 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
-            ) : activeTab.manifest.summary ? (
+              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} initialScrollLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? pendingJump.line : null} onInitialScrollConsumed={() => setPendingJump(null)} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+            ) : (activeTab.manifest.triage || activeTab.manifest.summary) ? (
               <div className="pr-summary">
-                <h3>PR Summary</h3>
-                <SummaryParagraphs text={activeTab.manifest.summary} />
+                {activeTab.manifest.triage && (
+                  <TriageCard
+                    triage={activeTab.manifest.triage}
+                    onJump={handleTriageJump}
+                    onStartGuided={handleStartGuided}
+                  />
+                )}
+                {activeTab.manifest.summary && (
+                  <>
+                    <h3>PR Summary</h3>
+                    <SummaryParagraphs text={activeTab.manifest.summary} />
+                  </>
+                )}
               </div>
             ) : (
               <div className="no-file-selected">Select a file to review</div>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
 import { SummaryParagraphs } from "./components/SummaryParagraphs";
 import { TriageCard } from "./components/TriageCard";
+import { TourPlayer } from "./components/TourPlayer";
 import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ReviewPicker } from "./components/ReviewPicker";
@@ -22,12 +23,21 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, TourState, TourStop } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
 function isOpenerTab(tab: Tab): boolean {
   return !tab.manifest && !tab.loading && !tab.error;
+}
+
+const IDLE_TOUR: TourState = { status: "idle", stops: [], index: 0, playing: false, opening: "" };
+
+/** How long a tour stop lingers before auto-advancing — scaled to reading time
+ * (~200 wpm), clamped so short notes don't flash and long ones don't drag. */
+function tourDwellMs(narration: string): number {
+  const words = narration.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(4500, Math.min(13000, 2800 + words * 320));
 }
 
 function App() {
@@ -41,6 +51,8 @@ function App() {
   const [expandAllHunks, setExpandAllHunks] = useState(false);
   // Set when jumping from the triage card so the diff scrolls to the risk's line.
   const [pendingJump, setPendingJump] = useState<{ path: string; line: number } | null>(null);
+  // The cinematic guided tour (auto-playing walkthrough of the active PR).
+  const [tour, setTour] = useState<TourState>(IDLE_TOUR);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -229,7 +241,7 @@ function App() {
       onRefresh: () => { if (activeTab?.manifest) handleRefreshPr(); },
       onOpenSearch: () => searchRef.current?.open("local"),
       onToggleHelp: () => setHelpOpen((o) => !o),
-      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); },
+      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); exitTour(); },
       onNextTab: () => selectAdjacentTab(1),
       onPrevTab: () => selectAdjacentTab(-1),
       onCloseTab: () => { if (activeTabId) closeTab(activeTabId); },
@@ -845,6 +857,111 @@ function App() {
     updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided", selectedFile: target ?? t.selectedFile }));
     setPendingJump(null);
   }
+
+  // ─── Cinematic guided tour ──────────────────────────────────────────────
+  type TourCandidate = { path: string; line: number | null; kind: "intro" | "note"; severity?: string; seed: string };
+
+  // Build the tour's stops (important parts only): walk the contract-first order;
+  // for each file that carries a critical/warning note or is high-risk, add a
+  // brief intro then a stop at each important highlight.
+  function buildTourCandidates(manifest: ReviewManifest): TourCandidate[] {
+    const order = manifest.triage?.review_order ?? [];
+    const rationale = new Map(order.map((o) => [o.path, o.rationale]));
+    const candidates: TourCandidate[] = [];
+    for (const item of order) {
+      const file = manifest.files.find((f) => f.path === item.path);
+      if (!file) continue;
+      const important = (file.highlights ?? [])
+        .filter((h) => h.severity === "critical" || h.severity === "warning")
+        .sort((a, b) => a.start_line - b.start_line);
+      const highRisk = file.risk_level === "critical" || file.risk_level === "high";
+      if (important.length === 0 && !highRisk) continue;
+      candidates.push({
+        path: file.path,
+        line: important[0]?.start_line ?? file.highlights?.[0]?.start_line ?? null,
+        kind: "intro",
+        seed: rationale.get(file.path) || `${file.category}: ${file.reason}`,
+      });
+      for (const h of important) {
+        candidates.push({ path: file.path, line: h.start_line, kind: "note", severity: h.severity, seed: h.comment });
+      }
+    }
+    return candidates;
+  }
+
+  async function handleStartTour() {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab?.manifest) return;
+    const manifest = tab.manifest;
+    const candidates = buildTourCandidates(manifest);
+    if (candidates.length === 0) {
+      addToast("info", "Nothing stands out to tour — use the guided list to review in order");
+      return;
+    }
+    updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided" }));
+    setTour({ ...IDLE_TOUR, status: "loading" });
+    try {
+      const result = await invoke<{ opening: string; narrations: string[] }>("generate_tour", {
+        prTitle: manifest.pr_title,
+        summary: manifest.summary,
+        seeds: candidates.map((c) => ({ path: c.path, kind: c.kind, seed: c.seed, severity: c.severity ?? null })),
+      });
+      const stops: TourStop[] = candidates.map((c, i) => ({
+        path: c.path,
+        line: c.line,
+        kind: c.kind,
+        severity: c.severity,
+        narration: result.narrations[i] || c.seed,
+      }));
+      // Lead with the opening as its own stop on the first file.
+      if (result.opening.trim()) {
+        stops.unshift({ path: stops[0].path, line: null, kind: "intro", narration: result.opening });
+      }
+      setTour({ status: "active", stops, index: 0, playing: true, opening: result.opening });
+    } catch (err) {
+      setTour(IDLE_TOUR);
+      addToast("error", `Couldn't build the tour: ${String(err)}`);
+    }
+  }
+
+  function exitTour() { setTour(IDLE_TOUR); }
+  function tourPrev() { setTour((t) => (t.status === "active" ? { ...t, index: Math.max(0, t.index - 1), playing: false } : t)); }
+  function tourNext() { setTour((t) => (t.status === "active" ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t)); }
+  function tourPlayPause() { setTour((t) => (t.status === "active" ? { ...t, playing: !t.playing } : t)); }
+
+  // Drive the diff for the current tour stop: select its file and scroll/flash
+  // the line (reusing the triage-jump machinery).
+  useEffect(() => {
+    if (tour.status !== "active") return;
+    const stop = tour.stops[tour.index];
+    if (!stop) return;
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    const file = tab?.manifest?.files.find((f) => f.path === stop.path);
+    if (file) {
+      setSelectedFile(file);
+      if (stop.line != null) setPendingJump({ path: stop.path, line: stop.line });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tour.status, tour.index]);
+
+  // The current stop's dwell (0 on the last stop) — drives both the auto-advance
+  // timer and the progress-bar fill.
+  const stopDwell =
+    tour.status === "active" && tour.index < tour.stops.length - 1
+      ? tourDwellMs(tour.stops[tour.index]?.narration ?? "")
+      : 0;
+  useEffect(() => {
+    if (tour.status !== "active" || !tour.playing || stopDwell <= 0) return;
+    const timer = setTimeout(() => {
+      setTour((t) => (t.status === "active" ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t));
+    }, stopDwell);
+    return () => clearTimeout(timer);
+  }, [tour.status, tour.playing, tour.index, stopDwell]);
+
+  // Leave the tour if the user switches tabs (its stops point at the old PR).
+  useEffect(() => {
+    setTour((t) => (t.status === "idle" ? t : IDLE_TOUR));
+  }, [activeTabId]);
 
   function toggleViewed(filePath: string) {
     const tab = tabs.find((t) => t.id === activeTabId);
@@ -1697,6 +1814,7 @@ function App() {
                     triage={activeTab.manifest.triage}
                     onJump={handleTriageJump}
                     onStartGuided={handleStartGuided}
+                    onStartTour={handleStartTour}
                   />
                 )}
                 {activeTab.manifest.summary && (
@@ -1714,6 +1832,14 @@ function App() {
         </div>
       )}
       {overlays}
+      <TourPlayer
+        tour={tour}
+        dwellMs={stopDwell}
+        onPrev={tourPrev}
+        onNext={tourNext}
+        onPlayPause={tourPlayPause}
+        onExit={exitTour}
+      />
     </div>
   );
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1636,23 +1636,31 @@ function App() {
             {activeTab.sidebarView === "guided" && activeTab.selectedFile && (() => {
               const idx = visibleOrder.indexOf(activeTab.selectedFile.path);
               const total = visibleOrder.length;
+              // idx === -1 means the current file dropped out of the list (e.g. it
+              // was just marked viewed and viewed files are hidden) — Next should
+              // still advance into the remaining files.
+              const inList = idx >= 0;
               return (
                 <div className="guided-nav">
                   <button
                     className="guided-nav-btn"
                     onClick={() => selectAdjacentFile(-1)}
-                    disabled={idx <= 0}
+                    disabled={inList ? idx <= 0 : total === 0}
                     title="Previous file in the guided path ([)"
                   >
                     &larr; Prev
                   </button>
                   <span className="guided-nav-pos">
-                    {idx >= 0 ? `File ${idx + 1} of ${total}` : `${total} files`}
+                    {inList
+                      ? `File ${idx + 1} of ${total}`
+                      : total > 0
+                        ? `${total} file${total === 1 ? "" : "s"} left`
+                        : "All files reviewed"}
                   </span>
                   <button
                     className="guided-nav-btn"
                     onClick={() => selectAdjacentFile(1)}
-                    disabled={idx < 0 || idx >= total - 1}
+                    disabled={total === 0 || (inList && idx >= total - 1)}
                     title="Next file in the guided path (])"
                   >
                     Next &rarr;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -877,9 +877,11 @@ function App() {
         .sort((a, b) => a.start_line - b.start_line);
       const highRisk = file.risk_level === "critical" || file.risk_level === "high";
       if (important.length === 0 && !highRisk) continue;
+      // Intro lands at the top of the file (line: null) — the reviewer gets
+      // oriented before the tour pans down into the specific changes.
       candidates.push({
         path: file.path,
-        line: important[0]?.start_line ?? file.highlights?.[0]?.start_line ?? null,
+        line: null,
         kind: "intro",
         seed: rationale.get(file.path) || `${file.category}: ${file.reason}`,
       });
@@ -915,9 +917,10 @@ function App() {
         severity: c.severity,
         narration: result.narrations[i] || c.seed,
       }));
-      // Lead with the opening as its own stop on the first file.
+      // Lead with the opening rundown as its own stop on the overview card
+      // (empty path = show the triage overview, not a file).
       if (result.opening.trim()) {
-        stops.unshift({ path: stops[0].path, line: null, kind: "intro", narration: result.opening });
+        stops.unshift({ path: "", line: null, kind: "intro", narration: result.opening });
       }
       setTour({ status: "active", stops, index: 0, playing: true, opening: result.opening });
     } catch (err) {
@@ -937,13 +940,17 @@ function App() {
     if (tour.status !== "active") return;
     const stop = tour.stops[tour.index];
     if (!stop) return;
+    // The opening rundown stop has no file — show the triage overview card.
+    if (!stop.path) {
+      updateTab(activeTabId, (t) => ({ ...t, selectedFile: null }));
+      return;
+    }
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     const file = tab?.manifest?.files.find((f) => f.path === stop.path);
     if (file) {
+      // Intro stops land at the file top; note stops are scrolled/flashed/panned
+      // by the DiffViewer via the derived `tourPan` prop below.
       setSelectedFile(file);
-      if (stop.line != null) {
-        setPendingJump({ path: stop.path, line: stop.line, endLine: stop.endLine ?? undefined });
-      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tour.status, tour.index]);
@@ -954,6 +961,13 @@ function App() {
     tour.status === "active" && tour.index < tour.stops.length - 1
       ? tourDwellMs(tour.stops[tour.index]?.narration ?? "")
       : 0;
+
+  // The pan for the current tour stop (note stops only; intro/overview = null).
+  const tourStop = tour.status === "active" ? tour.stops[tour.index] : null;
+  const tourPan =
+    tourStop && tourStop.path && tourStop.line != null
+      ? { line: tourStop.line, endLine: tourStop.endLine ?? tourStop.line, durationMs: stopDwell || 6500, seq: tour.index }
+      : null;
   useEffect(() => {
     if (tour.status !== "active" || !tour.playing || stopDwell <= 0) return;
     const timer = setTimeout(() => {
@@ -1810,7 +1824,7 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} initialScrollLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? pendingJump.line : null} initialScrollEndLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? (pendingJump.endLine ?? null) : null} onInitialScrollConsumed={() => setPendingJump(null)} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} initialScrollLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? pendingJump.line : null} initialScrollEndLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? (pendingJump.endLine ?? null) : null} onInitialScrollConsumed={() => setPendingJump(null)} tourPan={tourStop && tourStop.path === activeTab.selectedFile.path ? tourPan : null} tourPanPlaying={tour.playing} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
             ) : (activeTab.manifest.triage || activeTab.manifest.summary) ? (
               <div className="pr-summary">
                 {activeTab.manifest.triage && (
@@ -1831,19 +1845,19 @@ function App() {
             ) : (
               <div className="no-file-selected">Select a file to review</div>
             )}
+            <TourPlayer
+              tour={tour}
+              dwellMs={stopDwell}
+              onPrev={tourPrev}
+              onNext={tourNext}
+              onPlayPause={tourPlayPause}
+              onExit={exitTour}
+            />
           </div>
         </div>
         </div>
       )}
       {overlays}
-      <TourPlayer
-        tour={tour}
-        dwellMs={stopDwell}
-        onPrev={tourPrev}
-        onNext={tourNext}
-        onPlayPause={tourPlayPause}
-        onExit={exitTour}
-      />
     </div>
   );
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -49,8 +49,9 @@ function App() {
   const [showAiNotes, setShowAiNotes] = useState(true);
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
   const [expandAllHunks, setExpandAllHunks] = useState(false);
-  // Set when jumping from the triage card so the diff scrolls to the risk's line.
-  const [pendingJump, setPendingJump] = useState<{ path: string; line: number } | null>(null);
+  // Set when jumping from the triage card / tour so the diff scrolls to a line
+  // (and flashes through `endLine` when a range is given).
+  const [pendingJump, setPendingJump] = useState<{ path: string; line: number; endLine?: number } | null>(null);
   // The cinematic guided tour (auto-playing walkthrough of the active PR).
   const [tour, setTour] = useState<TourState>(IDLE_TOUR);
   const [error, setError] = useState<string | null>(null);
@@ -859,7 +860,7 @@ function App() {
   }
 
   // ─── Cinematic guided tour ──────────────────────────────────────────────
-  type TourCandidate = { path: string; line: number | null; kind: "intro" | "note"; severity?: string; seed: string };
+  type TourCandidate = { path: string; line: number | null; endLine?: number | null; kind: "intro" | "note"; severity?: string; seed: string };
 
   // Build the tour's stops (important parts only): walk the contract-first order;
   // for each file that carries a critical/warning note or is high-risk, add a
@@ -883,7 +884,7 @@ function App() {
         seed: rationale.get(file.path) || `${file.category}: ${file.reason}`,
       });
       for (const h of important) {
-        candidates.push({ path: file.path, line: h.start_line, kind: "note", severity: h.severity, seed: h.comment });
+        candidates.push({ path: file.path, line: h.start_line, endLine: h.end_line, kind: "note", severity: h.severity, seed: h.comment });
       }
     }
     return candidates;
@@ -909,6 +910,7 @@ function App() {
       const stops: TourStop[] = candidates.map((c, i) => ({
         path: c.path,
         line: c.line,
+        endLine: c.endLine,
         kind: c.kind,
         severity: c.severity,
         narration: result.narrations[i] || c.seed,
@@ -939,7 +941,9 @@ function App() {
     const file = tab?.manifest?.files.find((f) => f.path === stop.path);
     if (file) {
       setSelectedFile(file);
-      if (stop.line != null) setPendingJump({ path: stop.path, line: stop.line });
+      if (stop.line != null) {
+        setPendingJump({ path: stop.path, line: stop.line, endLine: stop.endLine ?? undefined });
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tour.status, tour.index]);
@@ -1806,7 +1810,7 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} initialScrollLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? pendingJump.line : null} onInitialScrollConsumed={() => setPendingJump(null)} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} initialScrollLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? pendingJump.line : null} initialScrollEndLine={pendingJump && pendingJump.path === activeTab.selectedFile.path ? (pendingJump.endLine ?? null) : null} onInitialScrollConsumed={() => setPendingJump(null)} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
             ) : (activeTab.manifest.triage || activeTab.manifest.summary) ? (
               <div className="pr-summary">
                 {activeTab.manifest.triage && (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -832,12 +832,17 @@ function App() {
     setPendingJump(startLine ? { path, line: startLine } : null);
   }
 
-  // Enter the guided path: switch to the Guided view and open its first file.
+  // Enter the guided path: switch to the Guided view and open the first file that
+  // hasn't been reviewed yet (falling back to the first file if all are reviewed).
   function handleStartGuided() {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
-    const order = tab?.manifest?.triage?.review_order ?? [];
-    const first = order.map((o) => tab!.manifest!.files.find((f) => f.path === o.path)).find(Boolean) ?? null;
-    updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided", selectedFile: first ?? t.selectedFile }));
+    if (!tab?.manifest) return;
+    const order = tab.manifest.triage?.review_order ?? [];
+    const files = order
+      .map((o) => tab.manifest!.files.find((f) => f.path === o.path))
+      .filter((f): f is FileDiff => !!f);
+    const target = files.find((f) => !tab.viewedFiles.has(f.path)) ?? files[0] ?? null;
+    updateTab(activeTabId, (t) => ({ ...t, sidebarView: "guided", selectedFile: target ?? t.selectedFile }));
     setPendingJump(null);
   }
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -125,12 +125,17 @@ function App() {
   const [pendingJump, setPendingJump] = useState<{ path: string; line: number; endLine?: number } | null>(null);
   // The cinematic guided tour (auto-playing walkthrough of the active PR).
   const [tour, setTour] = useState<TourState>(IDLE_TOUR);
-  // Spoken narration (Web Speech API). Defaults come from settings; the player
-  // mute toggle overrides for the session.
+  // Spoken narration via the macOS `say` backend (high-quality system voices).
+  // Defaults come from settings; the player mute toggle overrides for the session.
   const [ttsEnabled, setTtsEnabled] = useState(true);
   const [ttsVoice, setTtsVoice] = useState("");
   const [ttsRate, setTtsRate] = useState(1);
-  const ttsSupported = typeof window !== "undefined" && "speechSynthesis" in window;
+  const [ttsAvailable, setTtsAvailable] = useState(false);
+  useEffect(() => {
+    invoke<{ name: string; lang: string }[]>("list_tts_voices")
+      .then((v) => setTtsAvailable(v.length > 0))
+      .catch(() => {});
+  }, []);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -991,15 +996,6 @@ function App() {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
     const manifest = tab.manifest;
-    // Unlock speech synthesis within this click gesture (WebKit may otherwise
-    // stay silent until a user interaction), since the real speak() fires later.
-    if (ttsSupported && ttsEnabled) {
-      try {
-        const warm = new SpeechSynthesisUtterance(" ");
-        warm.volume = 0;
-        window.speechSynthesis.speak(warm);
-      } catch { /* best-effort */ }
-    }
     const order = manifest.triage?.review_order ?? [];
     const rationale = new Map(order.map((o) => [o.path, o.rationale]));
     const files = tourFilesFor(manifest);
@@ -1053,7 +1049,7 @@ function App() {
   }
 
   function exitTour() {
-    if (ttsSupported) window.speechSynthesis.cancel();
+    invoke("stop_tts").catch(() => {});
     setTour(IDLE_TOUR);
   }
   function tourPrev() { setTour((t) => (t.status === "active" ? { ...t, index: Math.max(0, t.index - 1), playing: false } : t)); }
@@ -1096,7 +1092,7 @@ function App() {
       : null;
   // When narration is spoken, advancement is driven by speech ending (below);
   // otherwise fall back to the reading-time timer.
-  const ttsActive = ttsEnabled && ttsSupported;
+  const ttsActive = ttsEnabled && ttsAvailable;
   useEffect(() => {
     if (ttsActive || tour.status !== "active" || !tour.playing || stopDwell <= 0) return;
     const timer = setTimeout(() => {
@@ -1105,35 +1101,33 @@ function App() {
     return () => clearTimeout(timer);
   }, [ttsActive, tour.status, tour.playing, tour.index, stopDwell]);
 
-  // Speak the current stop; advance when it finishes. Re-runs on stop/play/mute
-  // changes (resuming re-speaks the current line, which is fine — they're short).
+  // Speak the current stop via the `say` backend; advance when it finishes. The
+  // cleanup stops the `say` process on pause / skip / mute / exit.
   useEffect(() => {
-    if (!ttsSupported) return;
-    const synth = window.speechSynthesis;
-    synth.cancel();
-    if (!ttsActive || tour.status !== "active" || !tour.playing) return;
+    if (!ttsActive || tour.status !== "active" || !tour.playing) {
+      invoke("stop_tts").catch(() => {});
+      return;
+    }
     const stop = tour.stops[tour.index];
     const text = stop?.narration?.trim();
     if (!text) return;
+    let cancelled = false;
     const atEnd = tour.index >= tour.stops.length - 1;
-    const utter = new SpeechSynthesisUtterance(text);
-    utter.rate = ttsRate;
-    if (ttsVoice) {
-      const voice = synth.getVoices().find((v) => v.name === ttsVoice);
-      if (voice) utter.voice = voice;
-    }
-    utter.onend = () => {
-      if (atEnd) return;
-      // Small breath between stops, then advance.
-      window.setTimeout(() => {
-        setTour((t) => (t.status === "active" && t.playing ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t));
-      }, 550);
+    const rateWpm = Math.round(180 * ttsRate);
+    invoke<boolean>("speak_tts", { text, voice: ttsVoice, rateWpm })
+      .then((finished) => {
+        if (cancelled || !finished || atEnd) return;
+        window.setTimeout(() => {
+          setTour((t) => (t.status === "active" && t.playing ? { ...t, index: Math.min(t.stops.length - 1, t.index + 1) } : t));
+        }, 450);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      invoke("stop_tts").catch(() => {});
     };
-    // Voices can load late; speak on the next tick so a chosen voice is available.
-    synth.speak(utter);
-    return () => synth.cancel();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ttsActive, tour.status, tour.playing, tour.index]);
+  }, [ttsActive, tour.status, tour.playing, tour.index, ttsVoice, ttsRate]);
 
   // Leave the tour if the user switches tabs (its stops point at the old PR).
   useEffect(() => {
@@ -2009,7 +2003,7 @@ function App() {
               dwellMs={stopDwell}
               ttsDriven={ttsActive}
               muted={!ttsEnabled}
-              ttsSupported={ttsSupported}
+              ttsSupported={ttsAvailable}
               onToggleMute={() => setTtsEnabled((v) => !v)}
               onPrev={tourPrev}
               onNext={tourNext}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -112,6 +112,13 @@ interface DiffViewerProps {
   searchMatches?: SearchMatch[];
   currentSearchMatch?: SearchMatch | null;
   searchQuery?: string;
+  /** When true, open with all hunks expanded instead of auto-collapsing
+   * low-significance ones (issue #55 setting). */
+  expandAllHunks?: boolean;
+  /** Line (head side) to scroll to on mount — set when arriving via a triage
+   * jump. Consumed once, then `onInitialScrollConsumed` is called. */
+  initialScrollLine?: number | null;
+  onInitialScrollConsumed?: () => void;
 }
 
 /** Imperative API for keyboard-driven navigation, folding, and the line cursor. */
@@ -1470,7 +1477,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery, expandAllHunks, initialScrollLine, onInitialScrollConsumed }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -1621,7 +1628,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)
   const [collapsedHunks, setCollapsedHunks] = useState<Set<number>>(() => {
-    if (!showHunkSignificance || hunks.length <= 1) return new Set<number>();
+    if (expandAllHunks || !showHunkSignificance || hunks.length <= 1) return new Set<number>();
     return new Set(
       hunks.filter((h) => h.significance === "low").map((h) => h.index)
     );
@@ -2115,6 +2122,26 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     }
     setPendingScroll(null);
   }, [pendingScroll]);
+
+  // Arriving via a triage jump: expand the hunk containing the target line and
+  // scroll to it, once. Keyed by file path upstream, so this runs on a fresh
+  // mount per jumped-to file.
+  useEffect(() => {
+    if (initialScrollLine == null) return;
+    const hunk = hunks.find((h) =>
+      h.lines.some((l) => l.newLineNum === initialScrollLine || l.oldLineNum === initialScrollLine),
+    );
+    if (hunk && collapsedHunks.has(hunk.index)) {
+      setCollapsedHunks((prev) => {
+        const n = new Set(prev);
+        n.delete(hunk.index);
+        return n;
+      });
+    }
+    setPendingScroll(`diff-line-${initialScrollLine}`);
+    onInitialScrollConsumed?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialScrollLine]);
 
   // No dep array: the handle is only ever called imperatively (on a keypress),
   // so rebuilding it each render keeps it always-fresh for free.

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -121,6 +121,11 @@ interface DiffViewerProps {
   /** Head-side end line of the range to flash (defaults to `initialScrollLine`). */
   initialScrollEndLine?: number | null;
   onInitialScrollConsumed?: () => void;
+  /** Cinematic tour pan: gently scroll through [line..endLine] over durationMs.
+   * `seq` changes per stop to (re)trigger it. */
+  tourPan?: { line: number; endLine: number; durationMs: number; seq: number } | null;
+  /** Whether the tour is playing (pauses/resumes the pan). */
+  tourPanPlaying?: boolean;
 }
 
 /** Imperative API for keyboard-driven navigation, folding, and the line cursor. */
@@ -1479,7 +1484,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery, expandAllHunks, initialScrollLine, initialScrollEndLine, onInitialScrollConsumed }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery, expandAllHunks, initialScrollLine, initialScrollEndLine, onInitialScrollConsumed, tourPan, tourPanPlaying }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -2165,6 +2170,95 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     onInitialScrollConsumed?.();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialScrollLine]);
+
+  // ── Cinematic tour pan ────────────────────────────────────────────────────
+  // Gently scroll through a highlighted region over the stop's dwell, with a
+  // soft flash, easing, and pause/resume.
+  const flashRange = (start: number, end: number) => {
+    const c = diffContentRef.current;
+    if (!c) return;
+    const last = Math.min(end, start + 60);
+    for (let n = start; n <= last; n++) {
+      const row = c.querySelector<HTMLElement>(`#diff-line-${n}`);
+      if (row) {
+        row.classList.add("finding-flash");
+        setTimeout(() => row.classList.remove("finding-flash"), 1400);
+      }
+    }
+  };
+
+  const panRef = useRef<{ raf: number | null; from: number; to: number; duration: number; elapsed: number; last: number } | null>(null);
+  const stopPanLoop = () => {
+    const p = panRef.current;
+    if (p?.raf != null) { cancelAnimationFrame(p.raf); p.raf = null; }
+  };
+  const panTick = (now: number) => {
+    const p = panRef.current;
+    const c = diffContentRef.current;
+    if (!p || !c) return;
+    p.elapsed += now - p.last;
+    p.last = now;
+    const t = Math.min(1, p.duration > 0 ? p.elapsed / p.duration : 1);
+    // easeInOutSine — slow start and finish, no jerk.
+    const eased = -(Math.cos(Math.PI * t) - 1) / 2;
+    c.scrollTop = p.from + (p.to - p.from) * eased;
+    p.raf = t < 1 ? requestAnimationFrame(panTick) : null;
+  };
+  const resumePan = () => {
+    const p = panRef.current;
+    if (!p || p.raf != null) return;
+    p.last = performance.now();
+    p.raf = requestAnimationFrame(panTick);
+  };
+
+  // Set up a pan for the current tour stop (keyed on seq).
+  useEffect(() => {
+    if (!tourPan) return;
+    const c = diffContentRef.current;
+    if (!c) return;
+    // Expand the hunk holding the line, then (after it renders) line up the pan.
+    const hunk = hunks.find((h) =>
+      h.lines.some((l) => l.newLineNum === tourPan.line || l.oldLineNum === tourPan.line),
+    );
+    if (hunk && collapsedHunks.has(hunk.index)) {
+      setCollapsedHunks((prev) => {
+        const n = new Set(prev);
+        n.delete(hunk.index);
+        return n;
+      });
+    }
+    const frame = requestAnimationFrame(() => {
+      const startEl = c.querySelector<HTMLElement>(`#diff-line-${tourPan.line}`);
+      if (!startEl) return;
+      const startOffset = offsetWithin(startEl, c);
+      const endEl = c.querySelector<HTMLElement>(`#diff-line-${tourPan.endLine}`) ?? startEl;
+      const endOffset = offsetWithin(endEl, c);
+      const maxScroll = Math.max(0, c.scrollHeight - c.clientHeight);
+      // Land the start line ~100px below the top, then drift down just enough to
+      // reveal the region + a little context — bounded so it stays gentle.
+      const from = Math.min(maxScroll, Math.max(0, startOffset - 100));
+      const reveal = Math.max(endOffset - startOffset + 160, c.clientHeight * 0.3);
+      const to = Math.min(maxScroll, from + Math.min(reveal, c.clientHeight * 0.7));
+      c.scrollTop = from;
+      flashRange(tourPan.line, tourPan.endLine);
+      panRef.current = { raf: null, from, to, duration: Math.max(2200, tourPan.durationMs - 800), elapsed: 0, last: 0 };
+      if (tourPanPlaying) resumePan();
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+      stopPanLoop();
+      panRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tourPan?.seq]);
+
+  // Pause/resume the pan with the tour.
+  useEffect(() => {
+    if (!panRef.current) return;
+    if (tourPanPlaying) resumePan();
+    else stopPanLoop();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tourPanPlaying]);
 
   // No dep array: the handle is only ever called imperatively (on a keypress),
   // so rebuilding it each render keeps it always-fresh for free.

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -118,6 +118,8 @@ interface DiffViewerProps {
   /** Line (head side) to scroll to on mount — set when arriving via a triage
    * jump. Consumed once, then `onInitialScrollConsumed` is called. */
   initialScrollLine?: number | null;
+  /** Head-side end line of the range to flash (defaults to `initialScrollLine`). */
+  initialScrollEndLine?: number | null;
   onInitialScrollConsumed?: () => void;
 }
 
@@ -1477,7 +1479,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery, expandAllHunks, initialScrollLine, onInitialScrollConsumed }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery, expandAllHunks, initialScrollLine, initialScrollEndLine, onInitialScrollConsumed }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -2105,6 +2107,10 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   const nextFinding = () => stepFinding(1);
   const prevFinding = () => stepFinding(-1);
 
+  // A line range to flash (in addition to the single pending-scroll row), set
+  // when arriving at a tour stop with a multi-line highlight.
+  const flashRangeRef = useRef<{ start: number; end: number } | null>(null);
+
   // Scroll to + paint the cursor on the pending row once it has (re-)rendered.
   useEffect(() => {
     if (pendingScroll == null) return;
@@ -2117,6 +2123,20 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
         setTimeout(() => el.classList.remove("finding-flash"), 1200);
         // Home the cursor exactly onto the landed row (carries data-cl/data-cs).
         if (el.dataset.cl != null) cursorRef.current = { cl: Number(el.dataset.cl), cs: el.dataset.cs as CursorPos["cs"] };
+      }
+      // Flash the whole highlighted range, not just the first row (capped so a
+      // pathological range can't flash hundreds of rows).
+      const range = flashRangeRef.current;
+      flashRangeRef.current = null;
+      if (range) {
+        const end = Math.min(range.end, range.start + 60);
+        for (let n = range.start; n <= end; n++) {
+          const row = c.querySelector<HTMLElement>(`#diff-line-${n}`);
+          if (row) {
+            row.classList.add("finding-flash");
+            setTimeout(() => row.classList.remove("finding-flash"), 1200);
+          }
+        }
       }
       paintCursor();
     }
@@ -2137,6 +2157,9 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
         n.delete(hunk.index);
         return n;
       });
+    }
+    if (initialScrollEndLine != null && initialScrollEndLine > initialScrollLine) {
+      flashRangeRef.current = { start: initialScrollLine, end: initialScrollEndLine };
     }
     setPendingScroll(`diff-line-${initialScrollLine}`);
     onInitialScrollConsumed?.();

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1136,10 +1136,11 @@ function UnifiedView({
       </colgroup>
       <tbody>
         {hunks.map((hunk) => {
-          const isLow = showSignificance && hunk.significance === "low";
           const isHigh = showSignificance && hunk.significance === "high";
           const isCollapsed = collapsedHunks.has(hunk.index);
-          const isDimmed = isLow && !isCollapsed;
+          // Low-significance hunks are no longer dimmed — expanded hunks all read
+          // at full strength.
+          const isDimmed = false;
 
           return (
             <Fragment key={hunk.index}>
@@ -1412,10 +1413,11 @@ function SplitView({
       </colgroup>
       <tbody>
         {hunks.map((hunk) => {
-          const isLow = showSignificance && hunk.significance === "low";
           const isHigh = showSignificance && hunk.significance === "high";
           const isCollapsed = collapsedHunks.has(hunk.index);
-          const isDimmed = isLow && !isCollapsed;
+          // Low-significance hunks are no longer dimmed — expanded hunks all read
+          // at full strength.
+          const isDimmed = false;
           const splitLines = isCollapsed ? [] : buildSplitLines(hunk.lines);
 
           return (

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { FileDiff, RiskLevel, ChangeGroup, HunkSignificanceFilter, SidebarView, ReviewThread } from "../types";
+import type { FileDiff, RiskLevel, ChangeGroup, HunkSignificanceFilter, SidebarView, ReviewThread, TriageReport } from "../types";
 import { getFileName } from "../utils";
 
 interface FileSidebarProps {
   files: FileDiff[];
   changeGroups: ChangeGroup[];
+  /** Triage guidance (top risks + contract-first order); enables the Guided view. */
+  triage?: TriageReport | null;
   selectedFile: FileDiff | null;
   onSelectFile: (file: FileDiff) => void;
   viewedFiles: Set<string>;
@@ -392,6 +394,7 @@ function CommentFileList({
 export function FileSidebar({
   files,
   changeGroups,
+  triage,
   selectedFile,
   onSelectFile,
   viewedFiles,
@@ -527,6 +530,30 @@ export function FileSidebar({
     });
   }, [visibleGrouped]);
 
+  const hasTriage = !!triage && triage.review_order.length > 0;
+
+  // Files referenced by a top risk — marked with a ⚠ in the guided path.
+  const topRiskPaths = useMemo(
+    () => new Set((triage?.top_risks ?? []).map((r) => r.path)),
+    [triage],
+  );
+
+  // The contract-first guided path: review_order mapped to visible files, with
+  // each file's rationale and whether it carries a top risk.
+  const guidedFiles = useMemo(() => {
+    if (!triage) return [];
+    return triage.review_order
+      .map((item) => {
+        const file = filesByPath.get(item.path);
+        if (!file) return null;
+        return { file, rationale: item.rationale, watch: topRiskPaths.has(item.path) };
+      })
+      .filter(
+        (x): x is { file: FileDiff; rationale: string; watch: boolean } =>
+          x !== null && isVisible(x.file),
+      );
+  }, [triage, filesByPath, visiblePaths, topRiskPaths]);
+
   // The flat top-to-bottom order of file rows as actually displayed for the
   // current view — respecting filters and collapsed sections, deduped to first
   // occurrence (critical files also appear under their category). Drives the
@@ -537,7 +564,9 @@ export function FileSidebar({
     const push = (path: string) => {
       if (!seen.has(path)) { seen.add(path); out.push(path); }
     };
-    if (view === "groups") {
+    if (view === "guided") {
+      guidedFiles.forEach((g) => push(g.file.path));
+    } else if (view === "groups") {
       changeGroups.forEach((group, idx) => {
         if (collapsed.has(`group:${idx}`)) return;
         for (const p of group.file_paths) {
@@ -557,7 +586,7 @@ export function FileSidebar({
     }
     // "comments" view drives a separate selection model — emit nothing.
     return out;
-  }, [view, changeGroups, collapsed, filesByPath, visiblePaths, ungroupedFiles, visibleCriticalFiles, visibleCategories, visibleGrouped, visibleFileTree]);
+  }, [view, guidedFiles, changeGroups, collapsed, filesByPath, visiblePaths, ungroupedFiles, visibleCriticalFiles, visibleCategories, visibleGrouped, visibleFileTree]);
 
   useEffect(() => {
     onVisibleFilesChange?.(navigableOrder);
@@ -573,6 +602,15 @@ export function FileSidebar({
         <div className="sidebar-header-top">
           <span className="sidebar-title">Files</span>
           <div className="sidebar-view-toggle">
+            {hasTriage && (
+              <button
+                className={view === "guided" ? "active" : ""}
+                onClick={() => setView("guided")}
+                title="Guided fastest path — contract-first order, risks called out"
+              >
+                Guided
+              </button>
+            )}
             {hasGroups && (
               <button
                 className={view === "groups" ? "active" : ""}
@@ -650,7 +688,38 @@ export function FileSidebar({
         </div>
       )}
       <nav className="file-list">
-        {view === "comments" ? (
+        {view === "guided" ? (
+          <div className="file-group guided-list">
+            {guidedFiles.length === 0 ? (
+              <div className="guided-empty">No files match the current filters.</div>
+            ) : (
+              guidedFiles.map(({ file, rationale, watch }, i) => (
+                <div key={file.path} className="guided-row">
+                  <span className="guided-num">{i + 1}</span>
+                  <div className="guided-row-main">
+                    <FileItem
+                      file={file}
+                      selectedFile={selectedFile}
+                      isViewed={viewedFiles.has(file.path)}
+                      isStale={staleViewedFiles.has(file.path)}
+                      onSelectFile={onSelectFile}
+                      onToggleViewed={onToggleViewed}
+                      showPathHint
+                    />
+                    {(rationale || watch) && (
+                      <div className="guided-rationale">
+                        {watch && (
+                          <span className="guided-watch" title="Flagged as a top risk to review">&#9888;</span>
+                        )}
+                        {rationale}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        ) : view === "comments" ? (
           <CommentFileList
             threads={commentThreads}
             selectedFile={selectedCommentFile}

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -7,6 +7,8 @@ interface FileSidebarProps {
   changeGroups: ChangeGroup[];
   /** Triage guidance (top risks + contract-first order); enables the Guided view. */
   triage?: TriageReport | null;
+  /** Return to the triage "what to review first" overview (deselects the file). */
+  onShowOverview?: () => void;
   selectedFile: FileDiff | null;
   onSelectFile: (file: FileDiff) => void;
   viewedFiles: Set<string>;
@@ -395,6 +397,7 @@ export function FileSidebar({
   files,
   changeGroups,
   triage,
+  onShowOverview,
   selectedFile,
   onSelectFile,
   viewedFiles,
@@ -690,6 +693,14 @@ export function FileSidebar({
       <nav className="file-list">
         {view === "guided" ? (
           <div className="file-group guided-list">
+            <button
+              className={`guided-overview ${selectedFile === null ? "active" : ""}`}
+              onClick={() => onShowOverview?.()}
+              title="What to review first — top risks and overview"
+            >
+              <span className="guided-overview-star">&#9733;</span>
+              What to review first
+            </button>
             {guidedFiles.length === 0 ? (
               <div className="guided-empty">No files match the current filters.</div>
             ) : (

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -30,6 +30,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [perWatchCap, setPerWatchCap] = useState(50);
   const [showApprovedPrs, setShowApprovedPrs] = useState(false);
   const [expandAllHunks, setExpandAllHunks] = useState(true);
+  const [ttsMuted, setTtsMuted] = useState(false);
+  const [ttsVoice, setTtsVoice] = useState("");
+  const [ttsRate, setTtsRate] = useState(1);
+  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -52,6 +56,9 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setPerWatchCap(s.activity_per_watch_cap || 50);
         setShowApprovedPrs(s.show_approved_prs ?? false);
         setExpandAllHunks(s.expand_all_hunks ?? true);
+        setTtsMuted(s.tts_muted ?? false);
+        setTtsVoice(s.tts_voice ?? "");
+        setTtsRate(s.tts_rate ?? 1);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -69,6 +76,24 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   function removeWatch(id: string) {
     setWatches((ws) => ws.filter((w) => w.id !== id));
     setSaved(false);
+  }
+  // Load available speech-synthesis voices (they can populate asynchronously).
+  useEffect(() => {
+    if (!("speechSynthesis" in window)) return;
+    const load = () => setVoices(window.speechSynthesis.getVoices());
+    load();
+    window.speechSynthesis.addEventListener("voiceschanged", load);
+    return () => window.speechSynthesis.removeEventListener("voiceschanged", load);
+  }, []);
+
+  function testVoice() {
+    if (!("speechSynthesis" in window)) return;
+    window.speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance("This is how the guided tour will sound.");
+    u.rate = ttsRate;
+    const v = voices.find((x) => x.name === ttsVoice);
+    if (v) u.voice = v;
+    window.speechSynthesis.speak(u);
   }
 
   async function handleSave(e: React.FormEvent) {
@@ -93,6 +118,9 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           activity_per_watch_cap: perWatchCap,
           show_approved_prs: showApprovedPrs,
           expand_all_hunks: expandAllHunks,
+          tts_muted: ttsMuted,
+          tts_voice: ttsVoice,
+          tts_rate: ttsRate,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -393,6 +421,69 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             When off, low-significance hunks start collapsed so you can focus on the
             changes that matter (takes effect the next time you open a file).
           </p>
+
+          {"speechSynthesis" in window && (
+            <>
+              <div className="settings-divider" />
+              <h3 className="settings-section-title">Tour narration</h3>
+              <label className="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={!ttsMuted}
+                  onChange={(e) => {
+                    setTtsMuted(!e.target.checked);
+                    setSaved(false);
+                  }}
+                />
+                Narrate guided tours out loud by default
+              </label>
+
+              <label className="settings-label" htmlFor="tts-voice">
+                Voice
+              </label>
+              <p className="settings-hint">
+                System voices. The enhanced/premium voices (download in macOS System
+                Settings &rarr; Accessibility &rarr; Spoken Content) sound far better.
+              </p>
+              <select
+                id="tts-voice"
+                className="settings-input"
+                value={ttsVoice}
+                onChange={(e) => {
+                  setTtsVoice(e.target.value);
+                  setSaved(false);
+                }}
+              >
+                <option value="">System default</option>
+                {voices.map((v) => (
+                  <option key={v.name} value={v.name}>
+                    {v.name} ({v.lang}){v.localService ? "" : " — online"}
+                  </option>
+                ))}
+              </select>
+
+              <label className="settings-label" htmlFor="tts-rate">
+                Speed — {ttsRate.toFixed(2)}×
+              </label>
+              <div className="settings-rate-row">
+                <input
+                  id="tts-rate"
+                  type="range"
+                  min={0.6}
+                  max={1.6}
+                  step={0.05}
+                  value={ttsRate}
+                  onChange={(e) => {
+                    setTtsRate(parseFloat(e.target.value));
+                    setSaved(false);
+                  }}
+                />
+                <button type="button" className="settings-test-voice" onClick={testVoice}>
+                  ▶ Test
+                </button>
+              </div>
+            </>
+          )}
 
           <div className="settings-divider" />
           <h3 className="settings-section-title">Browser Integration</h3>

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -93,6 +93,10 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     }).catch(() => {});
   }
 
+  // Enhanced/Premium voices sound far better than the defaults; nudge the user to
+  // download one if none are installed.
+  const hasEnhancedVoice = voices.some((v) => /\((enhanced|premium)\)/i.test(v.name));
+
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
@@ -438,9 +442,20 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
               <label className="settings-label" htmlFor="tts-voice">
                 Voice
               </label>
+              {!hasEnhancedVoice && (
+                <div className="settings-callout">
+                  <strong>For much better narration, install an Enhanced voice.</strong>
+                  <span>
+                    System Settings &rarr; Accessibility &rarr; Spoken Content &rarr;
+                    System Voice &rarr; Manage Voices… &rarr; English &rarr; download an
+                    <em> (Enhanced)</em> or <em>(Premium)</em> voice (e.g. Ava, Zoe, Evan).
+                    It'll appear here automatically.
+                  </span>
+                </div>
+              )}
               <p className="settings-hint">
-                System voices. The enhanced/premium voices (download in macOS System
-                Settings &rarr; Accessibility &rarr; Spoken Content) sound far better.
+                Voices from the macOS speech system. Enhanced/Premium voices sound far
+                better than the built-in defaults.
               </p>
               <select
                 id="tts-voice"

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -29,6 +29,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
   const [showApprovedPrs, setShowApprovedPrs] = useState(false);
+  const [expandAllHunks, setExpandAllHunks] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -50,6 +51,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setPerWatchCap(s.activity_per_watch_cap || 50);
         setShowApprovedPrs(s.show_approved_prs ?? false);
+        setExpandAllHunks(s.expand_all_hunks ?? false);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -90,6 +92,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           openai_base_url: openaiBaseUrl.trim(),
           activity_per_watch_cap: perWatchCap,
           show_approved_prs: showApprovedPrs,
+          expand_all_hunks: expandAllHunks,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -373,6 +376,22 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           <p className="settings-hint">
             By default, approving a PR removes it from the mini-player feed.
             Enable this to keep approved PRs in the list.
+          </p>
+          <h3 className="settings-section-title">Review display</h3>
+          <label className="settings-checkbox">
+            <input
+              type="checkbox"
+              checked={expandAllHunks}
+              onChange={(e) => {
+                setExpandAllHunks(e.target.checked);
+                setSaved(false);
+              }}
+            />
+            Expand all hunks by default
+          </label>
+          <p className="settings-hint">
+            When off, low-significance hunks start collapsed so you can focus on the
+            changes that matter (takes effect the next time you open a file).
           </p>
 
           <div className="settings-divider" />

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -33,7 +33,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [ttsMuted, setTtsMuted] = useState(false);
   const [ttsVoice, setTtsVoice] = useState("");
   const [ttsRate, setTtsRate] = useState(1);
-  const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [voices, setVoices] = useState<{ name: string; lang: string }[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -77,23 +77,20 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     setWatches((ws) => ws.filter((w) => w.id !== id));
     setSaved(false);
   }
-  // Load available speech-synthesis voices (they can populate asynchronously).
+  // Load the macOS system voices via the `say` backend.
   useEffect(() => {
-    if (!("speechSynthesis" in window)) return;
-    const load = () => setVoices(window.speechSynthesis.getVoices());
-    load();
-    window.speechSynthesis.addEventListener("voiceschanged", load);
-    return () => window.speechSynthesis.removeEventListener("voiceschanged", load);
+    invoke<{ name: string; lang: string }[]>("list_tts_voices")
+      .then(setVoices)
+      .catch(() => {});
   }, []);
 
   function testVoice() {
-    if (!("speechSynthesis" in window)) return;
-    window.speechSynthesis.cancel();
-    const u = new SpeechSynthesisUtterance("This is how the guided tour will sound.");
-    u.rate = ttsRate;
-    const v = voices.find((x) => x.name === ttsVoice);
-    if (v) u.voice = v;
-    window.speechSynthesis.speak(u);
+    invoke("stop_tts").catch(() => {});
+    invoke("speak_tts", {
+      text: "This is how the guided tour will sound.",
+      voice: ttsVoice,
+      rateWpm: Math.round(180 * ttsRate),
+    }).catch(() => {});
   }
 
   async function handleSave(e: React.FormEvent) {
@@ -422,7 +419,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             changes that matter (takes effect the next time you open a file).
           </p>
 
-          {"speechSynthesis" in window && (
+          {voices.length > 0 && (
             <>
               <div className="settings-divider" />
               <h3 className="settings-section-title">Tour narration</h3>
@@ -457,7 +454,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
                 <option value="">System default</option>
                 {voices.map((v) => (
                   <option key={v.name} value={v.name}>
-                    {v.name} ({v.lang}){v.localService ? "" : " — online"}
+                    {v.name} ({v.lang})
                   </option>
                 ))}
               </select>

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -29,7 +29,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
   const [showApprovedPrs, setShowApprovedPrs] = useState(false);
-  const [expandAllHunks, setExpandAllHunks] = useState(false);
+  const [expandAllHunks, setExpandAllHunks] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -51,7 +51,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setPerWatchCap(s.activity_per_watch_cap || 50);
         setShowApprovedPrs(s.show_approved_prs ?? false);
-        setExpandAllHunks(s.expand_all_hunks ?? false);
+        setExpandAllHunks(s.expand_all_hunks ?? true);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);

--- a/app/src/components/TourPlayer.tsx
+++ b/app/src/components/TourPlayer.tsx
@@ -47,6 +47,11 @@ export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit 
         />
       </div>
       <div className="tour-body">
+        {stop.kind === "note" ? (
+          <span className={`tour-tag tour-tag-${stop.severity ?? "warning"}`} key={`tag-${tour.index}`}>⚠ Concern</span>
+        ) : stop.kind === "walk" ? (
+          <span className="tour-tag tour-tag-walk" key={`tag-${tour.index}`}>Walkthrough</span>
+        ) : null}
         <p className="tour-caption" key={tour.index}>{stop.narration}</p>
         <div className="tour-controls">
           <span className="tour-progress">{tour.index + 1} / {total}</span>

--- a/app/src/components/TourPlayer.tsx
+++ b/app/src/components/TourPlayer.tsx
@@ -1,0 +1,69 @@
+import type { TourState } from "../types";
+
+interface TourPlayerProps {
+  tour: TourState;
+  /** Milliseconds the current stop will dwell before auto-advancing (drives the
+   * progress bar animation); 0 when paused or on the last stop. */
+  dwellMs: number;
+  onPrev: () => void;
+  onNext: () => void;
+  onPlayPause: () => void;
+  onExit: () => void;
+}
+
+/**
+ * The cinematic guided-tour caption bar: a calm, fixed overlay at the bottom of
+ * the window showing the current narration, a dwell progress bar, and minimal
+ * transport controls. The scrolling/flashing of the diff is driven by App.
+ */
+export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit }: TourPlayerProps) {
+  if (tour.status === "loading") {
+    return (
+      <div className="tour-player tour-loading">
+        <span className="tour-spinner" aria-hidden="true">↻</span>
+        Preparing your guided tour…
+      </div>
+    );
+  }
+  if (tour.status !== "active") return null;
+  const stop = tour.stops[tour.index];
+  if (!stop) return null;
+
+  const total = tour.stops.length;
+  const atStart = tour.index === 0;
+  const atEnd = tour.index >= total - 1;
+
+  return (
+    <div className="tour-player">
+      {/* Dwell progress: re-keyed per stop so the fill animation restarts. */}
+      <div className="tour-dwell-track">
+        <div
+          key={tour.index}
+          className="tour-dwell-fill"
+          style={{
+            animationDuration: dwellMs > 0 ? `${dwellMs}ms` : "0ms",
+            animationPlayState: tour.playing && !atEnd ? "running" : "paused",
+          }}
+        />
+      </div>
+      <div className="tour-body">
+        <p className="tour-caption">{stop.narration}</p>
+        <div className="tour-controls">
+          <span className="tour-progress">{tour.index + 1} / {total}</span>
+          <button className="tour-btn" onClick={onPrev} disabled={atStart} title="Previous stop">
+            &lsaquo;
+          </button>
+          <button className="tour-btn tour-playpause" onClick={onPlayPause} title={tour.playing ? "Pause" : "Play"}>
+            {tour.playing ? "❚❚" : "▶"}
+          </button>
+          <button className="tour-btn" onClick={onNext} disabled={atEnd} title="Next stop">
+            &rsaquo;
+          </button>
+          <button className="tour-btn tour-exit" onClick={onExit} title="Exit tour (Esc)">
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/TourPlayer.tsx
+++ b/app/src/components/TourPlayer.tsx
@@ -47,7 +47,7 @@ export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit 
         />
       </div>
       <div className="tour-body">
-        <p className="tour-caption">{stop.narration}</p>
+        <p className="tour-caption" key={tour.index}>{stop.narration}</p>
         <div className="tour-controls">
           <span className="tour-progress">{tour.index + 1} / {total}</span>
           <button className="tour-btn" onClick={onPrev} disabled={atStart} title="Previous stop">

--- a/app/src/components/TourPlayer.tsx
+++ b/app/src/components/TourPlayer.tsx
@@ -5,6 +5,13 @@ interface TourPlayerProps {
   /** Milliseconds the current stop will dwell before auto-advancing (drives the
    * progress bar animation); 0 when paused or on the last stop. */
   dwellMs: number;
+  /** True when advancement is driven by spoken narration (not the timer). */
+  ttsDriven: boolean;
+  /** Narration is muted. */
+  muted: boolean;
+  /** The platform supports speech synthesis. */
+  ttsSupported: boolean;
+  onToggleMute: () => void;
   onPrev: () => void;
   onNext: () => void;
   onPlayPause: () => void;
@@ -16,7 +23,7 @@ interface TourPlayerProps {
  * the window showing the current narration, a dwell progress bar, and minimal
  * transport controls. The scrolling/flashing of the diff is driven by App.
  */
-export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit }: TourPlayerProps) {
+export function TourPlayer({ tour, dwellMs, ttsDriven, muted, ttsSupported, onToggleMute, onPrev, onNext, onPlayPause, onExit }: TourPlayerProps) {
   if (tour.status === "loading") {
     return (
       <div className="tour-player tour-loading">
@@ -35,16 +42,21 @@ export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit 
 
   return (
     <div className="tour-player">
-      {/* Dwell progress: re-keyed per stop so the fill animation restarts. */}
+      {/* Progress: a timed fill when paced by the reader, or an indeterminate
+          shimmer while narration is being spoken. */}
       <div className="tour-dwell-track">
-        <div
-          key={tour.index}
-          className="tour-dwell-fill"
-          style={{
-            animationDuration: dwellMs > 0 ? `${dwellMs}ms` : "0ms",
-            animationPlayState: tour.playing && !atEnd ? "running" : "paused",
-          }}
-        />
+        {ttsDriven && tour.playing && !atEnd ? (
+          <div className="tour-dwell-speaking" key={`spk-${tour.index}`} />
+        ) : (
+          <div
+            key={tour.index}
+            className="tour-dwell-fill"
+            style={{
+              animationDuration: dwellMs > 0 ? `${dwellMs}ms` : "0ms",
+              animationPlayState: tour.playing && !atEnd ? "running" : "paused",
+            }}
+          />
+        )}
       </div>
       <div className="tour-body">
         {stop.kind === "note" ? (
@@ -64,6 +76,15 @@ export function TourPlayer({ tour, dwellMs, onPrev, onNext, onPlayPause, onExit 
           <button className="tour-btn" onClick={onNext} disabled={atEnd} title="Next stop">
             &rsaquo;
           </button>
+          {ttsSupported && (
+            <button
+              className={`tour-btn tour-mute${muted ? " muted" : ""}`}
+              onClick={onToggleMute}
+              title={muted ? "Turn on narration" : "Mute narration"}
+            >
+              {muted ? "🔇" : "🔊"}
+            </button>
+          )}
           <button className="tour-btn tour-exit" onClick={onExit} title="Exit tour (Esc)">
             ✕
           </button>

--- a/app/src/components/TriageCard.tsx
+++ b/app/src/components/TriageCard.tsx
@@ -6,6 +6,8 @@ interface TriageCardProps {
   onJump: (path: string, startLine?: number | null) => void;
   /** Begin the guided fastest-path review from the first ordered file. */
   onStartGuided: () => void;
+  /** Begin the auto-playing cinematic tour. */
+  onStartTour: () => void;
 }
 
 /**
@@ -13,16 +15,21 @@ interface TriageCardProps {
  * with jump links, plus an entry point into the guided path. Shown when no file
  * is selected. Primes the reviewer on risk before they start reading in order.
  */
-export function TriageCard({ triage, onJump, onStartGuided }: TriageCardProps) {
+export function TriageCard({ triage, onJump, onStartGuided, onStartTour }: TriageCardProps) {
   const risks = triage.top_risks;
   return (
     <div className="triage-card">
       <div className="triage-header">
         <h3>What to review first</h3>
         {triage.review_order.length > 0 && (
-          <button className="triage-start" onClick={onStartGuided}>
-            Start guided review &rarr;
-          </button>
+          <div className="triage-actions">
+            <button className="triage-tour" onClick={onStartTour} title="Sit back — an auto-playing, narrated walkthrough">
+              ▶ Take the tour
+            </button>
+            <button className="triage-start" onClick={onStartGuided}>
+              Start guided review &rarr;
+            </button>
+          </div>
         )}
       </div>
       {risks.length === 0 ? (

--- a/app/src/components/TriageCard.tsx
+++ b/app/src/components/TriageCard.tsx
@@ -1,0 +1,55 @@
+import type { TriageReport } from "../types";
+
+interface TriageCardProps {
+  triage: TriageReport;
+  /** Jump to a file (and line, when known) flagged as a top risk. */
+  onJump: (path: string, startLine?: number | null) => void;
+  /** Begin the guided fastest-path review from the first ordered file. */
+  onStartGuided: () => void;
+}
+
+/**
+ * Top-of-review "what changed that matters" card: the 2-3 highest-risk changes
+ * with jump links, plus an entry point into the guided path. Shown when no file
+ * is selected. Primes the reviewer on risk before they start reading in order.
+ */
+export function TriageCard({ triage, onJump, onStartGuided }: TriageCardProps) {
+  const risks = triage.top_risks;
+  return (
+    <div className="triage-card">
+      <div className="triage-header">
+        <h3>What to review first</h3>
+        {triage.review_order.length > 0 && (
+          <button className="triage-start" onClick={onStartGuided}>
+            Start guided review &rarr;
+          </button>
+        )}
+      </div>
+      {risks.length === 0 ? (
+        <p className="triage-empty">
+          No standout high-risk changes — use the guided path to review the files in
+          the order that's easiest to follow.
+        </p>
+      ) : (
+        <ol className="triage-risks">
+          {risks.map((r, i) => (
+            <li key={i} className="triage-risk">
+              <button
+                className="triage-risk-jump"
+                onClick={() => onJump(r.path, r.start_line)}
+                title={`Jump to ${r.path}${r.start_line ? `:${r.start_line}` : ""}`}
+              >
+                <span className="triage-risk-title">{r.title}</span>
+                <span className="triage-risk-detail">{r.detail}</span>
+                <span className="triage-risk-path">
+                  {r.path}
+                  {r.start_line ? `:${r.start_line}` : ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -876,7 +876,11 @@ body {
 .diff-viewer {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  /* Fill the diff pane's remaining height (so a guided nav bar above it doesn't
+     push the bottom out of an overflow:hidden pane). Equivalent to height:100%
+     when it's the only child. */
+  flex: 1;
+  min-height: 0;
 }
 
 .diff-viewer-critical .diff-header {
@@ -4372,6 +4376,30 @@ mark.search-highlight-current {
 .triage-risk-title { display: block; font-size: 13px; font-weight: 600; color: var(--text-primary); }
 .triage-risk-detail { display: block; font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
 .triage-risk-path { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--text-muted); margin-top: 3px; }
+
+.guided-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+.guided-nav-btn {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.guided-nav-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.guided-nav-btn:disabled { opacity: 0.4; cursor: default; }
+.guided-nav-pos { font-size: 12px; color: var(--text-secondary); }
 
 .guided-list { padding: 4px 0; }
 .guided-overview {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4570,3 +4570,17 @@ mark.search-highlight-current {
   100% { margin-left: 100%; opacity: 0.4; }
 }
 .tour-mute.muted { opacity: 0.7; }
+
+.settings-rate-row { display: flex; align-items: center; gap: 12px; }
+.settings-rate-row input[type="range"] { flex: 1; }
+.settings-test-voice {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.settings-test-voice:hover { border-color: var(--accent); color: var(--accent); }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4315,7 +4315,8 @@ mark.search-highlight-current {
   border-left: 3px solid var(--risk-critical);
   border-radius: 8px;
   padding: 14px 16px;
-  margin: 0 0 20px;
+  max-width: 760px;
+  margin: 0 auto 20px;
 }
 .triage-header {
   display: flex;
@@ -4373,6 +4374,27 @@ mark.search-highlight-current {
 .triage-risk-path { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--text-muted); margin-top: 3px; }
 
 .guided-list { padding: 4px 0; }
+.guided-overview {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: calc(100% - 12px);
+  margin: 0 6px 6px;
+  padding: 7px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+.guided-overview:hover { color: var(--text-primary); }
+.guided-overview.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.guided-overview-star { color: var(--risk-critical); }
 .guided-empty { color: var(--text-muted); font-size: 12px; padding: 12px; }
 .guided-row { display: flex; align-items: flex-start; gap: 6px; padding: 2px 4px; }
 .guided-num {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4541,3 +4541,18 @@ mark.search-highlight-current {
 .tour-btn:disabled { opacity: 0.35; cursor: default; }
 .tour-playpause { min-width: 36px; }
 .tour-exit:hover { border-color: var(--diff-remove-text); color: var(--diff-remove-text); }
+
+.tour-tag {
+  display: inline-block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 5px;
+  margin-bottom: 8px;
+  animation: tour-caption-fade 0.55s ease;
+}
+.tour-tag-walk { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
+.tour-tag-critical { background: var(--risk-critical-bg); color: var(--risk-critical); }
+.tour-tag-warning { background: var(--risk-high-bg); color: var(--risk-high); }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4556,3 +4556,17 @@ mark.search-highlight-current {
 .tour-tag-walk { background: rgba(88, 166, 255, 0.15); color: var(--accent); }
 .tour-tag-critical { background: var(--risk-critical-bg); color: var(--risk-critical); }
 .tour-tag-warning { background: var(--risk-high-bg); color: var(--risk-high); }
+
+.tour-dwell-speaking {
+  height: 100%;
+  width: 35%;
+  background: var(--accent);
+  border-radius: 2px;
+  animation: tour-speaking 1.4s ease-in-out infinite;
+}
+@keyframes tour-speaking {
+  0% { margin-left: -35%; opacity: 0.4; }
+  50% { opacity: 1; }
+  100% { margin-left: 100%; opacity: 0.4; }
+}
+.tour-mute.muted { opacity: 0.7; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2378,25 +2378,27 @@ tr.cursor-selected td {
 
 /* ─── PR Summary (diff pane placeholder) ──────────────────────────────── */
 .pr-summary {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
   height: 100%;
-  padding: 32px;
+  overflow-y: auto;
+  padding: 24px 32px 48px;
   color: var(--text-secondary);
-  text-align: center;
+}
+
+/* Center the content as a readable column that scrolls when tall. */
+.pr-summary > * {
+  max-width: 760px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .pr-summary h3 {
   font-size: 16px;
   font-weight: 600;
   color: var(--text-primary);
-  margin-bottom: 12px;
+  margin: 0 auto 12px;
 }
 
 .pr-summary p {
-  max-width: 600px;
   font-size: 14px;
   line-height: 1.6;
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4306,3 +4306,95 @@ mark.search-highlight-current {
   0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); }
   50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent), 0 8px 24px rgba(0, 0, 0, 0.45); }
 }
+/* ─── Triage-first: what-matters card + guided path ─────────────────────── */
+.triage-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--risk-critical);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin: 0 0 20px;
+}
+.triage-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+.triage-header h3 { margin: 0; font-size: 15px; color: var(--text-primary); }
+.triage-start {
+  background: var(--accent);
+  color: #0d1117;
+  border: none;
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.triage-empty { color: var(--text-secondary); font-size: 13px; margin: 0; }
+.triage-risks { list-style: none; margin: 0; padding: 0; counter-reset: triage; }
+.triage-risk { margin: 0 0 8px; }
+.triage-risk-jump {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px 8px 34px;
+  position: relative;
+  cursor: pointer;
+  counter-increment: triage;
+}
+.triage-risk-jump:hover { border-color: var(--accent); }
+.triage-risk-jump::before {
+  content: counter(triage);
+  position: absolute;
+  left: 10px;
+  top: 8px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--risk-critical-bg);
+  color: var(--risk-critical);
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.triage-risk-title { display: block; font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.triage-risk-detail { display: block; font-size: 12px; color: var(--text-secondary); margin-top: 2px; }
+.triage-risk-path { display: block; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: var(--text-muted); margin-top: 3px; }
+
+.guided-list { padding: 4px 0; }
+.guided-empty { color: var(--text-muted); font-size: 12px; padding: 12px; }
+.guided-row { display: flex; align-items: flex-start; gap: 6px; padding: 2px 4px; }
+.guided-num {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: right;
+  font-size: 11px;
+  color: var(--text-muted);
+  padding-top: 8px;
+}
+.guided-row-main { flex: 1; min-width: 0; }
+.guided-rationale {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 0 8px 4px 30px;
+  line-height: 1.4;
+}
+.guided-watch { color: var(--risk-critical); margin-right: 4px; }
+
+.settings-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4450,3 +4450,85 @@ mark.search-highlight-current {
   color: var(--text-primary);
   cursor: pointer;
 }
+
+/* ─── Triage action buttons ─────────────────────────────────────────────── */
+.triage-actions { display: flex; gap: 8px; }
+.triage-tour {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.triage-tour:hover { background: rgba(88, 166, 255, 0.12); }
+
+/* ─── Cinematic guided tour player ──────────────────────────────────────── */
+.tour-player {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  width: min(720px, calc(100vw - 64px));
+  background: rgba(22, 27, 34, 0.92);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  overflow: hidden;
+  animation: tour-rise 0.3s ease;
+}
+@keyframes tour-rise {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+.tour-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 16px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.tour-spinner { display: inline-block; animation: spin 1.2s linear infinite; color: var(--accent); }
+
+.tour-dwell-track { height: 3px; background: var(--bg-tertiary); }
+.tour-dwell-fill {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  animation-name: tour-dwell;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
+}
+@keyframes tour-dwell { from { width: 0; } to { width: 100%; } }
+
+.tour-body { padding: 14px 18px 12px; }
+.tour-caption {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+.tour-controls { display: flex; align-items: center; gap: 8px; }
+.tour-progress { font-size: 11px; color: var(--text-muted); margin-right: auto; }
+.tour-btn {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-width: 30px;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.tour-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+.tour-btn:disabled { opacity: 0.35; cursor: default; }
+.tour-playpause { min-width: 36px; }
+.tour-exit:hover { border-color: var(--diff-remove-text); color: var(--diff-remove-text); }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4584,3 +4584,19 @@ mark.search-highlight-current {
   white-space: nowrap;
 }
 .settings-test-voice:hover { border-color: var(--accent); color: var(--accent); }
+
+.settings-callout {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: rgba(88, 166, 255, 0.1);
+  border: 1px solid rgba(88, 166, 255, 0.35);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 4px 0 8px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+.settings-callout strong { color: var(--text-primary); font-size: 12.5px; }
+.settings-callout em { color: var(--accent); font-style: normal; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -862,6 +862,7 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  position: relative; /* positioning context for the tour player overlay */
 }
 
 .no-file-selected {
@@ -4467,24 +4468,26 @@ mark.search-highlight-current {
 .triage-tour:hover { background: rgba(88, 166, 255, 0.12); }
 
 /* ─── Cinematic guided tour player ──────────────────────────────────────── */
+/* Centered within the diff pane (the right section), not the whole window. */
 .tour-player {
-  position: fixed;
+  position: absolute;
   left: 50%;
   bottom: 28px;
   transform: translateX(-50%);
-  width: min(720px, calc(100vw - 64px));
-  background: rgba(22, 27, 34, 0.92);
-  backdrop-filter: blur(8px);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-  z-index: 1000;
+  width: min(660px, calc(100% - 56px));
+  background: rgba(22, 27, 34, 0.72);
+  backdrop-filter: blur(18px) saturate(1.25);
+  -webkit-backdrop-filter: blur(18px) saturate(1.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 14px;
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.55);
+  z-index: 50;
   overflow: hidden;
-  animation: tour-rise 0.3s ease;
+  animation: tour-rise 0.5s cubic-bezier(0.22, 1, 0.36, 1);
 }
 @keyframes tour-rise {
-  from { opacity: 0; transform: translate(-50%, 12px); }
-  to { opacity: 1; transform: translate(-50%, 0); }
+  from { opacity: 0; transform: translate(-50%, 18px); filter: blur(4px); }
+  to { opacity: 1; transform: translate(-50%, 0); filter: blur(0); }
 }
 .tour-loading {
   display: flex;
@@ -4508,12 +4511,18 @@ mark.search-highlight-current {
 }
 @keyframes tour-dwell { from { width: 0; } to { width: 100%; } }
 
-.tour-body { padding: 14px 18px 12px; }
+.tour-body { padding: 16px 20px 12px; }
 .tour-caption {
   margin: 0 0 12px;
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 14.5px;
+  line-height: 1.55;
   color: var(--text-primary);
+  /* Cross-fade as the narration changes (re-keyed per stop). */
+  animation: tour-caption-fade 0.55s ease;
+}
+@keyframes tour-caption-fade {
+  from { opacity: 0; transform: translateY(4px); filter: blur(3px); }
+  to { opacity: 1; transform: translateY(0); filter: blur(0); }
 }
 .tour-controls { display: flex; align-items: center; gap: 8px; }
 .tour-progress { font-size: 11px; color: var(--text-muted); margin-right: auto; }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -52,6 +52,28 @@ export interface TriageReport {
   review_order: ReviewOrderItem[];
 }
 
+/** One stop in the cinematic guided tour. */
+export interface TourStop {
+  path: string;
+  /** Head-side line to scroll to and flash; null = just show the file from the top. */
+  line: number | null;
+  /** "intro" = arriving at a file; "note" = a specific important change. */
+  kind: "intro" | "note";
+  severity?: string;
+  /** AI-written narration shown as the caption. */
+  narration: string;
+}
+
+/** Auto-playing tour state (App-level, for the active review). */
+export interface TourState {
+  status: "idle" | "loading" | "active";
+  stops: TourStop[];
+  index: number;
+  playing: boolean;
+  /** One-line scene-setter shown before the first stop. */
+  opening: string;
+}
+
 export interface ReviewManifest {
   pr_title: string;
   pr_url: string;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -57,6 +57,8 @@ export interface TourStop {
   path: string;
   /** Head-side line to scroll to and flash; null = just show the file from the top. */
   line: number | null;
+  /** Head-side end line of the range to flash (defaults to `line` when absent). */
+  endLine?: number | null;
   /** "intro" = arriving at a file; "note" = a specific important change. */
   kind: "intro" | "note";
   severity?: string;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -59,8 +59,9 @@ export interface TourStop {
   line: number | null;
   /** Head-side end line of the range to flash (defaults to `line` when absent). */
   endLine?: number | null;
-  /** "intro" = arriving at a file; "note" = a specific important change. */
-  kind: "intro" | "note";
+  /** "intro" = arriving at a file; "walk" = explaining substantive code;
+   * "note" = a flagged issue. */
+  kind: "intro" | "walk" | "note";
   severity?: string;
   /** AI-written narration shown as the caption. */
   narration: string;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -32,6 +32,26 @@ export interface ChangeGroup {
   file_paths: string[];
 }
 
+/** One of the 2-3 highest-risk changes, shown in the triage card. */
+export interface TopRisk {
+  title: string;
+  detail: string;
+  path: string;
+  start_line?: number | null;
+}
+
+/** A file in the contract-first "fastest path" order, with a one-line rationale. */
+export interface ReviewOrderItem {
+  path: string;
+  rationale: string;
+}
+
+/** Triage-first guidance for large PRs (absent on small PRs). */
+export interface TriageReport {
+  top_risks: TopRisk[];
+  review_order: ReviewOrderItem[];
+}
+
 export interface ReviewManifest {
   pr_title: string;
   pr_url: string;
@@ -42,6 +62,8 @@ export interface ReviewManifest {
   head_sha: string;
   summary: string;
   change_groups: ChangeGroup[];
+  /** Triage guidance; null/undefined for small PRs. */
+  triage?: TriageReport | null;
   files: FileDiff[];
 }
 
@@ -93,7 +115,7 @@ export type CommentThreadsState =
   | { status: "loaded"; threads: ReviewThread[] }
   | { status: "error"; message: string };
 
-export type SidebarView = "groups" | "comments" | "category" | "tree";
+export type SidebarView = "guided" | "groups" | "comments" | "category" | "tree";
 
 export type DiffViewMode = "split" | "unified";
 
@@ -164,6 +186,7 @@ export interface Settings {
   activity_per_watch_cap: number;
   activity_mini_player: boolean;
   show_approved_prs: boolean;
+  expand_all_hunks: boolean;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -212,6 +212,9 @@ export interface Settings {
   activity_mini_player: boolean;
   show_approved_prs: boolean;
   expand_all_hunks: boolean;
+  tts_muted: boolean;
+  tts_voice: string;
+  tts_rate: number;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";


### PR DESCRIPTION
## Summary
- Builds the **triage-first "fastest review path"** for large PRs (closes #129), folding in #60 (AI review order) and #55 (collapse setting).
- A new AI **triage pass** emits the 2–3 highest-risk changes plus a **contract-first** review order with a one-line rationale per file.
- Surfaces risk **twice** — *priming* (a what-matters card up front) and *placement* (badges + existing inline significance call-outs) — so contract-first ordering keeps cognitive load low without hiding the risky changes.
- Gated to large PRs (≥5 relevant files); small PRs and old cached manifests are unaffected.

## Changes

**Backend (Rust)**
- `types.rs` — `TriageReport` / `TopRisk` / `ReviewOrderItem`; `#[serde(default)] triage: Option<TriageReport>` on `ReviewManifest` (cache-compatible). New `expand_all_hunks` setting.
- `prompts.rs` — `TRIAGE_PROMPT` + `build_triage_prompt` (structured file info + budgeted diff snippets; contract-first ordering + top risks as one JSON object).
- `ai.rs` — `extract_json_object` (object-shaped sibling of `extract_json_array`).
- `fetch.rs` — 4th parallel AI call in step 4, gated on `relevant.len() >= 5`; deterministic risk-sorted **fallback**; `finalize_triage` drops hallucinated paths and appends any omitted file so `[`/`]` still covers everything.
- `config.rs` — `expand_all_hunks` load/save/default.

**Frontend (React/TS)**
- `TriageCard.tsx` *(new)* — "What to review first" card with jump-to-line links + "Start guided review".
- `FileSidebar.tsx` — new **Guided** view (numbered contract-first list, rationale, risk badges + ⚠ watch markers); `navigableOrder` follows it; large PRs default to it.
- `DiffViewer.tsx` — `expandAllHunks` respected in the collapse initializer; `initialScrollLine` jump-to-line on mount (reuses the finding-scroll routine).
- `App.tsx` — render TriageCard when no file selected, jump/start-guided handlers, default guided view, thread the setting through; `]`/`[` start the walk from the card.
- `SettingsModal.tsx` — "Expand all hunks by default" checkbox. `types.ts` / `styles.css` — types + styling.

## Test Plan
- [x] `cargo test --workspace` (49 tests; new: `extract_json_object`, `fallback_triage`, `finalize_triage`) / `cargo build` / `cargo clippy` (no new warnings)
- [x] `npm run build` (tsc + vite) clean
- [ ] Open a large PR (≥5 relevant files): triage card shows 2–3 risks; clicking one jumps to the file/line; sidebar defaults to **Guided** with contract-first order, rationales, and risk badges; `]`/`[` walk it
- [ ] Toggle **Expand all hunks** in Settings → next file opens fully expanded; off → low-significance hunks collapsed
- [ ] Open a small PR (<5 files): no triage card / guided default (graceful fallback)
- [ ] Open a PR cached before this change: loads fine (triage = None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)