### PR TITLE
feat(gui): draft AI notes as editable comments first (#73)

### DIFF
--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -229,14 +229,11 @@ function InlineCommentForm({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // When pre-filled (posting an AI note as a draft), drop the cursor at the end
-  // so the reviewer can edit immediately.
+  // so the reviewer can edit immediately. The textarea's `autoFocus` already
+  // focuses it; this just moves the caret off the start.
   useEffect(() => {
-    if (!initialValue) return;
     const ta = textareaRef.current;
-    if (ta) {
-      ta.focus();
-      ta.setSelectionRange(ta.value.length, ta.value.length);
-    }
+    if (ta && initialValue) ta.setSelectionRange(ta.value.length, ta.value.length);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -1515,14 +1512,11 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     setDragging(null);
   }
 
-  function handlePostHighlightAsComment(h: Highlight) {
-    if (!onCreateComment) return;
-    // Open the comment composer pre-filled with the AI note as an editable draft
-    // (issue #73) instead of posting immediately — the reviewer tweaks, then sends.
-    const body = `**[AI ${h.severity.toUpperCase()}]** ${h.comment}`;
-    // Expand the hunk holding the line so the composer is visible, then scroll to it.
-    const hunk = hunks.find((hk) =>
-      hk.lines.some((l) => l.newLineNum === h.start_line || l.newLineNum === h.end_line),
+  // Un-collapse the hunk containing `line` so it renders, then queue a scroll to
+  // it. Shared by the AI-note composer and finding navigation.
+  function revealLine(line: number) {
+    const hunk = hunks.find((h) =>
+      h.lines.some((l) => l.newLineNum === line || l.oldLineNum === line),
     );
     if (hunk && collapsedHunks.has(hunk.index)) {
       setCollapsedHunks((prev) => {
@@ -1531,8 +1525,16 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
         return next;
       });
     }
+    setPendingScroll(`diff-line-${line}`);
+  }
+
+  function handlePostHighlightAsComment(h: Highlight) {
+    if (!onCreateComment) return;
+    // Open the comment composer pre-filled with the AI note as an editable draft
+    // (issue #73) instead of posting immediately — the reviewer tweaks, then sends.
+    const body = `**[AI ${h.severity.toUpperCase()}]** ${h.comment}`;
+    revealLine(h.end_line); // the composer renders at the end line
     setCommentingOn({ startLine: h.start_line, endLine: h.end_line, side: "RIGHT", initialBody: body });
-    setPendingScroll(`diff-line-${h.end_line}`);
   }
 
   useEffect(() => {
@@ -2078,21 +2080,11 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   const goToFinding = () => {
     const f = sortedFindings[findingIdxRef.current];
     if (!f) return;
-    // Expand the containing hunk if collapsed, then move the cursor + scroll once
-    // it has rendered. Findings live on the new (right) side.
-    const hunk = hunks.find((h) =>
-      h.lines.some((l) => l.newLineNum === f.start_line || l.oldLineNum === f.start_line),
-    );
-    if (hunk && collapsedHunks.has(hunk.index)) {
-      setCollapsedHunks((prev) => {
-        const n = new Set(prev);
-        n.delete(hunk.index);
-        return n;
-      });
-    }
+    // Reveal the line, then home the cursor onto it. Findings live on the new
+    // (right) side.
+    revealLine(f.start_line);
     cursorRef.current = { cl: f.start_line, cs: "RIGHT" };
     anchorRef.current = null;
-    setPendingScroll(`diff-line-${f.start_line}`);
   };
 
   const stepFinding = (dir: 1 | -1) => {

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -228,13 +228,15 @@ function InlineCommentForm({
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  // When pre-filled (posting an AI note as a draft), drop the cursor at the end
-  // so the reviewer can edit immediately. The textarea's `autoFocus` already
-  // focuses it; this just moves the caret off the start.
+  // Pre-filled drafts (posting an AI note) start with the caret at the end so the
+  // reviewer can edit immediately; an empty composer is unaffected. This is
+  // mount-only by design: the form remounts each time the composer opens, so it
+  // never needs to react to a later `initialValue`. We read the textarea's own
+  // value (not the `initialValue` prop) so the effect depends only on the stable
+  // ref — keeping the empty deps honest, no lint suppression needed.
   useEffect(() => {
     const ta = textareaRef.current;
-    if (ta && initialValue) ta.setSelectionRange(ta.value.length, ta.value.length);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    if (ta && ta.value) ta.setSelectionRange(ta.value.length, ta.value.length);
   }, []);
 
   function handleSubmit() {

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -91,6 +91,8 @@ interface CommentingOn {
   startLine: number;
   endLine: number;
   side: "LEFT" | "RIGHT";
+  /** Pre-filled draft body (e.g. when posting an AI note as a comment). */
+  initialBody?: string;
 }
 
 interface DiffViewerProps {
@@ -212,6 +214,7 @@ function InlineCommentForm({
   codeSnippet,
   lineRange,
   lang,
+  initialValue,
 }: {
   onSubmit: (body: string) => void;
   onCancel: () => void;
@@ -219,10 +222,23 @@ function InlineCommentForm({
   codeSnippet?: string;
   lineRange?: string;
   lang?: string;
+  initialValue?: string;
 }) {
-  const [text, setText] = useState("");
+  const [text, setText] = useState(initialValue ?? "");
   const [submitting, setSubmitting] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // When pre-filled (posting an AI note as a draft), drop the cursor at the end
+  // so the reviewer can edit immediately.
+  useEffect(() => {
+    if (!initialValue) return;
+    const ta = textareaRef.current;
+    if (ta) {
+      ta.focus();
+      ta.setSelectionRange(ta.value.length, ta.value.length);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleSubmit() {
     if (!text.trim() || submitting) return;
@@ -839,9 +855,9 @@ function HighlightMarker({ highlight, onPostAsComment }: { highlight: Highlight;
         <button
           className="highlight-post-comment"
           onClick={(e) => { e.stopPropagation(); onPostAsComment(highlight); }}
-          title="Post this AI note as a review comment"
+          title="Draft a review comment from this AI note (you can edit before posting)"
         >
-          Post as comment
+          Comment…
         </button>
       )}
     </div>
@@ -1046,6 +1062,7 @@ function UnifiedHunkLines({
                 codeSnippet={codeSnippet}
                 lineRange={lineRange}
                 lang={lang}
+                initialValue={commentingOn?.initialBody}
               />
             )}
           </Fragment>
@@ -1321,6 +1338,7 @@ function SplitHunkLines({
                 codeSnippet={codeSnippet}
                 lineRange={lineRange}
                 lang={lang}
+                initialValue={commentingOn?.initialBody}
               />
             )}
           </Fragment>
@@ -1499,16 +1517,22 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
 
   function handlePostHighlightAsComment(h: Highlight) {
     if (!onCreateComment) return;
+    // Open the comment composer pre-filled with the AI note as an editable draft
+    // (issue #73) instead of posting immediately — the reviewer tweaks, then sends.
     const body = `**[AI ${h.severity.toUpperCase()}]** ${h.comment}`;
-    const isRange = h.start_line !== h.end_line;
-    onCreateComment(
-      file.path,
-      h.end_line,
-      "RIGHT",
-      body,
-      isRange ? h.start_line : undefined,
-      isRange ? "RIGHT" : undefined,
+    // Expand the hunk holding the line so the composer is visible, then scroll to it.
+    const hunk = hunks.find((hk) =>
+      hk.lines.some((l) => l.newLineNum === h.start_line || l.newLineNum === h.end_line),
     );
+    if (hunk && collapsedHunks.has(hunk.index)) {
+      setCollapsedHunks((prev) => {
+        const next = new Set(prev);
+        next.delete(hunk.index);
+        return next;
+      });
+    }
+    setCommentingOn({ startLine: h.start_line, endLine: h.end_line, side: "RIGHT", initialBody: body });
+    setPendingScroll(`diff-line-${h.end_line}`);
   }
 
   useEffect(() => {
@@ -2178,9 +2202,9 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
                 <button
                   className="highlight-post-comment"
                   onClick={(e) => { e.stopPropagation(); handlePostHighlightAsComment(h); }}
-                  title="Post this AI note as a review comment"
+                  title="Draft a review comment from this AI note (you can edit before posting)"
                 >
-                  Post as comment
+                  Comment…
                 </button>
               )}
               {onToggleHighlightDismissed && (


### PR DESCRIPTION
## Summary
- Closes #73. Clicking the "Post as comment" action on an AI highlight used to post to GitHub immediately, so any edit had to happen after the fact.
- It now opens the **inline comment composer pre-filled** with the AI note as an editable draft — the reviewer tweaks it, then submits. As the issue notes, it's one extra click when no change is needed, but far more usable.

## How it works
- `handlePostHighlightAsComment` no longer calls `onCreateComment` directly. Instead it sets `commentingOn` for the highlight's line range with an `initialBody` (the `**[AI SEVERITY]** …` text), expands the containing hunk if collapsed, and scrolls to it.
- `InlineCommentForm` takes an optional `initialValue`, seeds its textarea with it, and drops the cursor at the end on mount. Submitting goes through the existing `onCreateComment` path (so range/side handling is unchanged).
- The manual "drag to select lines → comment" flow is untouched (no `initialBody` → empty composer).
- Relabeled the buttons **"Comment…"** (with a clarifying tooltip) since they now open an editor rather than post.

## Test Plan
- [x] `npm run build` (tsc + vite) clean
- [ ] Open a PR with AI notes → click **Comment…** on a highlight (both the inline marker and the highlights-summary panel): the composer opens at that line, pre-filled with the note, cursor at end
- [ ] Edit the text and **Comment** → it posts the edited version as a review comment on the right line/range
- [ ] **Cancel** → nothing is posted
- [ ] Click **Comment…** on a note inside a collapsed hunk → the hunk expands and scrolls into view with the composer
- [ ] Manual line-select comment still opens an empty composer

🤖 Generated with [Claude Code](https://claude.com/claude-code)