### PR TITLE
feat(gui): PR activity mini-player (in-app dock + floating window)

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -615,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -887,6 +893,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation 0.10.1",
+ "core-graphics 0.24.0",
+ "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "core-foundation 0.10.1",
+ "core-graphics-types",
+ "objc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,6 +1012,19 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "libc",
+]
 
 [[package]]
 name = "core-graphics"
@@ -2793,6 +2841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3041,6 +3098,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3239,6 +3316,15 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -4083,6 +4169,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-nspanel",
  "tauri-plugin-deep-link",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -5074,7 +5161,7 @@ dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
  "dlopen2",
@@ -5243,6 +5330,22 @@ dependencies = [
  "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-nspanel"
+version = "2.0.1"
+source = "git+https://github.com/ahkohd/tauri-nspanel?rev=18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a#18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block",
+ "cocoa",
+ "core-foundation 0.10.1",
+ "core-graphics 0.25.0",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "tauri",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4020,6 +4020,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tokio",
 ]
 
@@ -5277,6 +5278,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4011,7 +4011,10 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "relevant-reviews"
 version = "0.1.0"
 dependencies = [
+ "block2",
  "marrow-core",
+ "objc2",
+ "objc2-foundation",
  "serde",
  "serde_json",
  "tauri",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -3058,8 +3058,38 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3084,6 +3114,41 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -4012,6 +4077,8 @@ name = "relevant-reviews"
 version = "0.1.0"
 dependencies = [
  "marrow-core",
+ "objc2",
+ "objc2-app-kit",
  "serde",
  "serde_json",
  "tauri",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4011,10 +4011,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 name = "relevant-reviews"
 version = "0.1.0"
 dependencies = [
- "block2",
  "marrow-core",
- "objc2",
- "objc2-foundation",
  "serde",
  "serde_json",
  "tauri",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ marrow-core = { path = "crates/core" }
 # state is the only reliable signal.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSEvent", "NSWindow"] }
 # Convert the floating mini-player into a non-activating NSPanel so dragging /
 # resizing it doesn't activate Marrow (which the app-active poll would treat as
 # "you're back" and hide it). Cmd+Tab / opening a PR still activate the app.

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -47,7 +47,7 @@ marrow-core = { path = "crates/core" }
 # state is the only reliable signal.
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
-objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder", "NSEvent", "NSWindow"] }
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
 # Convert the floating mini-player into a non-activating NSPanel so dragging /
 # resizing it doesn't activate Marrow (which the app-active poll would treat as
 # "you're back" and hide it). Cmd+Tab / opening a PR still activate the app.

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -41,3 +41,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 marrow-core = { path = "crates/core" }
+
+# Read NSApplication.isActive to drive the floating mini-player: macOS delivers
+# no webview focus event on app (re)activation (Cmd+Tab / dock), so app-active
+# state is the only reliable signal.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -41,10 +41,3 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 marrow-core = { path = "crates/core" }
-
-# Native AppKit hook to detect Marrow becoming the active app (Cmd+Tab / dock),
-# which delivers no webview focus event — used to hide the floating mini-player.
-[target.'cfg(target_os = "macos")'.dependencies]
-objc2 = "0.6"
-objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSOperation", "block2"] }
-block2 = "0.6"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -48,3 +48,7 @@ marrow-core = { path = "crates/core" }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSResponder"] }
+# Convert the floating mini-player into a non-activating NSPanel so dragging /
+# resizing it doesn't activate Marrow (which the app-active poll would treat as
+# "you're back" and hide it). Cmd+Tab / opening a PR still activate the app.
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "18ffb9a201fbf6fedfaa382fd4b92315ea30ab1a" }

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -41,3 +41,10 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 marrow-core = { path = "crates/core" }
+
+# Native AppKit hook to detect Marrow becoming the active app (Cmd+Tab / dock),
+# which delivers no webview focus event — used to hide the floating mini-player.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSNotification", "NSString", "NSOperation", "block2"] }
+block2 = "0.6"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -31,12 +31,12 @@ authors = ["Teancum Besendorfer"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-deep-link = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 marrow-core = { path = "crates/core" }

--- a/app/src-tauri/capabilities/mini-player.json
+++ b/app/src-tauri/capabilities/mini-player.json
@@ -1,0 +1,10 @@
+{
+  "identifier": "mini-player",
+  "description": "Capabilities for the floating PR activity mini-player window",
+  "windows": ["activity-widget"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging",
+    "core:window:allow-close"
+  ]
+}

--- a/app/src-tauri/crates/core/src/activity.rs
+++ b/app/src-tauri/crates/core/src/activity.rs
@@ -1,0 +1,347 @@
+//! PR activity model for the mini-player widget.
+//!
+//! Two responsibilities:
+//!  1. Persist a per-PR *seen-state* (`activity.json`) — a snapshot of what the
+//!     observable fields looked like the last time the user acknowledged a PR.
+//!  2. Diff freshly observed PRs against that seen-state to produce
+//!     [`PrActivityItem`]s carrying `deltas` (what changed) and an `unread` flag.
+//!
+//! This module is pure/testable: the network fetches live in `github.rs` and the
+//! Tauri event emission lives in the app layer. [`compute_activity`] takes
+//! already-fetched observations plus the loaded seen-state and returns the
+//! payload to emit.
+
+use crate::config::app_config_dir;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+/// The observable fields of a PR we compare across polls to detect activity.
+/// All optional beyond `updated_at` because different sources surface different
+/// amounts of detail (a watch search gives `updated_at`; an enriched review
+/// request adds review state and threads; a focused diff adds sha/comments/CI).
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq)]
+pub struct Observed {
+    pub updated_at: String,
+    #[serde(default)]
+    pub review_state: Option<String>,
+    #[serde(default)]
+    pub unresolved_threads: Option<u32>,
+    #[serde(default)]
+    pub head_sha: Option<String>,
+    #[serde(default)]
+    pub comment_count: Option<u32>,
+    #[serde(default)]
+    pub ci_state: Option<String>,
+}
+
+/// One entry in `activity.json`: what we last *acknowledged* for a PR, plus when
+/// the user marked it seen.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SeenState {
+    pub last_seen_at: String,
+    pub observed: Observed,
+}
+
+/// `activity.json` on disk: `pr_url -> SeenState`.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct ActivityStore {
+    #[serde(default)]
+    pub prs: HashMap<String, SeenState>,
+}
+
+/// A PR observed this poll, with the source-derived metadata the UI renders and
+/// the raw observable state used for diffing. Built by the caller from GitHub
+/// results; `deltas`/`unread` are filled in by [`compute_activity`].
+#[derive(Debug, Clone)]
+pub struct ObservedPr {
+    pub pr_url: String,
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub avatar_url: String,
+    pub draft: bool,
+    /// Why this PR is in the feed, e.g. "review-requested", "watching:acme-web".
+    pub reasons: Vec<String>,
+    pub observed: Observed,
+}
+
+/// A feed row emitted to the UI. Field names are camelCase on the wire to match
+/// the existing `ReviewRequestItem` shape the frontend already renders.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrActivityItem {
+    pub pr_url: String,
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+    pub title: String,
+    pub author: String,
+    pub avatar_url: String,
+    pub updated_at: String,
+    pub draft: bool,
+    pub reasons: Vec<String>,
+    /// What changed since the user last acknowledged this PR.
+    pub deltas: Vec<String>,
+    pub review_state: Option<String>,
+    pub unresolved_threads: Option<u32>,
+    pub ci_state: Option<String>,
+    pub unread: bool,
+}
+
+/// The `pr-activity` event payload broadcast to all windows.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrActivityPayload {
+    pub items: Vec<PrActivityItem>,
+    /// Per-watch counts of results dropped by the cap, for honest "+N more" UI.
+    pub truncated: HashMap<String, u32>,
+    pub fetched_at: String,
+}
+
+fn activity_path() -> PathBuf {
+    app_config_dir().join("activity.json")
+}
+
+/// Current time as an RFC3339 string — the timestamp format used throughout
+/// (so the app layer doesn't need its own `chrono` dependency).
+pub fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+pub fn load_activity_store() -> ActivityStore {
+    let path = activity_path();
+    let Ok(content) = fs::read_to_string(&path) else {
+        return ActivityStore::default();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+pub fn save_activity_store(store: &ActivityStore) -> Result<(), String> {
+    let path = activity_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(store)
+        .map_err(|e| format!("Failed to serialize activity store: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write activity store: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(&path, perms);
+    }
+
+    Ok(())
+}
+
+/// Compute the deltas between what we last acknowledged (`seen`) and what we
+/// just observed (`now`). Empty when nothing meaningful changed.
+fn diff(seen: &Observed, now: &Observed) -> Vec<String> {
+    let mut deltas = Vec::new();
+    if now.updated_at != seen.updated_at {
+        deltas.push("updated".to_string());
+    }
+    if now.head_sha.is_some() && now.head_sha != seen.head_sha {
+        deltas.push("new-commits".to_string());
+    }
+    if let (Some(now_c), Some(seen_c)) = (now.comment_count, seen.comment_count) {
+        if now_c > seen_c {
+            deltas.push("new-comments".to_string());
+        }
+    }
+    if now.review_state.is_some() && now.review_state != seen.review_state {
+        deltas.push("review-state-changed".to_string());
+    }
+    if let (Some(now_t), Some(seen_t)) = (now.unresolved_threads, seen.unresolved_threads) {
+        if now_t > seen_t {
+            deltas.push("new-threads".to_string());
+        }
+    }
+    if now.ci_state.is_some() && now.ci_state != seen.ci_state {
+        deltas.push("ci-changed".to_string());
+    }
+    deltas
+}
+
+/// Turn this poll's observations into a feed payload by diffing against the
+/// persisted seen-state. A PR never seen before is `unread` with a `new` delta;
+/// a PR whose observable fields all match its seen-state is read with no deltas.
+pub fn compute_activity(
+    observations: Vec<ObservedPr>,
+    store: &ActivityStore,
+    truncated: HashMap<String, u32>,
+    fetched_at: String,
+) -> PrActivityPayload {
+    let mut items: Vec<PrActivityItem> = observations
+        .into_iter()
+        .map(|pr| {
+            let (deltas, unread) = match store.prs.get(&pr.pr_url) {
+                Some(seen) => {
+                    let d = diff(&seen.observed, &pr.observed);
+                    let unread = !d.is_empty();
+                    (d, unread)
+                }
+                None => (vec!["new".to_string()], true),
+            };
+            PrActivityItem {
+                pr_url: pr.pr_url,
+                owner: pr.owner,
+                repo: pr.repo,
+                number: pr.number,
+                title: pr.title,
+                author: pr.author,
+                avatar_url: pr.avatar_url,
+                updated_at: pr.observed.updated_at.clone(),
+                draft: pr.draft,
+                reasons: pr.reasons,
+                deltas,
+                review_state: pr.observed.review_state.clone(),
+                unresolved_threads: pr.observed.unresolved_threads,
+                ci_state: pr.observed.ci_state.clone(),
+                unread,
+            }
+        })
+        .collect();
+
+    // Unread first, then most-recently-updated.
+    items.sort_by(|a, b| {
+        b.unread
+            .cmp(&a.unread)
+            .then_with(|| b.updated_at.cmp(&a.updated_at))
+    });
+
+    PrActivityPayload {
+        items,
+        truncated,
+        fetched_at,
+    }
+}
+
+/// Record that the user has acknowledged a PR: store its current observable
+/// state so future polls diff against it (clearing the unread state).
+pub fn mark_seen(store: &mut ActivityStore, pr_url: &str, observed: Observed, now: String) {
+    store.prs.insert(
+        pr_url.to_string(),
+        SeenState {
+            last_seen_at: now,
+            observed,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obs(updated: &str) -> Observed {
+        Observed {
+            updated_at: updated.to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn pr(url: &str, observed: Observed) -> ObservedPr {
+        ObservedPr {
+            pr_url: url.to_string(),
+            owner: "o".into(),
+            repo: "r".into(),
+            number: 1,
+            title: "t".into(),
+            author: "a".into(),
+            avatar_url: "".into(),
+            draft: false,
+            reasons: vec!["watching:x".into()],
+            observed,
+        }
+    }
+
+    #[test]
+    fn never_seen_pr_is_unread_with_new_delta() {
+        let store = ActivityStore::default();
+        let payload = compute_activity(
+            vec![pr("u1", obs("2026-01-01T00:00:00Z"))],
+            &store,
+            HashMap::new(),
+            "now".into(),
+        );
+        assert_eq!(payload.items.len(), 1);
+        assert!(payload.items[0].unread);
+        assert_eq!(payload.items[0].deltas, vec!["new".to_string()]);
+    }
+
+    #[test]
+    fn unchanged_pr_is_read_with_no_deltas() {
+        let mut store = ActivityStore::default();
+        mark_seen(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "seen".into());
+        let payload = compute_activity(
+            vec![pr("u1", obs("2026-01-01T00:00:00Z"))],
+            &store,
+            HashMap::new(),
+            "now".into(),
+        );
+        assert!(!payload.items[0].unread);
+        assert!(payload.items[0].deltas.is_empty());
+    }
+
+    #[test]
+    fn newer_update_marks_unread() {
+        let mut store = ActivityStore::default();
+        mark_seen(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "seen".into());
+        let payload = compute_activity(
+            vec![pr("u1", obs("2026-02-01T00:00:00Z"))],
+            &store,
+            HashMap::new(),
+            "now".into(),
+        );
+        assert!(payload.items[0].unread);
+        assert!(payload.items[0].deltas.contains(&"updated".to_string()));
+    }
+
+    #[test]
+    fn detects_richer_field_changes() {
+        let seen = Observed {
+            updated_at: "t".into(),
+            review_state: Some("pending".into()),
+            unresolved_threads: Some(1),
+            head_sha: Some("aaa".into()),
+            comment_count: Some(3),
+            ci_state: Some("success".into()),
+        };
+        let now = Observed {
+            updated_at: "t".into(), // same timestamp; only richer fields move
+            review_state: Some("changes_requested".into()),
+            unresolved_threads: Some(3),
+            head_sha: Some("bbb".into()),
+            comment_count: Some(5),
+            ci_state: Some("failure".into()),
+        };
+        let d = diff(&seen, &now);
+        assert!(d.contains(&"review-state-changed".to_string()));
+        assert!(d.contains(&"new-threads".to_string()));
+        assert!(d.contains(&"new-commits".to_string()));
+        assert!(d.contains(&"new-comments".to_string()));
+        assert!(d.contains(&"ci-changed".to_string()));
+        assert!(!d.contains(&"updated".to_string()));
+    }
+
+    #[test]
+    fn unread_items_sort_first() {
+        let mut store = ActivityStore::default();
+        mark_seen(&mut store, "seen-url", obs("2026-05-01T00:00:00Z"), "s".into());
+        let payload = compute_activity(
+            vec![
+                pr("seen-url", obs("2026-05-01T00:00:00Z")), // read
+                pr("new-url", obs("2026-01-01T00:00:00Z")),  // unread, older
+            ],
+            &store,
+            HashMap::new(),
+            "now".into(),
+        );
+        assert_eq!(payload.items[0].pr_url, "new-url", "unread sorts before read");
+    }
+}

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -101,6 +101,7 @@ fn default_settings() -> Settings {
         show_hunk_significance: true,
         show_ai_notes: true,
         hunk_filter: "all".to_string(),
+        activity_per_watch_cap: 50,
     }
 }
 
@@ -129,6 +130,7 @@ pub fn load_settings() -> Settings {
     let mut show_hunk_significance = true;
     let mut show_ai_notes = true;
     let mut hunk_filter = "all".to_string();
+    let mut activity_per_watch_cap = 50u64;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -159,6 +161,10 @@ pub fn load_settings() -> Settings {
             show_ai_notes = val == "true";
         } else if let Some(val) = line.strip_prefix("hunk_filter=") {
             hunk_filter = val.to_string();
+        } else if let Some(val) = line.strip_prefix("activity_per_watch_cap=") {
+            if let Ok(n) = val.parse::<u64>() {
+                activity_per_watch_cap = n;
+            }
         }
     }
 
@@ -177,6 +183,7 @@ pub fn load_settings() -> Settings {
         show_hunk_significance,
         show_ai_notes,
         hunk_filter,
+        activity_per_watch_cap,
     }
 }
 
@@ -215,6 +222,10 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     content.push_str(&format!("show_hunk_significance={}\n", settings.show_hunk_significance));
     content.push_str(&format!("show_ai_notes={}\n", settings.show_ai_notes));
     content.push_str(&format!("hunk_filter={}\n", settings.hunk_filter));
+    content.push_str(&format!(
+        "activity_per_watch_cap={}\n",
+        settings.activity_per_watch_cap
+    ));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -102,6 +102,7 @@ fn default_settings() -> Settings {
         show_ai_notes: true,
         hunk_filter: "all".to_string(),
         activity_per_watch_cap: 50,
+        activity_mini_player: true,
     }
 }
 
@@ -131,6 +132,7 @@ pub fn load_settings() -> Settings {
     let mut show_ai_notes = true;
     let mut hunk_filter = "all".to_string();
     let mut activity_per_watch_cap = 50u64;
+    let mut activity_mini_player = true;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -165,6 +167,8 @@ pub fn load_settings() -> Settings {
             if let Ok(n) = val.parse::<u64>() {
                 activity_per_watch_cap = n;
             }
+        } else if let Some(val) = line.strip_prefix("activity_mini_player=") {
+            activity_mini_player = val == "true";
         }
     }
 
@@ -184,6 +188,7 @@ pub fn load_settings() -> Settings {
         show_ai_notes,
         hunk_filter,
         activity_per_watch_cap,
+        activity_mini_player,
     }
 }
 
@@ -225,6 +230,10 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     content.push_str(&format!(
         "activity_per_watch_cap={}\n",
         settings.activity_per_watch_cap
+    ));
+    content.push_str(&format!(
+        "activity_mini_player={}\n",
+        settings.activity_mini_player
     ));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -470,8 +470,8 @@ impl GithubClient {
         let url = format!(
             "https://api.github.com/search/issues?q={}&sort={}&order={}&per_page=100",
             urlencoding::encode(query),
-            sort,
-            order
+            urlencoding::encode(sort),
+            urlencoding::encode(order)
         );
         let resp = self
             .send_checked(&url, "application/vnd.github.v3+json")

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -460,37 +460,31 @@ impl GithubClient {
         Ok(user.login)
     }
 
-    async fn search_prs(
+    /// Run a `/search/issues` query, returning (items, server-reported total).
+    async fn search_issues(
         &self,
         query: &str,
-    ) -> Result<Vec<SearchItem>, String> {
+        sort: &str,
+        order: &str,
+    ) -> Result<(Vec<SearchItem>, u32), String> {
         let url = format!(
-            "https://api.github.com/search/issues?q={}&sort=created&order=asc&per_page=100",
-            urlencoding::encode(query)
+            "https://api.github.com/search/issues?q={}&sort={}&order={}&per_page=100",
+            urlencoding::encode(query),
+            sort,
+            order
         );
-
         let resp = self
-            .client
-            .get(&url)
-            .header(AUTHORIZATION, format!("Bearer {}", self.token))
-            .header(USER_AGENT, "relevant-reviews")
-            .header(ACCEPT, "application/vnd.github.v3+json")
-            .send()
-            .await
-            .map_err(|e| format!("GitHub API request failed: {}", e))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("GitHub API error ({}): {}", status, body));
-        }
-
+            .send_checked(&url, "application/vnd.github.v3+json")
+            .await?;
         let search: SearchResponse = resp
             .json()
             .await
             .map_err(|e| format!("Failed to parse search results: {}", e))?;
+        Ok((search.items, search.total_count))
+    }
 
-        Ok(search.items)
+    async fn search_prs(&self, query: &str) -> Result<Vec<SearchItem>, String> {
+        Ok(self.search_issues(query, "created", "asc").await?.0)
     }
 
     pub async fn get_review_requests(
@@ -1553,22 +1547,11 @@ fn merge_observation(
 }
 
 impl GithubClient {
-    /// Like `search_prs` but also returns the server-reported `total_count` so
-    /// callers can report truncation honestly when a watch matches more PRs
+    /// Like `search_prs` but ordered by recency and returning the server total
+    /// so callers can report truncation honestly when a watch matches more PRs
     /// than one page (or the feed cap) shows.
     async fn search_prs_total(&self, query: &str) -> Result<(Vec<SearchItem>, u32), String> {
-        let url = format!(
-            "https://api.github.com/search/issues?q={}&sort=updated&order=desc&per_page=100",
-            urlencoding::encode(query)
-        );
-        let resp = self
-            .send_checked(&url, "application/vnd.github.v3+json")
-            .await?;
-        let search: SearchResponse = resp
-            .json()
-            .await
-            .map_err(|e| format!("Failed to parse search results: {}", e))?;
-        Ok((search.items, search.total_count))
+        self.search_issues(query, "updated", "desc").await
     }
 
     /// Fetch the viewer's PR notifications (only PR-type, unread). Each maps to
@@ -1691,12 +1674,17 @@ impl GithubClient {
         let mut notif_poll_interval = None;
         let mut notif_last_modified = None;
 
-        // Involved PRs + notifications require a known viewer.
+        // Involved PRs + notifications require a known viewer. They're
+        // independent, so fetch them concurrently once we have the username.
         if let Ok(username) = self.get_authenticated_user().await {
             let cutoff = (chrono::Utc::now() - chrono::Duration::days(30))
                 .format("%Y-%m-%d")
                 .to_string();
-            if let Ok(items) = self.get_review_requests(&username, &cutoff, true).await {
+            let (review_requests, notifications) = tokio::join!(
+                self.get_review_requests(&username, &cutoff, true),
+                self.get_notifications(notif_since),
+            );
+            if let Ok(items) = review_requests {
                 for it in items {
                     let reason = if it.direct_request {
                         "review-requested"
@@ -1706,7 +1694,7 @@ impl GithubClient {
                     merge_observation(&mut merged, review_item_to_observed(it, reason));
                 }
             }
-            if let Ok(res) = self.get_notifications(notif_since).await {
+            if let Ok(res) = notifications {
                 notif_poll_interval = res.poll_interval;
                 notif_last_modified = res.last_modified;
                 for pr in res.items {

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -23,6 +23,8 @@ struct GithubUser {
 
 #[derive(Deserialize)]
 struct SearchResponse {
+    #[serde(default)]
+    total_count: u32,
     items: Vec<SearchItem>,
 }
 
@@ -1431,4 +1433,327 @@ impl GithubClient {
             is_merged,
         })
     }
+}
+
+/// GitHub serves an avatar (with a redirect) at `https://github.com/<login>.png`.
+/// Using it avoids an extra API call just to render a face in the activity feed.
+fn avatar_for(login: &str) -> String {
+    if login.is_empty() {
+        String::new()
+    } else {
+        format!("https://github.com/{}.png?size=40", login)
+    }
+}
+
+/// Convert a notifications `subject.url`
+/// (`https://api.github.com/repos/{owner}/{repo}/pulls/{n}`) into the canonical
+/// HTML PR url so it keys the same as search/review-request results.
+fn pulls_api_to_html(api_url: &str) -> Option<String> {
+    let rest = api_url.strip_prefix("https://api.github.com/repos/")?;
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() == 4 && parts[2] == "pulls" {
+        Some(format!(
+            "https://github.com/{}/{}/pull/{}",
+            parts[0], parts[1], parts[3]
+        ))
+    } else {
+        None
+    }
+}
+
+fn search_item_to_observed(
+    item: SearchItem,
+    reason: String,
+) -> Option<crate::activity::ObservedPr> {
+    if let Some(pr) = &item.pull_request {
+        if pr.merged_at.is_some() {
+            return None;
+        }
+    }
+    let parsed = crate::pr_parser::parse_pr_ref(&item.html_url).ok()?;
+    let avatar_url = avatar_for(&item.user.login);
+    Some(crate::activity::ObservedPr {
+        pr_url: item.html_url,
+        owner: parsed.owner,
+        repo: parsed.repo,
+        number: item.number,
+        title: item.title,
+        author: item.user.login,
+        avatar_url,
+        draft: item.draft.unwrap_or(false),
+        reasons: vec![reason],
+        observed: crate::activity::Observed {
+            updated_at: item.updated_at,
+            ..Default::default()
+        },
+    })
+}
+
+fn review_item_to_observed(
+    item: crate::types::ReviewRequestItem,
+    reason: &str,
+) -> crate::activity::ObservedPr {
+    let avatar_url = avatar_for(&item.author);
+    crate::activity::ObservedPr {
+        pr_url: item.html_url,
+        owner: item.owner,
+        repo: item.repo,
+        number: item.number,
+        title: item.title,
+        author: item.author,
+        avatar_url,
+        draft: item.draft,
+        reasons: vec![reason.to_string()],
+        observed: crate::activity::Observed {
+            updated_at: item.updated_at,
+            review_state: Some(item.my_review_status),
+            unresolved_threads: Some(item.unresolved_thread_count),
+            ..Default::default()
+        },
+    }
+}
+
+/// Merge an observation into the de-duplicated map keyed by PR url: union the
+/// `reasons`, keep the freshest `updated_at`, and fill any observable field the
+/// existing entry is still missing (so a rich review-request entry isn't
+/// clobbered by a bare watch-search hit, or vice-versa).
+fn merge_observation(
+    map: &mut HashMap<String, crate::activity::ObservedPr>,
+    incoming: crate::activity::ObservedPr,
+) {
+    match map.get_mut(&incoming.pr_url) {
+        Some(existing) => {
+            for r in incoming.reasons {
+                if !existing.reasons.contains(&r) {
+                    existing.reasons.push(r);
+                }
+            }
+            let o = &mut existing.observed;
+            let i = incoming.observed;
+            if i.updated_at > o.updated_at {
+                o.updated_at = i.updated_at;
+            }
+            o.review_state = o.review_state.take().or(i.review_state);
+            o.unresolved_threads = o.unresolved_threads.or(i.unresolved_threads);
+            o.head_sha = o.head_sha.take().or(i.head_sha);
+            o.comment_count = o.comment_count.or(i.comment_count);
+            o.ci_state = o.ci_state.take().or(i.ci_state);
+            if existing.author.is_empty() {
+                existing.author = incoming.author;
+                existing.avatar_url = incoming.avatar_url;
+            }
+            if existing.title.is_empty() {
+                existing.title = incoming.title;
+            }
+        }
+        None => {
+            map.insert(incoming.pr_url.clone(), incoming);
+        }
+    }
+}
+
+impl GithubClient {
+    /// Like `search_prs` but also returns the server-reported `total_count` so
+    /// callers can report truncation honestly when a watch matches more PRs
+    /// than one page (or the feed cap) shows.
+    async fn search_prs_total(&self, query: &str) -> Result<(Vec<SearchItem>, u32), String> {
+        let url = format!(
+            "https://api.github.com/search/issues?q={}&sort=updated&order=desc&per_page=100",
+            urlencoding::encode(query)
+        );
+        let resp = self
+            .send_checked(&url, "application/vnd.github.v3+json")
+            .await?;
+        let search: SearchResponse = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse search results: {}", e))?;
+        Ok((search.items, search.total_count))
+    }
+
+    /// Fetch the viewer's PR notifications (only PR-type, unread). Each maps to
+    /// an observation with reason `notification:<reason>`.
+    ///
+    /// Honors conditional requests: pass the previous response's `Last-Modified`
+    /// as `if_modified_since` and a `304 Not Modified` (no items, free against
+    /// the rate limit) comes back. The returned `poll_interval` is GitHub's
+    /// `X-Poll-Interval` — the minimum seconds to wait before polling again.
+    pub async fn get_notifications(
+        &self,
+        if_modified_since: Option<&str>,
+    ) -> Result<NotificationsResult, String> {
+        let mut req = self.request(
+            "https://api.github.com/notifications?all=false&per_page=50",
+            "application/vnd.github.v3+json",
+        );
+        if let Some(ims) = if_modified_since {
+            req = req.header(reqwest::header::IF_MODIFIED_SINCE, ims);
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| format!("Notifications request failed: {}", e))?;
+
+        let poll_interval = resp
+            .headers()
+            .get("x-poll-interval")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+        let last_modified = resp
+            .headers()
+            .get(reqwest::header::LAST_MODIFIED)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
+        if resp.status() == reqwest::StatusCode::NOT_MODIFIED {
+            return Ok(NotificationsResult {
+                items: Vec::new(),
+                poll_interval,
+                last_modified,
+            });
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("GitHub API error ({}): {}", status, body));
+        }
+
+        let arr: Vec<serde_json::Value> = resp
+            .json()
+            .await
+            .map_err(|e| format!("Failed to parse notifications: {}", e))?;
+
+        let mut out = Vec::new();
+        for n in arr {
+            if n.pointer("/subject/type").and_then(|v| v.as_str()) != Some("PullRequest") {
+                continue;
+            }
+            let api_url = n
+                .pointer("/subject/url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let Some(html_url) = pulls_api_to_html(api_url) else {
+                continue;
+            };
+            let Ok(parsed) = crate::pr_parser::parse_pr_ref(&html_url) else {
+                continue;
+            };
+            let title = n
+                .pointer("/subject/title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let updated_at = n
+                .get("updated_at")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let reason = n.get("reason").and_then(|v| v.as_str()).unwrap_or("notification");
+            out.push(crate::activity::ObservedPr {
+                pr_url: html_url,
+                owner: parsed.owner,
+                repo: parsed.repo,
+                number: parsed.number,
+                title,
+                author: String::new(),
+                avatar_url: String::new(),
+                draft: false,
+                reasons: vec![format!("notification:{}", reason)],
+                observed: crate::activity::Observed {
+                    updated_at,
+                    ..Default::default()
+                },
+            });
+        }
+        Ok(NotificationsResult {
+            items: out,
+            poll_interval,
+            last_modified,
+        })
+    }
+
+    /// Gather the full activity set for the mini-player: involved PRs (review
+    /// requests, enriched), notifications, and each saved watch's search. Merges
+    /// and de-duplicates by PR url, and returns per-watch truncation counts plus
+    /// the notification poll-interval / last-modified for adaptive scheduling.
+    ///
+    /// Best-effort: a failure of any one source is swallowed so the others still
+    /// produce a feed. `notif_since` is forwarded as the conditional
+    /// `If-Modified-Since` for the notifications fetch.
+    pub async fn collect_activity(
+        &self,
+        watches: &[crate::watches::Watch],
+        per_watch_cap: usize,
+        notif_since: Option<&str>,
+    ) -> CollectedActivity {
+        let mut merged: HashMap<String, crate::activity::ObservedPr> = HashMap::new();
+        let mut truncated: HashMap<String, u32> = HashMap::new();
+        let mut notif_poll_interval = None;
+        let mut notif_last_modified = None;
+
+        // Involved PRs + notifications require a known viewer.
+        if let Ok(username) = self.get_authenticated_user().await {
+            let cutoff = (chrono::Utc::now() - chrono::Duration::days(30))
+                .format("%Y-%m-%d")
+                .to_string();
+            if let Ok(items) = self.get_review_requests(&username, &cutoff, true).await {
+                for it in items {
+                    let reason = if it.direct_request {
+                        "review-requested"
+                    } else {
+                        "involved"
+                    };
+                    merge_observation(&mut merged, review_item_to_observed(it, reason));
+                }
+            }
+            if let Ok(res) = self.get_notifications(notif_since).await {
+                notif_poll_interval = res.poll_interval;
+                notif_last_modified = res.last_modified;
+                for pr in res.items {
+                    merge_observation(&mut merged, pr);
+                }
+            }
+        }
+
+        // Saved watches (work even where the viewer isn't a reviewer).
+        for w in watches {
+            if let Ok((items, total)) = self.search_prs_total(&w.query).await {
+                let returned = items.len();
+                let label = format!("watching:{}", w.label);
+                for item in items.into_iter().take(per_watch_cap) {
+                    if let Some(pr) = search_item_to_observed(item, label.clone()) {
+                        merge_observation(&mut merged, pr);
+                    }
+                }
+                let shown = per_watch_cap.min(returned);
+                let dropped = (total as usize).saturating_sub(shown);
+                if dropped > 0 {
+                    truncated.insert(w.label.clone(), dropped as u32);
+                }
+            }
+        }
+
+        CollectedActivity {
+            observations: merged.into_values().collect(),
+            truncated,
+            notif_poll_interval,
+            notif_last_modified,
+        }
+    }
+}
+
+/// Result of a notifications fetch, carrying the conditional-request metadata
+/// callers need to poll politely.
+pub struct NotificationsResult {
+    pub items: Vec<crate::activity::ObservedPr>,
+    pub poll_interval: Option<u64>,
+    pub last_modified: Option<String>,
+}
+
+/// The merged activity set plus notification scheduling metadata.
+pub struct CollectedActivity {
+    pub observations: Vec<crate::activity::ObservedPr>,
+    pub truncated: HashMap<String, u32>,
+    pub notif_poll_interval: Option<u64>,
+    pub notif_last_modified: Option<String>,
 }

--- a/app/src-tauri/crates/core/src/lib.rs
+++ b/app/src-tauri/crates/core/src/lib.rs
@@ -2,6 +2,7 @@
 //! `marrow` CLI: GitHub client, fetch/diff pipeline, AI classification, config,
 //! and local caching. No Tauri, no UI.
 
+pub mod activity;
 pub mod ai;
 pub mod bedrock;
 pub mod checks_dismiss;
@@ -15,3 +16,4 @@ pub mod prompts;
 pub mod session;
 pub mod types;
 pub mod viewed_state;
+pub mod watches;

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -122,6 +122,10 @@ pub struct Settings {
     /// reported as "+N more". Useful to raise for org-wide watches.
     #[serde(default = "default_per_watch_cap")]
     pub activity_per_watch_cap: u64,
+    /// Whether the floating mini-player auto-shows when the main window loses
+    /// focus. The widget's ✕ turns this off; the Settings checkbox turns it on.
+    #[serde(default = "default_true")]
+    pub activity_mini_player: bool,
 }
 
 fn default_true() -> bool {

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -118,10 +118,18 @@ pub struct Settings {
     pub show_ai_notes: bool,
     #[serde(default = "default_all")]
     pub hunk_filter: String,
+    /// Max PRs the activity mini-player surfaces per watch; the rest are
+    /// reported as "+N more". Useful to raise for org-wide watches.
+    #[serde(default = "default_per_watch_cap")]
+    pub activity_per_watch_cap: u64,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_per_watch_cap() -> u64 {
+    50
 }
 
 fn default_split() -> String {

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -123,7 +123,7 @@ pub struct Settings {
     #[serde(default = "default_per_watch_cap")]
     pub activity_per_watch_cap: u64,
     /// Whether the floating mini-player auto-shows when the main window loses
-    /// focus. The widget's ✕ turns this off; the Settings checkbox turns it on.
+    /// focus. The widget's ✕ turns this off; the dock's ⧉ toggle turns it on.
     #[serde(default = "default_true")]
     pub activity_mini_player: bool,
 }

--- a/app/src-tauri/crates/core/src/watches.rs
+++ b/app/src-tauri/crates/core/src/watches.rs
@@ -1,0 +1,51 @@
+//! User-defined "watches": saved GitHub searches that surface PRs the user
+//! cares about — including repos/orgs where they are *not* a requested
+//! reviewer. Stored as a JSON sidecar in the config dir (the flat key=value
+//! `config` file can't represent a list of structured entries).
+
+use crate::config::app_config_dir;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+/// A single saved GitHub search. `query` is raw GitHub search syntax, e.g.
+/// `is:pr is:open repo:acme/web -is:draft`.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Watch {
+    pub id: String,
+    pub label: String,
+    pub query: String,
+}
+
+fn watches_path() -> PathBuf {
+    app_config_dir().join("watches.json")
+}
+
+/// Load the saved watches. Returns an empty list if none are configured yet
+/// (a missing or unparseable file is treated as "no watches").
+pub fn load_watches() -> Vec<Watch> {
+    let path = watches_path();
+    let Ok(content) = fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+pub fn save_watches(watches: &[Watch]) -> Result<(), String> {
+    let path = watches_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("Failed to create config dir: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(watches)
+        .map_err(|e| format!("Failed to serialize watches: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write watches: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        let _ = fs::set_permissions(&path, perms);
+    }
+
+    Ok(())
+}

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -196,6 +196,15 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
     Ok(())
 }
 
+/// Toggle whether the floating mini-player auto-shows when Marrow is in the
+/// background (the in-app dock's toggle writes this).
+#[command]
+pub fn set_mini_player_enabled(enabled: bool) -> Result<(), String> {
+    let mut settings = load_settings();
+    settings.activity_mini_player = enabled;
+    save_settings_to_disk(&settings)
+}
+
 /// Dismiss the floating mini-player from its own ✕: persistently disable
 /// auto-show (so navigating away won't bring it back), close the window, and on
 /// macOS hide the app so focus returns to whatever the user was in — rather

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -138,22 +138,36 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
 
 /// Build the floating mini-player window: a frameless, transparent,
 /// always-on-top, resizable webview rendering `widget.html`.
+///
+/// Built hidden so we can restore the user's last size/position (via
+/// tauri-plugin-window-state) before showing — otherwise it would flash at the
+/// default geometry first. The caller shows it.
 fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
-    WebviewWindowBuilder::new(app, "activity-widget", WebviewUrl::App("widget.html".into()))
-        .title("Marrow Activity")
-        .inner_size(340.0, 460.0)
-        .min_inner_size(210.0, 132.0)
-        .resizable(true)
-        .decorations(false)
-        .transparent(true)
-        // macOS draws a rectangular shadow around the full (square) window
-        // bounds, which shows as a square contour behind the rounded panel.
-        // Disable it and let the panel's own CSS box-shadow provide the look.
-        .shadow(false)
-        .always_on_top(true)
-        .build()
-        .map_err(|e| format!("Failed to open activity window: {}", e))?;
+    use tauri_plugin_window_state::{StateFlags, WindowExt};
+    let win = WebviewWindowBuilder::new(
+        app,
+        "activity-widget",
+        WebviewUrl::App("widget.html".into()),
+    )
+    .title("Marrow Activity")
+    .inner_size(340.0, 460.0)
+    .min_inner_size(210.0, 132.0)
+    .resizable(true)
+    .decorations(false)
+    .transparent(true)
+    // macOS draws a rectangular shadow around the full (square) window
+    // bounds, which shows as a square contour behind the rounded panel.
+    // Disable it and let the panel's own CSS box-shadow provide the look.
+    .shadow(false)
+    .always_on_top(true)
+    .visible(false)
+    .build()
+    .map_err(|e| format!("Failed to open activity window: {}", e))?;
+
+    // Restore the last-saved size & position before revealing it.
+    let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
+    win.show().map_err(|e| e.to_string())?;
     Ok(())
 }
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -142,7 +142,7 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
 /// Built hidden so we can restore the user's last size/position (via
 /// tauri-plugin-window-state) before showing — otherwise it would flash at the
 /// default geometry first. The caller shows it.
-fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
+pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
     use tauri_plugin_window_state::{StateFlags, WindowExt};
     let win = WebviewWindowBuilder::new(

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -136,34 +136,45 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
     activity::save_activity_store(&store)
 }
 
-/// Open (or focus) the floating mini-player window: a frameless, transparent,
+/// Build the floating mini-player window: a frameless, transparent,
 /// always-on-top, resizable webview rendering `widget.html`.
+fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
+    use tauri::{WebviewUrl, WebviewWindowBuilder};
+    WebviewWindowBuilder::new(app, "activity-widget", WebviewUrl::App("widget.html".into()))
+        .title("Marrow Activity")
+        .inner_size(340.0, 460.0)
+        .min_inner_size(210.0, 132.0)
+        .resizable(true)
+        .decorations(false)
+        .transparent(true)
+        // macOS draws a rectangular shadow around the full (square) window
+        // bounds, which shows as a square contour behind the rounded panel.
+        // Disable it and let the panel's own CSS box-shadow provide the look.
+        .shadow(false)
+        .always_on_top(true)
+        .build()
+        .map_err(|e| format!("Failed to open activity window: {}", e))?;
+    Ok(())
+}
+
+/// Show or hide the floating mini-player. The main window drives this from its
+/// own visibility (Page Visibility API): the floating window is shown only when
+/// the main window is hidden/minimized, and hidden when it's visible — so the
+/// two are never on screen at once. Creates the window on first show.
 #[command]
-pub fn open_activity_window(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
-    if let Some(win) = app.get_webview_window("activity-widget") {
-        let _ = win.show();
-        let _ = win.set_focus();
-        return Ok(());
+pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
+    use tauri::Manager;
+    match app.get_webview_window("activity-widget") {
+        Some(win) => {
+            if visible {
+                win.show().map_err(|e| e.to_string())?;
+            } else {
+                win.hide().map_err(|e| e.to_string())?;
+            }
+        }
+        None if visible => build_activity_window(&app)?,
+        None => {}
     }
-    WebviewWindowBuilder::new(
-        &app,
-        "activity-widget",
-        WebviewUrl::App("widget.html".into()),
-    )
-    .title("Marrow Activity")
-    .inner_size(340.0, 460.0)
-    .min_inner_size(210.0, 132.0)
-    .resizable(true)
-    .decorations(false)
-    .transparent(true)
-    // macOS draws a rectangular shadow around the full (square) window bounds,
-    // which shows as a square contour behind the rounded panel. Disable it and
-    // let the panel's own CSS box-shadow provide the floating look.
-    .shadow(false)
-    .always_on_top(true)
-    .build()
-    .map_err(|e| format!("Failed to open activity window: {}", e))?;
     Ok(())
 }
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -164,6 +164,10 @@ fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
 #[command]
 pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
     use tauri::Manager;
+    // Respect the user's opt-out: never auto-show when the feature is disabled.
+    if visible && !load_settings().activity_mini_player {
+        return Ok(());
+    }
     match app.get_webview_window("activity-widget") {
         Some(win) => {
             if visible {
@@ -174,6 +178,26 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
         }
         None if visible => build_activity_window(&app)?,
         None => {}
+    }
+    Ok(())
+}
+
+/// Dismiss the floating mini-player from its own ✕: persistently disable
+/// auto-show (so navigating away won't bring it back), close the window, and on
+/// macOS hide the app so focus returns to whatever the user was in — rather
+/// than yanking them into the main Marrow window. Re-enable via Settings.
+#[command]
+pub fn dismiss_mini_player(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri::Manager;
+    let mut settings = load_settings();
+    settings.activity_mini_player = false;
+    let _ = save_settings_to_disk(&settings);
+    if let Some(win) = app.get_webview_window("activity-widget") {
+        let _ = win.close();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.hide();
     }
     Ok(())
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -23,11 +23,6 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
-    // Last time the user actually touched the floating mini-player (pointer
-    // move/down, or a window move/resize). Lets the visibility poll tell
-    // "you're interacting with the panel" from "macOS just re-focused it on a
-    // Cmd+Tab back to the app", so the panel hides on return either way.
-    pub widget_interacted_at: Mutex<Option<std::time::Instant>>,
 }
 
 fn github_client() -> GithubClient {
@@ -173,23 +168,6 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
     // Restore the last-saved size & position before revealing it.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
 
-    // Treat a window move/resize as a fresh interaction (edge-resize produces no
-    // webview pointer events, so the frontend can't report it).
-    {
-        use tauri::Manager;
-        let ev_app = app.clone();
-        win.on_window_event(move |event| {
-            if matches!(
-                event,
-                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_)
-            ) {
-                if let Ok(mut t) = ev_app.state::<AppState>().widget_interacted_at.lock() {
-                    *t = Some(std::time::Instant::now());
-                }
-            }
-        });
-    }
-
     // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
     // doesn't activate Marrow (which the app-active poll treats as "you're back"
     // and hides). Cmd+Tab / opening a PR still activate the app → still hide.
@@ -262,17 +240,6 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
             None => {}
         }
         Ok(())
-    }
-}
-
-/// Record that the user just touched the floating mini-player (the floating
-/// widget calls this on pointer move/down). The visibility poll uses recency of
-/// this to keep the panel up while you're using it, but hide it when you
-/// Cmd+Tab back to the app without touching it.
-#[command]
-pub fn mark_widget_interaction(state: State<AppState>) {
-    if let Ok(mut t) = state.widget_interacted_at.lock() {
-        *t = Some(std::time::Instant::now());
     }
 }
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -23,10 +23,6 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
-    // Last time the floating mini-player was moved or resized. The visibility
-    // poll keeps the panel up briefly after a move/resize so a click-to-drag
-    // isn't yanked away by the auto-hide.
-    pub widget_moved_at: Mutex<Option<std::time::Instant>>,
 }
 
 fn github_client() -> GithubClient {
@@ -171,23 +167,6 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
 
     // Restore the last-saved size & position before revealing it.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
-
-    // Note window moves/resizes so the visibility poll can keep the panel up
-    // while you're dragging/resizing it (these fire reliably, Rust-side).
-    {
-        use tauri::Manager;
-        let ev_app = app.clone();
-        win.on_window_event(move |event| {
-            if matches!(
-                event,
-                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_)
-            ) {
-                if let Ok(mut t) = ev_app.state::<AppState>().widget_moved_at.lock() {
-                    *t = Some(std::time::Instant::now());
-                }
-            }
-        });
-    }
 
     // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
     // doesn't activate Marrow (which the app-active poll treats as "you're back"

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -180,6 +180,10 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
         match win.to_panel() {
             Ok(panel) => {
                 panel.set_style_mask(NONACTIVATING_RESIZABLE);
+                // NSPanels are released-when-closed by default; turn that off so a
+                // stray close() can't deallocate it out from under Tauri (which
+                // aborts with a foreign-exception runtime error).
+                panel.set_released_when_closed(false);
                 // order_front_regardless (NOT show()/makeKeyAndOrderFront): showing
                 // it must not make it key, or activation gets pulled back to Marrow
                 // and the app-active poll flip-flops (flashing) while you're away.
@@ -253,21 +257,34 @@ pub fn set_mini_player_enabled(enabled: bool) -> Result<(), String> {
 }
 
 /// Dismiss the floating mini-player from its own ✕: persistently disable
-/// auto-show (so navigating away won't bring it back), close the window, and on
-/// macOS hide the app so focus returns to whatever the user was in — rather
-/// than yanking them into the main Marrow window. Re-enable via Settings.
+/// auto-show (so navigating away won't bring it back) and hide the window. On
+/// macOS, hide the app too so focus returns to whatever the user was in rather
+/// than the main Marrow window. Re-enable via the dock toggle.
+///
+/// We HIDE the panel (order_out), not close()/destroy it: an NSPanel is released
+/// when closed by default, and destroying it while Tauri still holds a reference
+/// raises an Objective-C exception that aborts the process. The disabled setting
+/// keeps it from reappearing; the hidden panel is reused if re-enabled.
 #[command]
 pub fn dismiss_mini_player(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::Manager;
     let mut settings = load_settings();
     settings.activity_mini_player = false;
     let _ = save_settings_to_disk(&settings);
-    if let Some(win) = app.get_webview_window("activity-widget") {
-        let _ = win.close();
-    }
+
     #[cfg(target_os = "macos")]
     {
+        use tauri_nspanel::ManagerExt;
+        if let Ok(panel) = app.get_webview_panel("activity-widget") {
+            panel.order_out(None);
+        }
         let _ = app.hide();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        use tauri::Manager;
+        if let Some(win) = app.get_webview_window("activity-widget") {
+            let _ = win.hide();
+        }
     }
     Ok(())
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -180,7 +180,10 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
         match win.to_panel() {
             Ok(panel) => {
                 panel.set_style_mask(NONACTIVATING_RESIZABLE);
-                panel.show();
+                // order_front_regardless (NOT show()/makeKeyAndOrderFront): showing
+                // it must not make it key, or activation gets pulled back to Marrow
+                // and the app-active poll flip-flops (flashing) while you're away.
+                panel.order_front_regardless();
                 return Ok(());
             }
             Err(_) => {
@@ -199,23 +202,45 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
 /// two are never on screen at once. Creates the window on first show.
 #[command]
 pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
-    use tauri::Manager;
     // Respect the user's opt-out: never auto-show when the feature is disabled.
     if visible && !load_settings().activity_mini_player {
         return Ok(());
     }
-    match app.get_webview_window("activity-widget") {
-        Some(win) => {
+
+    // macOS: drive the NSPanel directly. order_front_regardless/order_out never
+    // make the panel key, so showing it while you're in another app can't pull
+    // activation back to Marrow (which made the app-active poll flip-flop).
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_nspanel::ManagerExt;
+        if let Ok(panel) = app.get_webview_panel("activity-widget") {
             if visible {
-                win.show().map_err(|e| e.to_string())?;
+                panel.order_front_regardless();
             } else {
-                win.hide().map_err(|e| e.to_string())?;
+                panel.order_out(None);
             }
+        } else if visible {
+            build_activity_window(&app)?;
         }
-        None if visible => build_activity_window(&app)?,
-        None => {}
+        return Ok(());
     }
-    Ok(())
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        use tauri::Manager;
+        match app.get_webview_window("activity-widget") {
+            Some(win) => {
+                if visible {
+                    win.show().map_err(|e| e.to_string())?;
+                } else {
+                    win.hide().map_err(|e| e.to_string())?;
+                }
+            }
+            None if visible => build_activity_window(&app)?,
+            None => {}
+        }
+        Ok(())
+    }
 }
 
 /// Toggle whether the floating mini-player auto-shows when Marrow is in the

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -7,6 +7,8 @@ use marrow_core::manifest_cache::{self, CachedPrInfo};
 use marrow_core::session::{self, SessionState};
 use marrow_core::dismissed_highlights::{self, DismissedHighlights};
 use marrow_core::viewed_state::{self, ViewedFileState};
+use marrow_core::activity::{self, Observed};
+use marrow_core::watches::{self, Watch};
 use std::collections::HashMap;
 use std::fs;
 use std::sync::Mutex;
@@ -109,6 +111,73 @@ pub async fn fetch_review_requests(
     github
         .get_review_requests(&username, &cutoff_date, fetch_recent)
         .await
+}
+
+// ---- Mini-player: PR activity widget ----
+
+#[command]
+pub fn get_watches() -> Vec<Watch> {
+    watches::load_watches()
+}
+
+#[command]
+pub fn save_watches(watches: Vec<Watch>) -> Result<(), String> {
+    marrow_core::watches::save_watches(&watches)
+}
+
+/// Acknowledge a PR in the activity feed: store its current observable state so
+/// future polls diff against it (clearing the unread badge). The frontend sends
+/// the fields it has from the feed item; sha/comment-count it doesn't track stay
+/// `None` and simply don't contribute to future diffs.
+#[command]
+pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
+    let mut store = activity::load_activity_store();
+    activity::mark_seen(&mut store, &pr_url, observed, activity::now_rfc3339());
+    activity::save_activity_store(&store)
+}
+
+/// Open (or focus) the floating mini-player window: a frameless, transparent,
+/// always-on-top, resizable webview rendering `widget.html`.
+#[command]
+pub fn open_activity_window(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri::{Manager, WebviewUrl, WebviewWindowBuilder};
+    if let Some(win) = app.get_webview_window("activity-widget") {
+        let _ = win.show();
+        let _ = win.set_focus();
+        return Ok(());
+    }
+    WebviewWindowBuilder::new(
+        &app,
+        "activity-widget",
+        WebviewUrl::App("widget.html".into()),
+    )
+    .title("Marrow Activity")
+    .inner_size(340.0, 460.0)
+    .min_inner_size(210.0, 132.0)
+    .resizable(true)
+    .decorations(false)
+    .transparent(true)
+    // macOS draws a rectangular shadow around the full (square) window bounds,
+    // which shows as a square contour behind the rounded panel. Disable it and
+    // let the panel's own CSS box-shadow provide the floating look.
+    .shadow(false)
+    .always_on_top(true)
+    .build()
+    .map_err(|e| format!("Failed to open activity window: {}", e))?;
+    Ok(())
+}
+
+/// Route a PR-open from the floating widget back to the main window: the main
+/// window already listens for `deep-link-open` (the same channel the browser
+/// deep link uses), so we just re-emit and focus it.
+#[command]
+pub fn open_pr_in_main(app: tauri::AppHandle, pr_ref: String) -> Result<(), String> {
+    use tauri::{Emitter, Manager};
+    let _ = app.emit("deep-link-open", &pr_ref);
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.set_focus();
+    }
+    Ok(())
 }
 
 #[command]

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -23,6 +23,11 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
+    // Last time the user actually touched the floating mini-player (pointer
+    // move/down, or a window move/resize). Lets the visibility poll tell
+    // "you're interacting with the panel" from "macOS just re-focused it on a
+    // Cmd+Tab back to the app", so the panel hides on return either way.
+    pub widget_interacted_at: Mutex<Option<std::time::Instant>>,
 }
 
 fn github_client() -> GithubClient {
@@ -168,6 +173,23 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
     // Restore the last-saved size & position before revealing it.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
 
+    // Treat a window move/resize as a fresh interaction (edge-resize produces no
+    // webview pointer events, so the frontend can't report it).
+    {
+        use tauri::Manager;
+        let ev_app = app.clone();
+        win.on_window_event(move |event| {
+            if matches!(
+                event,
+                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_)
+            ) {
+                if let Ok(mut t) = ev_app.state::<AppState>().widget_interacted_at.lock() {
+                    *t = Some(std::time::Instant::now());
+                }
+            }
+        });
+    }
+
     // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
     // doesn't activate Marrow (which the app-active poll treats as "you're back"
     // and hides). Cmd+Tab / opening a PR still activate the app → still hide.
@@ -240,6 +262,17 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
             None => {}
         }
         Ok(())
+    }
+}
+
+/// Record that the user just touched the floating mini-player (the floating
+/// widget calls this on pointer move/down). The visibility poll uses recency of
+/// this to keep the panel up while you're using it, but hide it when you
+/// Cmd+Tab back to the app without touching it.
+#[command]
+pub fn mark_widget_interaction(state: State<AppState>) {
+    if let Ok(mut t) = state.widget_interacted_at.lock() {
+        *t = Some(std::time::Instant::now());
     }
 }
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -139,9 +139,11 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
 /// Build the floating mini-player window: a frameless, transparent,
 /// always-on-top, resizable webview rendering `widget.html`.
 ///
-/// Built hidden so we can restore the user's last size/position (via
-/// tauri-plugin-window-state) before showing — otherwise it would flash at the
-/// default geometry first. The caller shows it.
+/// Create the floating mini-player window, left HIDDEN. Built eagerly at
+/// startup (and on enable) so that the first show is never a window-creation —
+/// creating a webview window activates the app, which would yank you back to
+/// Marrow on your first Cmd+Tab away. The caller reveals it via
+/// `set_activity_window_visible`.
 pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String> {
     use tauri::{WebviewUrl, WebviewWindowBuilder};
     use tauri_plugin_window_state::{StateFlags, WindowExt};
@@ -165,38 +167,27 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
     .build()
     .map_err(|e| format!("Failed to open activity window: {}", e))?;
 
-    // Restore the last-saved size & position before revealing it.
+    // Restore the last-saved size & position so it reveals at the right geometry.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
 
     // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
-    // doesn't activate Marrow (which the app-active poll treats as "you're back"
-    // and hides). Cmd+Tab / opening a PR still activate the app → still hide.
+    // doesn't activate Marrow (so interacting with it never pulls focus from the
+    // app you're in). It stays hidden here; the caller orders it front.
     #[cfg(target_os = "macos")]
     {
         use tauri_nspanel::WebviewWindowExt;
         // NSWindowStyleMask bits: Resizable (1<<3) keeps edge-resize; Borderless
         // (0) = frameless; NonactivatingPanel (1<<7) is the key bit.
         const NONACTIVATING_RESIZABLE: i32 = (1 << 3) | (1 << 7); // 8 | 128 = 136
-        match win.to_panel() {
-            Ok(panel) => {
-                panel.set_style_mask(NONACTIVATING_RESIZABLE);
-                // NSPanels are released-when-closed by default; turn that off so a
-                // stray close() can't deallocate it out from under Tauri (which
-                // aborts with a foreign-exception runtime error).
-                panel.set_released_when_closed(false);
-                // order_front_regardless (NOT show()/makeKeyAndOrderFront): showing
-                // it must not make it key, or activation gets pulled back to Marrow
-                // and the app-active poll flip-flops (flashing) while you're away.
-                panel.order_front_regardless();
-                return Ok(());
-            }
-            Err(_) => {
-                // Fall through to a normal window show if conversion fails.
-            }
+        if let Ok(panel) = win.to_panel() {
+            panel.set_style_mask(NONACTIVATING_RESIZABLE);
+            // NSPanels are released-when-closed by default; turn that off so a
+            // stray close() can't deallocate it out from under Tauri (which
+            // aborts with a foreign-exception runtime error).
+            panel.set_released_when_closed(false);
         }
     }
 
-    win.show().map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -217,14 +208,16 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
     #[cfg(target_os = "macos")]
     {
         use tauri_nspanel::ManagerExt;
+        // Normally pre-created at startup; build lazily only as a fallback.
+        if visible && app.get_webview_panel("activity-widget").is_err() {
+            build_activity_window(&app)?;
+        }
         if let Ok(panel) = app.get_webview_panel("activity-widget") {
             if visible {
                 panel.order_front_regardless();
             } else {
                 panel.order_out(None);
             }
-        } else if visible {
-            build_activity_window(&app)?;
         }
         return Ok(());
     }
@@ -232,16 +225,15 @@ pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Resu
     #[cfg(not(target_os = "macos"))]
     {
         use tauri::Manager;
-        match app.get_webview_window("activity-widget") {
-            Some(win) => {
-                if visible {
-                    win.show().map_err(|e| e.to_string())?;
-                } else {
-                    win.hide().map_err(|e| e.to_string())?;
-                }
+        if visible && app.get_webview_window("activity-widget").is_none() {
+            build_activity_window(&app)?;
+        }
+        if let Some(win) = app.get_webview_window("activity-widget") {
+            if visible {
+                win.show().map_err(|e| e.to_string())?;
+            } else {
+                win.hide().map_err(|e| e.to_string())?;
             }
-            None if visible => build_activity_window(&app)?,
-            None => {}
         }
         Ok(())
     }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -167,6 +167,28 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
 
     // Restore the last-saved size & position before revealing it.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
+
+    // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
+    // doesn't activate Marrow (which the app-active poll treats as "you're back"
+    // and hides). Cmd+Tab / opening a PR still activate the app → still hide.
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_nspanel::WebviewWindowExt;
+        // NSWindowStyleMask bits: Resizable (1<<3) keeps edge-resize; Borderless
+        // (0) = frameless; NonactivatingPanel (1<<7) is the key bit.
+        const NONACTIVATING_RESIZABLE: i32 = (1 << 3) | (1 << 7); // 8 | 128 = 136
+        match win.to_panel() {
+            Ok(panel) => {
+                panel.set_style_mask(NONACTIVATING_RESIZABLE);
+                panel.show();
+                return Ok(());
+            }
+            Err(_) => {
+                // Fall through to a normal window show if conversion fails.
+            }
+        }
+    }
+
     win.show().map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -136,9 +136,6 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
     activity::save_activity_store(&store)
 }
 
-/// Build the floating mini-player window: a frameless, transparent,
-/// always-on-top, resizable webview rendering `widget.html`.
-///
 /// Create the floating mini-player window, left HIDDEN. Built eagerly at
 /// startup (and on enable) so that the first show is never a window-creation —
 /// creating a webview window activates the app, which would yank you back to
@@ -191,10 +188,10 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
     Ok(())
 }
 
-/// Show or hide the floating mini-player. The main window drives this from its
-/// own visibility (Page Visibility API): the floating window is shown only when
-/// the main window is hidden/minimized, and hidden when it's visible — so the
-/// two are never on screen at once. Creates the window on first show.
+/// Show or hide the floating mini-player. This is the single actuator; callers
+/// decide *when*: the macOS app-active poll shows it when you leave Marrow, and
+/// the main window hides it when it regains focus (see App.tsx). The panel is
+/// pre-created at startup, so the lazy build here is only a fallback.
 #[command]
 pub fn set_activity_window_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
     // Respect the user's opt-out: never auto-show when the feature is disabled.
@@ -259,9 +256,8 @@ pub fn set_mini_player_enabled(enabled: bool) -> Result<(), String> {
 /// keeps it from reappearing; the hidden panel is reused if re-enabled.
 #[command]
 pub fn dismiss_mini_player(app: tauri::AppHandle) -> Result<(), String> {
-    let mut settings = load_settings();
-    settings.activity_mini_player = false;
-    let _ = save_settings_to_disk(&settings);
+    // Same persistent opt-out as the dock toggle, plus hide the window.
+    let _ = set_mini_player_enabled(false);
 
     #[cfg(target_os = "macos")]
     {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -23,6 +23,10 @@ pub struct AppState {
     // replay; after that point, hot-open emits suffice and we skip buffering
     // to avoid replaying stale URLs on the next cold-start.
     pub frontend_ready: Mutex<bool>,
+    // Last time the floating mini-player was moved or resized. The visibility
+    // poll keeps the panel up briefly after a move/resize so a click-to-drag
+    // isn't yanked away by the auto-hide.
+    pub widget_moved_at: Mutex<Option<std::time::Instant>>,
 }
 
 fn github_client() -> GithubClient {
@@ -167,6 +171,23 @@ pub(crate) fn build_activity_window(app: &tauri::AppHandle) -> Result<(), String
 
     // Restore the last-saved size & position before revealing it.
     let _ = win.restore_state(StateFlags::POSITION | StateFlags::SIZE);
+
+    // Note window moves/resizes so the visibility poll can keep the panel up
+    // while you're dragging/resizing it (these fire reliably, Rust-side).
+    {
+        use tauri::Manager;
+        let ev_app = app.clone();
+        win.on_window_event(move |event| {
+            if matches!(
+                event,
+                tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_)
+            ) {
+                if let Ok(mut t) = ev_app.state::<AppState>().widget_moved_at.lock() {
+                    *t = Some(std::time::Instant::now());
+                }
+            }
+        });
+    }
 
     // Make it a non-activating NSPanel so clicking/dragging/resizing the widget
     // doesn't activate Marrow (which the app-active poll treats as "you're back"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -13,8 +13,8 @@ use tauri_plugin_deep_link::DeepLinkExt;
 /// Default/min seconds between activity polls. GitHub's notifications API floor
 /// is 60s; we honor its `X-Poll-Interval` header above this when it asks for more.
 const ACTIVITY_POLL_SECS: u64 = 60;
-/// Max PRs surfaced per watch; the rest are reported via the payload's `truncated`.
-const ACTIVITY_PER_WATCH_CAP: usize = 50;
+/// Fallback per-watch cap when the configured value is 0/unset.
+const DEFAULT_PER_WATCH_CAP: usize = 50;
 
 /// One activity poll: build a GitHub client from the saved token, collect
 /// involved PRs + watch results, diff against the seen-state, and broadcast the
@@ -28,8 +28,12 @@ async fn poll_activity_once(
     let token = marrow_core::config::resolve_github_token(&settings)?;
     let client = marrow_core::github::GithubClient::new(Some(token));
     let watches = marrow_core::watches::load_watches();
+    let cap = match settings.activity_per_watch_cap {
+        0 => DEFAULT_PER_WATCH_CAP,
+        n => n as usize,
+    };
     let collected = client
-        .collect_activity(&watches, ACTIVITY_PER_WATCH_CAP, notif_since.as_deref())
+        .collect_activity(&watches, cap, notif_since.as_deref())
         .await;
     let store = marrow_core::activity::load_activity_store();
     let payload = marrow_core::activity::compute_activity(

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
+            widget_interacted_at: Mutex::new(None),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -188,16 +189,22 @@ pub fn run() {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
-                            // The widget panel itself being focused means the user is
-                            // interacting with it (drag/resize/✕) — clicking a webview
-                            // activates the app, but we must NOT hide while they're in
-                            // the panel. Hide only when Marrow is active AND the panel
-                            // is not the focused window (i.e. they returned to main).
+                            // Keep the panel up only while you're actually using it:
+                            // it's the focused window AND you touched it recently.
+                            // That distinguishes real interaction (drag/resize/✕ —
+                            // which activate the app) from macOS merely re-focusing the
+                            // panel when you Cmd+Tab back; in the latter case there's no
+                            // recent touch, so the panel hides on return.
                             let panel_focused = h
                                 .get_webview_window("activity-widget")
                                 .map(|w| w.is_focused().unwrap_or(false))
                                 .unwrap_or(false);
-                            let want_visible = !active || panel_focused;
+                            let touched_recently = h
+                                .try_state::<commands::AppState>()
+                                .and_then(|s| s.widget_interacted_at.lock().ok().and_then(|t| *t))
+                                .map(|t| t.elapsed() < std::time::Duration::from_millis(1500))
+                                .unwrap_or(false);
+                            let want_visible = !active || (panel_focused && touched_recently);
                             let code = if want_visible { 1 } else { 2 };
                             if last.swap(code, Ordering::Relaxed) != code {
                                 let _ = commands::set_activity_window_visible(h, want_visible);
@@ -246,6 +253,7 @@ pub fn run() {
             commands::mark_pr_seen,
             commands::set_activity_window_visible,
             commands::set_mini_player_enabled,
+            commands::mark_widget_interaction,
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -197,6 +197,15 @@ pub fn run() {
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // macOS dock-icon reopen brings Marrow to the front without a
+            // webview focus event, so hide the floating mini-player here too.
+            if let tauri::RunEvent::Reopen { .. } = event {
+                if let Some(win) = app_handle.get_webview_window("activity-widget") {
+                    let _ = win.hide();
+                }
+            }
+        });
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -56,6 +56,13 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_deep_link::init())
+        // Persist/restore the floating mini-player's size & position. Scoped to
+        // the activity window only (the main window keeps its config default).
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_denylist(&["main"])
+                .build(),
+        )
         .on_menu_event(|app, event| {
             // Cmd+W / Cmd+T are routed to the frontend, which owns the tab model.
             // The frontend skips closing when a text field is focused. Cmd+Q has no

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -84,7 +84,6 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
-            widget_moved_at: Mutex::new(None),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -173,59 +172,30 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             {
                 use std::sync::atomic::{AtomicU8, Ordering};
-                use std::sync::Mutex as StdMutex;
-                use std::time::{Duration, Instant};
-                // How long after Marrow activates to wait before auto-hiding (gives
-                // you time to start a drag/resize), and how long a move/resize keeps
-                // the panel up after you stop.
-                const GRACE: Duration = Duration::from_millis(500);
                 let poll_handle = app.handle().clone();
-                let last_visible = std::sync::Arc::new(AtomicU8::new(0)); // 1 show, 2 hide
                 let was_active = std::sync::Arc::new(AtomicU8::new(0)); // 1 active, 2 inactive
-                let active_since = std::sync::Arc::new(StdMutex::new(None::<Instant>));
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         let h = poll_handle.clone();
-                        let lv = last_visible.clone();
                         let wa = was_active.clone();
-                        let asince = active_since.clone();
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
                             use objc2_app_kit::NSApplication;
-                            use tauri::Manager;
 
                             let Some(mtm) = MainThreadMarker::new() else {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
 
-                            // Stamp when Marrow (re)activated — starts the grace window.
+                            // SHOW the panel when you leave Marrow (active→inactive).
+                            // HIDING is driven by the main window gaining focus
+                            // (see App.tsx) — NOT by app-active — so clicking/dragging
+                            // the panel (which activates the app but does not focus the
+                            // main window) never hides it.
                             let acode = if active { 1 } else { 2 };
-                            if wa.swap(acode, Ordering::Relaxed) != 1 && acode == 1 {
-                                if let Ok(mut t) = asince.lock() {
-                                    *t = Some(Instant::now());
-                                }
-                            }
-
-                            let within = |i: Option<Instant>| {
-                                i.map(|i| i.elapsed() < GRACE).unwrap_or(false)
-                            };
-                            let in_grace = within(asince.lock().ok().and_then(|g| *g));
-                            let moved_recently = within(
-                                h.try_state::<commands::AppState>()
-                                    .and_then(|s| s.widget_moved_at.lock().ok().and_then(|g| *g)),
-                            );
-
-                            // Visible while away from Marrow, OR briefly after it
-                            // activates (room to grab the panel), OR while you're
-                            // moving/resizing it. Otherwise it hides shortly after you
-                            // return — regardless of cursor position or which window
-                            // macOS focused, so Cmd+Tab back always tucks it away.
-                            let want_visible = !active || in_grace || moved_recently;
-                            let vcode = if want_visible { 1 } else { 2 };
-                            if lv.swap(vcode, Ordering::Relaxed) != vcode {
-                                let _ = commands::set_activity_window_visible(h, want_visible);
+                            if wa.swap(acode, Ordering::Relaxed) == 1 && acode == 2 {
+                                let _ = commands::set_activity_window_visible(h, true);
                             }
                         });
                     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -48,7 +48,8 @@ pub fn run() {
     let args: Vec<String> = env::args().collect();
     let manifest_path = args.get(1).cloned();
 
-    tauri::Builder::default()
+    #[allow(unused_mut)]
+    let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
@@ -59,7 +60,14 @@ pub fn run() {
             tauri_plugin_window_state::Builder::default()
                 .with_denylist(&["main"])
                 .build(),
-        )
+        );
+    // Lets the activity window become a non-activating NSPanel (macOS only).
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder.plugin(tauri_nspanel::init());
+    }
+
+    builder
         .on_menu_event(|app, event| {
             // Cmd+W / Cmd+T are routed to the frontend, which owns the tab model.
             // The frontend skips closing when a text field is focused. Cmd+Q has no

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -156,6 +156,55 @@ pub fn run() {
                 }
             });
 
+            // macOS: drive the floating mini-player from the app-active state.
+            // App (re)activation (Cmd+Tab / dock) delivers no webview focus event
+            // and Page Visibility doesn't fire for occlusion, so focus-based
+            // logic can't catch it. Polling NSApplication.isActive on the main
+            // thread is the one reliable signal: show the widget while Marrow is
+            // NOT the active app, hide it once it is (unless the widget itself is
+            // focused, i.e. the user clicked into it to use it).
+            #[cfg(target_os = "macos")]
+            {
+                let poll_handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        let h = poll_handle.clone();
+                        let _ = poll_handle.run_on_main_thread(move || {
+                            use objc2::MainThreadMarker;
+                            use objc2_app_kit::NSApplication;
+                            use tauri::Manager;
+
+                            let Some(mtm) = MainThreadMarker::new() else {
+                                return;
+                            };
+                            let active = NSApplication::sharedApplication(mtm).isActive();
+                            let enabled =
+                                marrow_core::config::load_settings().activity_mini_player;
+
+                            match h.get_webview_window("activity-widget") {
+                                Some(win) => {
+                                    let visible = win.is_visible().unwrap_or(false);
+                                    let focused = win.is_focused().unwrap_or(false);
+                                    if active {
+                                        if visible && !focused {
+                                            let _ = win.hide();
+                                        }
+                                    } else if enabled && !visible {
+                                        let _ = win.show();
+                                    }
+                                }
+                                None => {
+                                    if !active && enabled {
+                                        let _ = commands::build_activity_window(&h);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                });
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -198,15 +247,6 @@ pub fn run() {
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])
-        .build(tauri::generate_context!())
-        .expect("error while building tauri application")
-        .run(|app_handle, event| {
-            // macOS dock-icon reopen brings Marrow to the front without a
-            // webview focus event, so hide the floating mini-player here too.
-            if let tauri::RunEvent::Reopen { .. } = event {
-                if let Some(win) = app_handle.get_webview_window("activity-widget") {
-                    let _ = win.hide();
-                }
-            }
-        });
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -174,45 +174,52 @@ pub fn run() {
                 use std::sync::atomic::{AtomicU8, Ordering};
                 let poll_handle = app.handle().clone();
                 let last_visible = std::sync::Arc::new(AtomicU8::new(0)); // 1 show, 2 hide
-                let last_active = std::sync::Arc::new(AtomicU8::new(0)); // 1 active, 2 inactive
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         let h = poll_handle.clone();
                         let lv = last_visible.clone();
-                        let la = last_active.clone();
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
-                            use objc2_app_kit::NSApplication;
+                            use objc2_app_kit::{NSApplication, NSEvent, NSWindow};
                             use tauri::Manager;
-                            use tauri_nspanel::ManagerExt;
 
                             let Some(mtm) = MainThreadMarker::new() else {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
 
-                            // On the active→inactive edge (you left Marrow), drop the
-                            // panel's key status so macOS restores the MAIN window — not
-                            // the panel — as key when you return. Otherwise, once you've
-                            // clicked the panel it stays the app's key window and a
-                            // Cmd+Tab back re-focuses it, leaving it stuck on screen.
-                            let acode = if active { 1 } else { 2 };
-                            if la.swap(acode, Ordering::Relaxed) == 1 && acode == 2 {
-                                if let Ok(panel) = h.get_webview_panel("activity-widget") {
-                                    panel.resign_key_window();
-                                }
-                            }
-
-                            // Keep the panel up while it's the focused window (you're
-                            // dragging/resizing/clicking it — which activates the app);
-                            // hide it when Marrow is active and the panel isn't focused
-                            // (you've returned to the main window).
-                            let panel_focused = h
+                            // Is the cursor over the floating panel? A NATIVE check
+                            // (global mouse location vs the panel's frame) — it works
+                            // even while the app/panel is inactive, where the webview
+                            // gets no pointer events, and reading it in the poll is
+                            // race-free. This is what tells "you're using the panel"
+                            // (drag/resize/click — cursor on it) from "you've moved back
+                            // to the main window" (cursor off it).
+                            let mouse_over_panel = h
                                 .get_webview_window("activity-widget")
-                                .map(|w| w.is_focused().unwrap_or(false))
+                                .and_then(|win| {
+                                    let ns_ptr = win.ns_window().ok()?;
+                                    let ns_window: &NSWindow =
+                                        unsafe { &*(ns_ptr as *const NSWindow) };
+                                    let frame = ns_window.frame();
+                                    let mouse = NSEvent::mouseLocation();
+                                    let m = 6.0; // small margin so edge-resize counts
+                                    Some(
+                                        mouse.x >= frame.origin.x - m
+                                            && mouse.x
+                                                <= frame.origin.x + frame.size.width + m
+                                            && mouse.y >= frame.origin.y - m
+                                            && mouse.y
+                                                <= frame.origin.y + frame.size.height + m,
+                                    )
+                                })
                                 .unwrap_or(false);
-                            let want_visible = !active || panel_focused;
+
+                            // Show while away from Marrow, or while the cursor is on the
+                            // panel (you're using it). Hide once Marrow is active and the
+                            // cursor has left the panel (you've gone back to the app).
+                            let want_visible = !active || mouse_over_panel;
                             let vcode = if want_visible { 1 } else { 2 };
                             if lv.swap(vcode, Ordering::Relaxed) != vcode {
                                 let _ = commands::set_activity_window_visible(h, want_visible);

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -13,8 +13,6 @@ use tauri_plugin_deep_link::DeepLinkExt;
 /// Default/min seconds between activity polls. GitHub's notifications API floor
 /// is 60s; we honor its `X-Poll-Interval` header above this when it asks for more.
 const ACTIVITY_POLL_SECS: u64 = 60;
-/// Fallback per-watch cap when the configured value is 0/unset.
-const DEFAULT_PER_WATCH_CAP: usize = 50;
 
 /// One activity poll: build a GitHub client from the saved token, collect
 /// involved PRs + watch results, diff against the seen-state, and broadcast the
@@ -28,10 +26,9 @@ async fn poll_activity_once(
     let token = marrow_core::config::resolve_github_token(&settings)?;
     let client = marrow_core::github::GithubClient::new(Some(token));
     let watches = marrow_core::watches::load_watches();
-    let cap = match settings.activity_per_watch_cap {
-        0 => DEFAULT_PER_WATCH_CAP,
-        n => n as usize,
-    };
+    // Settings default to 50 and the UI clamps to >= 1; .max(1) is a cheap guard
+    // against a hand-edited 0.
+    let cap = (settings.activity_per_watch_cap as usize).max(1);
     let collected = client
         .collect_activity(&watches, cap, notif_since.as_deref())
         .await;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -84,7 +84,6 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
-            widget_interacted_at: Mutex::new(None),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -174,39 +173,48 @@ pub fn run() {
             {
                 use std::sync::atomic::{AtomicU8, Ordering};
                 let poll_handle = app.handle().clone();
-                let last_state = std::sync::Arc::new(AtomicU8::new(0)); // 0 unknown, 1 show, 2 hide
+                let last_visible = std::sync::Arc::new(AtomicU8::new(0)); // 1 show, 2 hide
+                let last_active = std::sync::Arc::new(AtomicU8::new(0)); // 1 active, 2 inactive
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         let h = poll_handle.clone();
-                        let last = last_state.clone();
+                        let lv = last_visible.clone();
+                        let la = last_active.clone();
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
                             use objc2_app_kit::NSApplication;
                             use tauri::Manager;
+                            use tauri_nspanel::ManagerExt;
 
                             let Some(mtm) = MainThreadMarker::new() else {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
-                            // Keep the panel up only while you're actually using it:
-                            // it's the focused window AND you touched it recently.
-                            // That distinguishes real interaction (drag/resize/✕ —
-                            // which activate the app) from macOS merely re-focusing the
-                            // panel when you Cmd+Tab back; in the latter case there's no
-                            // recent touch, so the panel hides on return.
+
+                            // On the active→inactive edge (you left Marrow), drop the
+                            // panel's key status so macOS restores the MAIN window — not
+                            // the panel — as key when you return. Otherwise, once you've
+                            // clicked the panel it stays the app's key window and a
+                            // Cmd+Tab back re-focuses it, leaving it stuck on screen.
+                            let acode = if active { 1 } else { 2 };
+                            if la.swap(acode, Ordering::Relaxed) == 1 && acode == 2 {
+                                if let Ok(panel) = h.get_webview_panel("activity-widget") {
+                                    panel.resign_key_window();
+                                }
+                            }
+
+                            // Keep the panel up while it's the focused window (you're
+                            // dragging/resizing/clicking it — which activates the app);
+                            // hide it when Marrow is active and the panel isn't focused
+                            // (you've returned to the main window).
                             let panel_focused = h
                                 .get_webview_window("activity-widget")
                                 .map(|w| w.is_focused().unwrap_or(false))
                                 .unwrap_or(false);
-                            let touched_recently = h
-                                .try_state::<commands::AppState>()
-                                .and_then(|s| s.widget_interacted_at.lock().ok().and_then(|t| *t))
-                                .map(|t| t.elapsed() < std::time::Duration::from_millis(1500))
-                                .unwrap_or(false);
-                            let want_visible = !active || (panel_focused && touched_recently);
-                            let code = if want_visible { 1 } else { 2 };
-                            if last.swap(code, Ordering::Relaxed) != code {
+                            let want_visible = !active || panel_focused;
+                            let vcode = if want_visible { 1 } else { 2 };
+                            if lv.swap(vcode, Ordering::Relaxed) != vcode {
                                 let _ = commands::set_activity_window_visible(h, want_visible);
                             }
                         });
@@ -253,7 +261,6 @@ pub fn run() {
             commands::mark_pr_seen,
             commands::set_activity_window_visible,
             commands::set_mini_player_enabled,
-            commands::mark_widget_interaction,
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -156,42 +156,6 @@ pub fn run() {
                 }
             });
 
-            // Hide the floating mini-player when Marrow becomes the active app
-            // (Cmd+Tab / dock click). That activation delivers no webview focus
-            // event — and Page Visibility doesn't fire for window occlusion —
-            // so the JS focus/visibility listeners can't catch it. We guard on
-            // is_focused() so a click that lands *in* the widget (which also
-            // activates the app) keeps it open.
-            #[cfg(target_os = "macos")]
-            {
-                use block2::RcBlock;
-                use objc2_foundation::{NSNotification, NSNotificationCenter, NSString};
-                use std::ptr::NonNull;
-                use tauri::Manager;
-
-                let activate_handle = app.handle().clone();
-                let block = RcBlock::new(move |_n: NonNull<NSNotification>| {
-                    if let Some(win) = activate_handle.get_webview_window("activity-widget") {
-                        if !win.is_focused().unwrap_or(false) {
-                            let _ = win.hide();
-                        }
-                    }
-                });
-                unsafe {
-                    let center = NSNotificationCenter::defaultCenter();
-                    let name = NSString::from_str("NSApplicationDidBecomeActiveNotification");
-                    let token = center.addObserverForName_object_queue_usingBlock(
-                        Some(&name),
-                        None,
-                        None,
-                        &block,
-                    );
-                    // Keep the observer token and block alive for the app's life.
-                    std::mem::forget(token);
-                }
-                std::mem::forget(block);
-            }
-
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -182,12 +182,16 @@ pub fn run() {
                             let enabled =
                                 marrow_core::config::load_settings().activity_mini_player;
 
+                            // Show the widget only while Marrow is NOT the
+                            // active app; hide it the moment Marrow is active.
+                            // (No is_focused guard: on Cmd+Tab the always-on-top
+                            // widget itself becomes key, so guarding on focus
+                            // would never let it hide.)
                             match h.get_webview_window("activity-widget") {
                                 Some(win) => {
                                     let visible = win.is_visible().unwrap_or(false);
-                                    let focused = win.is_focused().unwrap_or(false);
                                     if active {
-                                        if visible && !focused {
+                                        if visible {
                                             let _ = win.hide();
                                         }
                                     } else if enabled && !visible {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -176,7 +176,7 @@ pub fn run() {
                 let was_active = std::sync::Arc::new(AtomicU8::new(0)); // 1 active, 2 inactive
                 tauri::async_runtime::spawn(async move {
                     loop {
-                        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         let h = poll_handle.clone();
                         let wa = was_active.clone();
                         let _ = poll_handle.run_on_main_thread(move || {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -10,6 +10,38 @@ use std::sync::Mutex;
 use tauri::{Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 
+/// Default/min seconds between activity polls. GitHub's notifications API floor
+/// is 60s; we honor its `X-Poll-Interval` header above this when it asks for more.
+const ACTIVITY_POLL_SECS: u64 = 60;
+/// Max PRs surfaced per watch; the rest are reported via the payload's `truncated`.
+const ACTIVITY_PER_WATCH_CAP: usize = 50;
+
+/// One activity poll: build a GitHub client from the saved token, collect
+/// involved PRs + watch results, diff against the seen-state, and broadcast the
+/// `pr-activity` event. Returns the notifications scheduling metadata
+/// `(poll_interval, last_modified)`, or `None` when no token is configured.
+async fn poll_activity_once(
+    handle: &tauri::AppHandle,
+    notif_since: Option<String>,
+) -> Option<(Option<u64>, Option<String>)> {
+    let settings = marrow_core::config::load_settings();
+    let token = marrow_core::config::resolve_github_token(&settings)?;
+    let client = marrow_core::github::GithubClient::new(Some(token));
+    let watches = marrow_core::watches::load_watches();
+    let collected = client
+        .collect_activity(&watches, ACTIVITY_PER_WATCH_CAP, notif_since.as_deref())
+        .await;
+    let store = marrow_core::activity::load_activity_store();
+    let payload = marrow_core::activity::compute_activity(
+        collected.observations,
+        &store,
+        collected.truncated,
+        marrow_core::activity::now_rfc3339(),
+    );
+    let _ = handle.emit("pr-activity", payload);
+    Some((collected.notif_poll_interval, collected.notif_last_modified))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let args: Vec<String> = env::args().collect();
@@ -87,6 +119,31 @@ pub fn run() {
                     }
                 }
             });
+
+            // Mini-player background watcher: poll the user's involved PRs +
+            // saved watches, diff against the persisted seen-state, and emit a
+            // `pr-activity` event to every window. Runs for the app's lifetime.
+            let activity_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                // Conditional-request state for notifications: `Last-Modified`
+                // makes the next poll cheap (304), and `X-Poll-Interval` sets
+                // the cadence GitHub asks us to keep.
+                let mut notif_since: Option<String> = None;
+                let mut poll_secs = ACTIVITY_POLL_SECS;
+                loop {
+                    if let Some((poll_interval, last_modified)) =
+                        poll_activity_once(&activity_handle, notif_since.clone()).await
+                    {
+                        if last_modified.is_some() {
+                            notif_since = last_modified;
+                        }
+                        if let Some(pi) = poll_interval {
+                            poll_secs = pi.max(ACTIVITY_POLL_SECS);
+                        }
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(poll_secs)).await;
+                }
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -121,6 +178,11 @@ pub fn run() {
             commands::load_cached_manifest_by_pr,
             commands::save_session,
             commands::load_session,
+            commands::get_watches,
+            commands::save_watches,
+            commands::mark_pr_seen,
+            commands::open_activity_window,
+            commands::open_pr_in_main,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -186,6 +186,7 @@ pub fn run() {
             commands::save_watches,
             commands::mark_pr_seen,
             commands::set_activity_window_visible,
+            commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])
         .run(tauri::generate_context!())

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -202,6 +202,14 @@ pub fn run() {
                 });
             }
 
+            // Pre-create the mini-player panel (hidden) at startup if enabled, so
+            // the first show isn't a window creation — creating a webview window
+            // activates the app and would yank you back to Marrow on your first
+            // Cmd+Tab away. Runs on the main thread (setup), where it's safe.
+            if marrow_core::config::load_settings().activity_mini_player {
+                let _ = commands::build_activity_window(app.handle());
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -155,6 +155,43 @@ pub fn run() {
                     tokio::time::sleep(std::time::Duration::from_secs(poll_secs)).await;
                 }
             });
+
+            // Hide the floating mini-player when Marrow becomes the active app
+            // (Cmd+Tab / dock click). That activation delivers no webview focus
+            // event — and Page Visibility doesn't fire for window occlusion —
+            // so the JS focus/visibility listeners can't catch it. We guard on
+            // is_focused() so a click that lands *in* the widget (which also
+            // activates the app) keeps it open.
+            #[cfg(target_os = "macos")]
+            {
+                use block2::RcBlock;
+                use objc2_foundation::{NSNotification, NSNotificationCenter, NSString};
+                use std::ptr::NonNull;
+                use tauri::Manager;
+
+                let activate_handle = app.handle().clone();
+                let block = RcBlock::new(move |_n: NonNull<NSNotification>| {
+                    if let Some(win) = activate_handle.get_webview_window("activity-widget") {
+                        if !win.is_focused().unwrap_or(false) {
+                            let _ = win.hide();
+                        }
+                    }
+                });
+                unsafe {
+                    let center = NSNotificationCenter::defaultCenter();
+                    let name = NSString::from_str("NSApplicationDidBecomeActiveNotification");
+                    let token = center.addObserverForName_object_queue_usingBlock(
+                        Some(&name),
+                        None,
+                        None,
+                        &block,
+                    );
+                    // Keep the observer token and block alive for the app's life.
+                    std::mem::forget(token);
+                }
+                std::mem::forget(block);
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -185,7 +185,7 @@ pub fn run() {
             commands::get_watches,
             commands::save_watches,
             commands::mark_pr_seen,
-            commands::open_activity_window,
+            commands::set_activity_window_visible,
             commands::open_pr_in_main,
         ])
         .run(tauri::generate_context!())

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -193,6 +193,7 @@ pub fn run() {
             commands::save_watches,
             commands::mark_pr_seen,
             commands::set_activity_window_visible,
+            commands::set_mini_player_enabled,
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
         ])

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -145,9 +145,8 @@ pub fn run() {
                     if let Some((poll_interval, last_modified)) =
                         poll_activity_once(&activity_handle, notif_since.clone()).await
                     {
-                        if last_modified.is_some() {
-                            notif_since = last_modified;
-                        }
+                        // A 304 (None) means "unchanged" — keep the prior value.
+                        notif_since = last_modified.or(notif_since);
                         if let Some(pi) = poll_interval {
                             poll_secs = pi.max(ACTIVITY_POLL_SECS);
                         }
@@ -160,49 +159,32 @@ pub fn run() {
             // App (re)activation (Cmd+Tab / dock) delivers no webview focus event
             // and Page Visibility doesn't fire for occlusion, so focus-based
             // logic can't catch it. Polling NSApplication.isActive on the main
-            // thread is the one reliable signal: show the widget while Marrow is
-            // NOT the active app, hide it once it is (unless the widget itself is
-            // focused, i.e. the user clicked into it to use it).
+            // thread is the one reliable signal: the widget shows while Marrow is
+            // NOT the active app and hides once it is. We act only on a CHANGE in
+            // active-state and delegate the actual show/hide/build (and the
+            // enabled-setting gate) to `set_activity_window_visible`, so the disk
+            // read and window mutation happen on transitions, not every tick.
             #[cfg(target_os = "macos")]
             {
+                use std::sync::atomic::{AtomicU8, Ordering};
                 let poll_handle = app.handle().clone();
+                let last_state = std::sync::Arc::new(AtomicU8::new(0)); // 0 unknown, 1 active, 2 inactive
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         let h = poll_handle.clone();
+                        let last = last_state.clone();
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
                             use objc2_app_kit::NSApplication;
-                            use tauri::Manager;
 
                             let Some(mtm) = MainThreadMarker::new() else {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
-                            let enabled =
-                                marrow_core::config::load_settings().activity_mini_player;
-
-                            // Show the widget only while Marrow is NOT the
-                            // active app; hide it the moment Marrow is active.
-                            // (No is_focused guard: on Cmd+Tab the always-on-top
-                            // widget itself becomes key, so guarding on focus
-                            // would never let it hide.)
-                            match h.get_webview_window("activity-widget") {
-                                Some(win) => {
-                                    let visible = win.is_visible().unwrap_or(false);
-                                    if active {
-                                        if visible {
-                                            let _ = win.hide();
-                                        }
-                                    } else if enabled && !visible {
-                                        let _ = win.show();
-                                    }
-                                }
-                                None => {
-                                    if !active && enabled {
-                                        let _ = commands::build_activity_window(&h);
-                                    }
-                                }
+                            let code = if active { 1 } else { 2 };
+                            if last.swap(code, Ordering::Relaxed) != code {
+                                let _ = commands::set_activity_window_visible(h, !active);
                             }
                         });
                     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -173,7 +173,7 @@ pub fn run() {
             {
                 use std::sync::atomic::{AtomicU8, Ordering};
                 let poll_handle = app.handle().clone();
-                let last_state = std::sync::Arc::new(AtomicU8::new(0)); // 0 unknown, 1 active, 2 inactive
+                let last_state = std::sync::Arc::new(AtomicU8::new(0)); // 0 unknown, 1 show, 2 hide
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
@@ -182,14 +182,25 @@ pub fn run() {
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
                             use objc2_app_kit::NSApplication;
+                            use tauri::Manager;
 
                             let Some(mtm) = MainThreadMarker::new() else {
                                 return;
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
-                            let code = if active { 1 } else { 2 };
+                            // The widget panel itself being focused means the user is
+                            // interacting with it (drag/resize/✕) — clicking a webview
+                            // activates the app, but we must NOT hide while they're in
+                            // the panel. Hide only when Marrow is active AND the panel
+                            // is not the focused window (i.e. they returned to main).
+                            let panel_focused = h
+                                .get_webview_window("activity-widget")
+                                .map(|w| w.is_focused().unwrap_or(false))
+                                .unwrap_or(false);
+                            let want_visible = !active || panel_focused;
+                            let code = if want_visible { 1 } else { 2 };
                             if last.swap(code, Ordering::Relaxed) != code {
-                                let _ = commands::set_activity_window_visible(h, !active);
+                                let _ = commands::set_activity_window_visible(h, want_visible);
                             }
                         });
                     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn run() {
             pending_deep_link: Mutex::new(None),
             pr_node_ids: Mutex::new(HashMap::new()),
             frontend_ready: Mutex::new(false),
+            widget_moved_at: Mutex::new(None),
         })
         .setup(|app| {
             // Custom menu intercepts Ctrl+W / Ctrl+Q at the native layer (see menu.rs).
@@ -172,16 +173,26 @@ pub fn run() {
             #[cfg(target_os = "macos")]
             {
                 use std::sync::atomic::{AtomicU8, Ordering};
+                use std::sync::Mutex as StdMutex;
+                use std::time::{Duration, Instant};
+                // How long after Marrow activates to wait before auto-hiding (gives
+                // you time to start a drag/resize), and how long a move/resize keeps
+                // the panel up after you stop.
+                const GRACE: Duration = Duration::from_millis(500);
                 let poll_handle = app.handle().clone();
                 let last_visible = std::sync::Arc::new(AtomicU8::new(0)); // 1 show, 2 hide
+                let was_active = std::sync::Arc::new(AtomicU8::new(0)); // 1 active, 2 inactive
+                let active_since = std::sync::Arc::new(StdMutex::new(None::<Instant>));
                 tauri::async_runtime::spawn(async move {
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
                         let h = poll_handle.clone();
                         let lv = last_visible.clone();
+                        let wa = was_active.clone();
+                        let asince = active_since.clone();
                         let _ = poll_handle.run_on_main_thread(move || {
                             use objc2::MainThreadMarker;
-                            use objc2_app_kit::{NSApplication, NSEvent, NSWindow};
+                            use objc2_app_kit::NSApplication;
                             use tauri::Manager;
 
                             let Some(mtm) = MainThreadMarker::new() else {
@@ -189,37 +200,29 @@ pub fn run() {
                             };
                             let active = NSApplication::sharedApplication(mtm).isActive();
 
-                            // Is the cursor over the floating panel? A NATIVE check
-                            // (global mouse location vs the panel's frame) — it works
-                            // even while the app/panel is inactive, where the webview
-                            // gets no pointer events, and reading it in the poll is
-                            // race-free. This is what tells "you're using the panel"
-                            // (drag/resize/click — cursor on it) from "you've moved back
-                            // to the main window" (cursor off it).
-                            let mouse_over_panel = h
-                                .get_webview_window("activity-widget")
-                                .and_then(|win| {
-                                    let ns_ptr = win.ns_window().ok()?;
-                                    let ns_window: &NSWindow =
-                                        unsafe { &*(ns_ptr as *const NSWindow) };
-                                    let frame = ns_window.frame();
-                                    let mouse = NSEvent::mouseLocation();
-                                    let m = 6.0; // small margin so edge-resize counts
-                                    Some(
-                                        mouse.x >= frame.origin.x - m
-                                            && mouse.x
-                                                <= frame.origin.x + frame.size.width + m
-                                            && mouse.y >= frame.origin.y - m
-                                            && mouse.y
-                                                <= frame.origin.y + frame.size.height + m,
-                                    )
-                                })
-                                .unwrap_or(false);
+                            // Stamp when Marrow (re)activated — starts the grace window.
+                            let acode = if active { 1 } else { 2 };
+                            if wa.swap(acode, Ordering::Relaxed) != 1 && acode == 1 {
+                                if let Ok(mut t) = asince.lock() {
+                                    *t = Some(Instant::now());
+                                }
+                            }
 
-                            // Show while away from Marrow, or while the cursor is on the
-                            // panel (you're using it). Hide once Marrow is active and the
-                            // cursor has left the panel (you've gone back to the app).
-                            let want_visible = !active || mouse_over_panel;
+                            let within = |i: Option<Instant>| {
+                                i.map(|i| i.elapsed() < GRACE).unwrap_or(false)
+                            };
+                            let in_grace = within(asince.lock().ok().and_then(|g| *g));
+                            let moved_recently = within(
+                                h.try_state::<commands::AppState>()
+                                    .and_then(|s| s.widget_moved_at.lock().ok().and_then(|g| *g)),
+                            );
+
+                            // Visible while away from Marrow, OR briefly after it
+                            // activates (room to grab the panel), OR while you're
+                            // moving/resizing it. Otherwise it hides shortly after you
+                            // return — regardless of cursor position or which window
+                            // macOS focused, so Cmd+Tab back always tucks it away.
+                            let want_visible = !active || in_grace || moved_recently;
                             let vcode = if want_visible { 1 } else { 2 };
                             if lv.swap(vcode, Ordering::Relaxed) != vcode {
                                 let _ = commands::set_activity_window_visible(h, want_visible);

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "beforeBuildCommand": "bun run build"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "title": "Marrow",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,6 +7,7 @@ import { CommentsViewer } from "./components/CommentsViewer";
 import { Header } from "./components/Header";
 import { PrOpener } from "./components/PrOpener";
 import { ReviewRequestList } from "./components/ReviewRequestList";
+import { ActivityWidget } from "./components/ActivityWidget";
 import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
@@ -1405,6 +1406,7 @@ function App() {
 
   return (
     <div className="app">
+      <ActivityWidget onOpenPr={(ref) => handleFetchStart(ref, activeTabId ?? undefined)} />
       <Header
         tabs={tabs}
         activeTabId={activeTabId}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1303,14 +1303,25 @@ function App() {
 
   // Show the floating activity mini-player whenever the main window is NOT the
   // focused window — i.e. you've navigated to another app/window (this also
-  // covers minimize and hide, which unfocus the window). Hidden again when the
-  // main window regains focus, so the two are never on screen together.
+  // covers minimize and hide). Hidden again when the main window regains focus,
+  // so the two are never on screen together. We listen on BOTH the Tauri window
+  // focus event and the DOM window focus/blur: the Tauri "focus" can miss the
+  // return trip (e.g. Cmd+Tab where the always-on-top widget was last key), and
+  // the DOM events fire reliably when the main webview itself (de)focuses.
   useEffect(() => {
-    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
-      invoke("set_activity_window_visible", { visible: !focused }).catch(() => {});
-    });
+    const setVisible = (visible: boolean) =>
+      invoke("set_activity_window_visible", { visible }).catch(() => {});
+    const onFocus = () => setVisible(false);
+    const onBlur = () => setVisible(true);
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) =>
+      setVisible(!focused)
+    );
+    window.addEventListener("focus", onFocus);
+    window.addEventListener("blur", onBlur);
     return () => {
       unlisten.then((fn) => fn());
+      window.removeEventListener("focus", onFocus);
+      window.removeEventListener("blur", onBlur);
     };
   }, []);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1309,6 +1309,10 @@ function App() {
   // return trip (e.g. Cmd+Tab where the always-on-top widget was last key), and
   // the DOM events fire reliably when the main webview itself (de)focuses.
   useEffect(() => {
+    // macOS drives the floating window from the native app-active poll in the
+    // Rust backend (focus/visibility events don't fire on Cmd+Tab activation),
+    // so only wire the webview focus path on other platforms.
+    if (navigator.userAgent.includes("Macintosh")) return;
     const setVisible = (visible: boolean) =>
       invoke("set_activity_window_visible", { visible }).catch(() => {});
     const onFocus = () => setVisible(false);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1313,15 +1313,25 @@ function App() {
       invoke("set_activity_window_visible", { visible }).catch(() => {});
     const onFocus = () => setVisible(false);
     const onBlur = () => setVisible(true);
+    // Activating Marrow (Cmd+Tab / dock click) brings the main window forward
+    // before it gets webview focus, so focus alone leaves the mini-player up
+    // until you click in. Becoming visible (unoccluded) fires on activation —
+    // hide on that too. We only HIDE on visibility (never show), since a window
+    // that's merely on-screen-but-unfocused stays "visible".
+    const onVisibility = () => {
+      if (!document.hidden) setVisible(false);
+    };
     const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) =>
       setVisible(!focused)
     );
     window.addEventListener("focus", onFocus);
     window.addEventListener("blur", onBlur);
+    document.addEventListener("visibilitychange", onVisibility);
     return () => {
       unlisten.then((fn) => fn());
       window.removeEventListener("focus", onFocus);
       window.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, []);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1303,41 +1303,31 @@ function App() {
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Show the floating activity mini-player whenever the main window is NOT the
-  // focused window — i.e. you've navigated to another app/window (this also
-  // covers minimize and hide). Hidden again when the main window regains focus,
-  // so the two are never on screen together. We listen on BOTH the Tauri window
-  // focus event and the DOM window focus/blur: the Tauri "focus" can miss the
-  // return trip (e.g. Cmd+Tab where the always-on-top widget was last key), and
-  // the DOM events fire reliably when the main webview itself (de)focuses.
+  // Floating mini-player visibility:
+  //  - HIDE it whenever the MAIN window gains focus (you've engaged the app).
+  //    Interacting with the floating panel focuses the panel, not the main
+  //    window, so dragging/resizing/clicking it never hides it — only genuinely
+  //    going to the main window does.
+  //  - SHOW it when you leave Marrow. On macOS that's driven by the native
+  //    app-active poll in the Rust backend (webview blur is unreliable for
+  //    app-switches there); on other platforms, on the main window's blur.
   useEffect(() => {
-    // macOS drives the floating window from the native app-active poll in the
-    // Rust backend (focus/visibility events don't fire on Cmd+Tab activation),
-    // so only wire the webview focus path on other platforms.
-    if (navigator.userAgent.includes("Macintosh")) return;
     const setVisible = (visible: boolean) =>
       invoke("set_activity_window_visible", { visible }).catch(() => {});
-    const onFocus = () => setVisible(false);
-    const onBlur = () => setVisible(true);
-    // Activating Marrow (Cmd+Tab / dock click) brings the main window forward
-    // before it gets webview focus, so focus alone leaves the mini-player up
-    // until you click in. Becoming visible (unoccluded) fires on activation —
-    // hide on that too. We only HIDE on visibility (never show), since a window
-    // that's merely on-screen-but-unfocused stays "visible".
-    const onVisibility = () => {
-      if (!document.hidden) setVisible(false);
-    };
-    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) =>
-      setVisible(!focused)
-    );
-    window.addEventListener("focus", onFocus);
-    window.addEventListener("blur", onBlur);
-    document.addEventListener("visibilitychange", onVisibility);
+    const hide = () => setVisible(false);
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused) hide();
+    });
+    window.addEventListener("focus", hide);
+
+    const isMac = navigator.userAgent.includes("Macintosh");
+    const show = () => setVisible(true);
+    if (!isMac) window.addEventListener("blur", show);
+
     return () => {
       unlisten.then((fn) => fn());
-      window.removeEventListener("focus", onFocus);
-      window.removeEventListener("blur", onBlur);
-      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("focus", hide);
+      if (!isMac) window.removeEventListener("blur", show);
     };
   }, []);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,7 +22,7 @@ import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
-import { parsePrUrl, extractPrRef } from "./utils";
+import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
 function isOpenerTab(tab: Tab): boolean {
@@ -562,6 +562,19 @@ function App() {
   // in place; otherwise a new tab is created so opening never takes over the
   // currently active review.
   async function handleFetchStart(prRef: string, targetTabId?: string) {
+    // If this PR is already open in a tab, just switch to it rather than
+    // fetching it again into a new tab.
+    const key = canonicalPrKey(prRef);
+    if (key) {
+      const alreadyOpen = tabsRef.current.find(
+        (t) => t.manifest && canonicalPrKey(t.manifest.pr_url) === key
+      );
+      if (alreadyOpen) {
+        setActiveTabId(alreadyOpen.id);
+        return;
+      }
+    }
+
     if (fetchingRef.current) return;
     fetchingRef.current = true;
     const token = ++fetchTokenRef.current;

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1301,6 +1301,19 @@ function App() {
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Show the floating activity mini-player only while the main window is NOT
+  // visible (minimized / hidden / fully occluded). `document.hidden` tracks
+  // visibility rather than focus, so the floating window doesn't pop up merely
+  // because another app took focus while Marrow is still on screen.
+  useEffect(() => {
+    const sync = () => {
+      invoke("set_activity_window_visible", { visible: document.hidden }).catch(() => {});
+    };
+    document.addEventListener("visibilitychange", sync);
+    sync(); // set initial state on mount
+    return () => document.removeEventListener("visibilitychange", sync);
+  }, []);
+
   // Re-load dismissed-highlight state from disk when the window regains focus, so
   // dismissals made outside the app (e.g. an external/AI tool writing the
   // ~/.config/marrow/dismissed file) show up without reopening the PR.

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -570,7 +570,9 @@ function App() {
         (t) => t.manifest && canonicalPrKey(t.manifest.pr_url) === key
       );
       if (alreadyOpen) {
-        setActiveTabId(alreadyOpen.id);
+        // handleSelectTab (not bare setActiveTabId) also clears the tab's
+        // unread badge, matching the deep-link open path.
+        handleSelectTab(alreadyOpen.id);
         return;
       }
     }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1301,17 +1301,17 @@ function App() {
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Show the floating activity mini-player only while the main window is NOT
-  // visible (minimized / hidden / fully occluded). `document.hidden` tracks
-  // visibility rather than focus, so the floating window doesn't pop up merely
-  // because another app took focus while Marrow is still on screen.
+  // Show the floating activity mini-player whenever the main window is NOT the
+  // focused window — i.e. you've navigated to another app/window (this also
+  // covers minimize and hide, which unfocus the window). Hidden again when the
+  // main window regains focus, so the two are never on screen together.
   useEffect(() => {
-    const sync = () => {
-      invoke("set_activity_window_visible", { visible: document.hidden }).catch(() => {});
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      invoke("set_activity_window_visible", { visible: !focused }).catch(() => {});
+    });
+    return () => {
+      unlisten.then((fn) => fn());
     };
-    document.addEventListener("visibilitychange", sync);
-    sync(); // set initial state on mount
-    return () => document.removeEventListener("visibilitychange", sync);
   }, []);
 
   // Re-load dismissed-highlight state from disk when the window regains focus, so

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -9,8 +9,8 @@ interface ActivityWidgetProps {
   /** Open a PR in the main window (an `owner/repo#number` ref). */
   onOpenPr: (prRef: string) => void;
   /**
-   * `dock` = an in-app, resizable, fixed-corner panel.
-   * `window` = fills a dedicated floating window (Phase 3).
+   * `dock` = the in-app, resizable, fixed-corner panel (shown while you're in
+   * Marrow). `window` = the floating NSPanel (shown while you're away).
    */
   variant?: "dock" | "window";
 }

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { PrActivityItem, Watch } from "../types";
 import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
 
@@ -242,8 +241,8 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         {variant === "window" && (
           <button
             className="aw-iconbtn"
-            onClick={() => getCurrentWindow().close().catch(() => {})}
-            title="Close"
+            onClick={() => invoke("dismiss_mini_player").catch(() => {})}
+            title="Dismiss (disable until re-enabled in Settings)"
           >
             ✕
           </button>

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -160,36 +160,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     invoke("set_mini_player_enabled", { enabled: next }).catch(() => {});
   }
 
-  // Floating window: hide itself when Marrow is reactivated (Cmd+Tab / dock).
-  // The widget can't be the key window while the app is inactive, so it only
-  // gains focus when the app becomes active. If that focus did NOT come from a
-  // pointer interaction in the widget, the user returned to Marrow (rather than
-  // clicking the widget to use it) → hide. A recent pointerdown keeps it open
-  // so clicking its controls/dragging it doesn't dismiss it.
-  useEffect(() => {
-    if (variant !== "window") return;
-    let interacting = false;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const markInteract = () => {
-      interacting = true;
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => {
-        interacting = false;
-      }, 600);
-    };
-    window.addEventListener("pointerdown", markInteract, true);
-    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
-      if (focused && !interacting) {
-        getCurrentWindow().hide().catch(() => {});
-      }
-    });
-    return () => {
-      window.removeEventListener("pointerdown", markInteract, true);
-      unlisten.then((fn) => fn());
-      if (timer) clearTimeout(timer);
-    };
-  }, [variant]);
-
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
   useEffect(() => {

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { PrActivityItem, Watch } from "../types";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { PrActivityItem, Settings, Watch } from "../types";
 import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
 
 interface ActivityWidgetProps {
@@ -132,6 +133,32 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   const [source, setSource] = useState("all"); // a raw reason string, or "all"
   const [watchLabels, setWatchLabels] = useState<string[]>([]);
   const [showControls, setShowControls] = useState(false);
+  // Whether the floating window auto-shows when Marrow is backgrounded (dock only).
+  const [floatingEnabled, setFloatingEnabled] = useState(true);
+
+  // Keep the dock's floating-window toggle in sync with the persisted setting —
+  // on mount and whenever the main window regains focus (so it reflects a ✕
+  // dismissal made from the floating window while we were away).
+  useEffect(() => {
+    if (variant !== "dock") return;
+    const load = () =>
+      invoke<Settings>("get_settings")
+        .then((s) => setFloatingEnabled(s.activity_mini_player ?? true))
+        .catch(() => {});
+    load();
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused) load();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, [variant]);
+
+  function toggleFloating() {
+    const next = !floatingEnabled;
+    setFloatingEnabled(next);
+    invoke("set_mini_player_enabled", { enabled: next }).catch(() => {});
+  }
 
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
@@ -234,9 +261,22 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
           ⌕
         </button>
         {variant === "dock" && (
-          <button className="aw-iconbtn" onClick={() => setCollapsedPersist(true)} title="Collapse">
-            –
-          </button>
+          <>
+            <button
+              className={`aw-iconbtn ${floatingEnabled ? "aw-iconbtn--on" : ""}`}
+              onClick={toggleFloating}
+              title={
+                floatingEnabled
+                  ? "Floating window: on — shows when Marrow is in the background"
+                  : "Floating window: off"
+              }
+            >
+              ⧉
+            </button>
+            <button className="aw-iconbtn" onClick={() => setCollapsedPersist(true)} title="Collapse">
+              –
+            </button>
+          </>
         )}
         {variant === "window" && (
           <button

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { PrActivityItem } from "../types";
+import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
+
+interface ActivityWidgetProps {
+  /** Open a PR in the main window (an `owner/repo#number` ref). */
+  onOpenPr: (prRef: string) => void;
+  /**
+   * `dock` = an in-app, resizable, fixed-corner panel.
+   * `window` = fills a dedicated floating window (Phase 3).
+   */
+  variant?: "dock" | "window";
+}
+
+function timeAgo(dateStr: string): string {
+  const then = new Date(dateStr).getTime();
+  if (Number.isNaN(then)) return "";
+  const mins = Math.floor((Date.now() - then) / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d`;
+  return `${Math.floor(days / 30)}mo`;
+}
+
+const DELTA_LABELS: Record<string, string> = {
+  new: "new",
+  updated: "updated",
+  "new-commits": "new commits",
+  "new-comments": "new comments",
+  "review-state-changed": "review changed",
+  "new-threads": "new threads",
+  "ci-changed": "CI changed",
+};
+
+/** Strip the `watching:`/`notification:` prefix for a compact chip label. */
+function reasonLabel(reason: string): string {
+  if (reason.startsWith("watching:")) return reason.slice("watching:".length);
+  if (reason.startsWith("notification:")) return reason.slice("notification:".length).replace(/_/g, " ");
+  if (reason === "review-requested") return "review requested";
+  return reason;
+}
+
+/** CI status → a single glyph + semantic class. */
+function ciGlyph(state?: string | null): { glyph: string; cls: string } | null {
+  if (!state) return null;
+  switch (state) {
+    case "success":
+      return { glyph: "✓", cls: "aw-ci--ok" };
+    case "failure":
+    case "error":
+      return { glyph: "✗", cls: "aw-ci--bad" };
+    case "pending":
+      return { glyph: "●", cls: "aw-ci--pending" };
+    default:
+      return { glyph: "●", cls: "aw-ci--pending" };
+  }
+}
+
+function ActivityRow({
+  item,
+  onActivate,
+}: {
+  item: PrActivityItem;
+  onActivate: (item: PrActivityItem) => void;
+}) {
+  const ci = ciGlyph(item.ciState);
+  return (
+    <button
+      className={`aw-row ${item.unread ? "aw-row--unread" : ""}`}
+      onClick={() => onActivate(item)}
+      title={`${item.repo}#${item.number} — ${item.title}`}
+    >
+      <span className="aw-row__dot" aria-hidden />
+      {item.avatarUrl ? (
+        <img className="aw-row__avatar" src={item.avatarUrl} alt="" loading="lazy" />
+      ) : (
+        <span className="aw-row__avatar aw-row__avatar--blank" aria-hidden />
+      )}
+      <span className="aw-row__main">
+        <span className="aw-row__title">{item.title}</span>
+        <span className="aw-row__meta">
+          <span className="aw-row__repo">
+            {item.repo}#{item.number}
+          </span>
+          {item.deltas.slice(0, 2).map((d) => (
+            <span key={d} className="aw-chip aw-chip--delta">
+              {DELTA_LABELS[d] ?? d}
+            </span>
+          ))}
+          {item.reasons.slice(0, 1).map((r) => (
+            <span key={r} className="aw-chip aw-chip--reason">
+              {reasonLabel(r)}
+            </span>
+          ))}
+        </span>
+      </span>
+      <span className="aw-row__status">
+        {ci && <span className={`aw-ci ${ci.cls}`}>{ci.glyph}</span>}
+        {!!item.unresolvedThreads && item.unresolvedThreads > 0 && (
+          <span className="aw-threads" title="unresolved threads">
+            {item.unresolvedThreads}
+          </span>
+        )}
+        <span className="aw-row__time">{timeAgo(item.updatedAt)}</span>
+      </span>
+    </button>
+  );
+}
+
+const COLLAPSED_KEY = "aw-collapsed";
+
+export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetProps) {
+  const { items, truncatedTotal, unreadCount, markSeen } = useActivityFeed();
+  // Default to the unobtrusive pill; remember the user's choice across launches.
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(COLLAPSED_KEY) !== "false";
+    } catch {
+      return true;
+    }
+  });
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [focusIdx, setFocusIdx] = useState(0);
+  // Session snooze: hide a PR until its `updatedAt` moves (i.e. until it changes).
+  const [snoozed, setSnoozed] = useState<Record<string, string>>({});
+
+  function setCollapsedPersist(v: boolean) {
+    setCollapsed(v);
+    try {
+      localStorage.setItem(COLLAPSED_KEY, String(v));
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const visible = useMemo(() => {
+    const base = unreadOnly ? items.filter((i) => i.unread) : items;
+    return base.filter((i) => snoozed[i.prUrl] !== i.updatedAt);
+  }, [items, unreadOnly, snoozed]);
+
+  // The "now playing" item: clamp the cursor into range as the feed changes.
+  const safeIdx = visible.length ? Math.min(focusIdx, visible.length - 1) : 0;
+  const focus = visible[safeIdx];
+
+  function activate(item: PrActivityItem) {
+    markSeen(item);
+    onOpenPr(prRefOf(item));
+  }
+
+  function snooze(item: PrActivityItem) {
+    setSnoozed((s) => ({ ...s, [item.prUrl]: item.updatedAt }));
+    setFocusIdx(0);
+  }
+
+  // Collapsed → glanceable pill (Tier 0). Only the in-app dock collapses; the
+  // floating window always shows the full widget.
+  if (collapsed && variant === "dock") {
+    return (
+      <button
+        className={`activity-widget activity-widget--pill ${unreadCount ? "activity-widget--alert" : ""}`}
+        onClick={() => setCollapsedPersist(false)}
+        title="PR activity"
+      >
+        <span className="aw-eq" aria-hidden>
+          <i />
+          <i />
+          <i />
+        </span>
+        <span className="aw-pill__count">{unreadCount}</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className={`activity-widget activity-widget--${variant}`}>
+      <header className="aw-head" data-tauri-drag-region>
+        <span className="aw-eq" aria-hidden>
+          <i />
+          <i />
+          <i />
+        </span>
+        <span className="aw-head__title">
+          {variant === "window" ? "Marrow Activity" : "Activity"}
+        </span>
+        {unreadCount > 0 && <span className="aw-head__badge">{unreadCount}</span>}
+        <span className="aw-head__spacer" />
+        <button
+          className={`aw-iconbtn ${unreadOnly ? "aw-iconbtn--on" : ""}`}
+          onClick={() => setUnreadOnly((v) => !v)}
+          title={unreadOnly ? "Showing unread" : "Showing all"}
+        >
+          {unreadOnly ? "Unread" : "All"}
+        </button>
+        {variant === "dock" && (
+          <>
+            <button
+              className="aw-iconbtn"
+              onClick={() => invoke("open_activity_window").catch(() => {})}
+              title="Pop out to floating window"
+            >
+              ⧉
+            </button>
+            <button className="aw-iconbtn" onClick={() => setCollapsedPersist(true)} title="Collapse">
+              –
+            </button>
+          </>
+        )}
+        {variant === "window" && (
+          <button
+            className="aw-iconbtn"
+            onClick={() => getCurrentWindow().close().catch(() => {})}
+            title="Close"
+          >
+            ✕
+          </button>
+        )}
+      </header>
+
+      {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
+      {focus && (
+        <div className="aw-focus">
+          <div className="aw-focus__transport">
+            <button
+              className="aw-iconbtn"
+              onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
+              disabled={safeIdx === 0}
+              title="Previous"
+            >
+              ‹
+            </button>
+            <button
+              className="aw-iconbtn"
+              onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
+              disabled={safeIdx >= visible.length - 1}
+              title="Next"
+            >
+              ›
+            </button>
+            <span className="aw-focus__pos">
+              {safeIdx + 1}/{visible.length}
+            </span>
+            <span className="aw-head__spacer" />
+            <button
+              className="aw-iconbtn"
+              onClick={() => snooze(focus)}
+              title="Snooze until this PR changes"
+            >
+              Snooze
+            </button>
+          </div>
+          <ActivityRow item={focus} onActivate={activate} />
+        </div>
+      )}
+
+      {/* Tier 2 — the feed. */}
+      <div className="aw-feed">
+        {visible.length === 0 ? (
+          <div className="aw-empty">{unreadOnly ? "Nothing unread" : "No PR activity yet"}</div>
+        ) : (
+          visible.map((item) => (
+            <ActivityRow key={item.prUrl} item={item} onActivate={activate} />
+          ))
+        )}
+        {truncatedTotal > 0 && (
+          <div className="aw-truncated">+{truncatedTotal} more not shown</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -47,6 +47,17 @@ function ciGlyph(state?: string | null): { glyph: string; cls: string } | null {
   }
 }
 
+/** Animated equalizer bars — the Spotify nod, shown on the pill and header. */
+function Equalizer() {
+  return (
+    <span className="aw-eq" aria-hidden>
+      <i />
+      <i />
+      <i />
+    </span>
+  );
+}
+
 function ActivityRow({
   item,
   onActivate,
@@ -209,11 +220,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         onClick={() => setCollapsedPersist(false)}
         title="PR activity"
       >
-        <span className="aw-eq" aria-hidden>
-          <i />
-          <i />
-          <i />
-        </span>
+        <Equalizer />
         <span className="aw-pill__count">{unreadCount}</span>
       </button>
     );
@@ -222,11 +229,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   return (
     <div className={`activity-widget activity-widget--${variant}`}>
       <header className="aw-head" data-tauri-drag-region>
-        <span className="aw-eq" aria-hidden>
-          <i />
-          <i />
-          <i />
-        </span>
+        <Equalizer />
         <span className="aw-head__title">
           {variant === "window" ? "Marrow Activity" : "Activity"}
         </span>

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { PrActivityItem, Settings, Watch } from "../types";
@@ -131,6 +131,21 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   // Whether the floating window auto-shows when Marrow is backgrounded (dock only).
   const [floatingEnabled, setFloatingEnabled] = useState(true);
 
+  // Height tier: show the "now playing" focus bar only when the widget is too
+  // short for a useful list; otherwise show the list. Height-axis container
+  // queries don't match in the macOS WKWebView, so measure the height directly.
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [compact, setCompact] = useState(false);
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      setCompact(entry.contentRect.height < 180);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [collapsed]);
+
   // Keep the dock's floating-window toggle in sync with the persisted setting —
   // on mount and whenever the main window regains focus (so it reflects a ✕
   // dismissal made from the floating window while we were away).
@@ -219,7 +234,10 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   }
 
   return (
-    <div className={`activity-widget activity-widget--${variant}`}>
+    <div
+      ref={rootRef}
+      className={`activity-widget activity-widget--${variant} ${compact ? "aw--compact" : ""}`}
+    >
       <header className="aw-head" data-tauri-drag-region>
         <Equalizer />
         <span className="aw-head__title">
@@ -309,8 +327,8 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       </div>
       )}
 
-      {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
-      {focus && (
+      {/* Tier 1 — "now playing". Shown only when too short for a list. */}
+      {compact && focus && (
         <div className="aw-focus">
           <div className="aw-focus__transport">
             <button
@@ -337,25 +355,27 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         </div>
       )}
 
-      {/* Tier 2 — the feed. */}
-      <div className="aw-feed">
-        {visible.length === 0 ? (
-          <div className="aw-empty">
-            {query.trim() || source !== "all"
-              ? "No matches"
-              : unreadOnly
-                ? "Nothing unread"
-                : "No PR activity yet"}
-          </div>
-        ) : (
-          visible.map((item) => (
-            <ActivityRow key={item.prUrl} item={item} onActivate={activate} />
-          ))
-        )}
-        {truncatedTotal > 0 && (
-          <div className="aw-truncated">+{truncatedTotal} more not shown</div>
-        )}
-      </div>
+      {/* Tier 2 — the feed. Hidden only when the compact focus bar takes over. */}
+      {(!compact || !focus) && (
+        <div className="aw-feed">
+          {visible.length === 0 ? (
+            <div className="aw-empty">
+              {query.trim() || source !== "all"
+                ? "No matches"
+                : unreadOnly
+                  ? "Nothing unread"
+                  : "No PR activity yet"}
+            </div>
+          ) : (
+            visible.map((item) => (
+              <ActivityRow key={item.prUrl} item={item} onActivate={activate} />
+            ))
+          )}
+          {truncatedTotal > 0 && (
+            <div className="aw-truncated">+{truncatedTotal} more not shown</div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -128,6 +128,17 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   const [focusIdx, setFocusIdx] = useState(0);
   // Session snooze: hide a PR until its `updatedAt` moves (i.e. until it changes).
   const [snoozed, setSnoozed] = useState<Record<string, string>>({});
+  // Temporary feed filters (not persisted).
+  const [query, setQuery] = useState("");
+  const [source, setSource] = useState("all"); // a raw reason string, or "all"
+
+  // The distinct sources present in the feed (watch labels, review-requested,
+  // notifications, …), for the source dropdown.
+  const sources = useMemo(() => {
+    const set = new Set<string>();
+    for (const i of items) for (const r of i.reasons) set.add(r);
+    return Array.from(set).sort();
+  }, [items]);
 
   function setCollapsedPersist(v: boolean) {
     setCollapsed(v);
@@ -139,9 +150,18 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   }
 
   const visible = useMemo(() => {
-    const base = unreadOnly ? items.filter((i) => i.unread) : items;
-    return base.filter((i) => snoozed[i.prUrl] !== i.updatedAt);
-  }, [items, unreadOnly, snoozed]);
+    const q = query.trim().toLowerCase();
+    return items.filter((i) => {
+      if (unreadOnly && !i.unread) return false;
+      if (snoozed[i.prUrl] === i.updatedAt) return false;
+      if (source !== "all" && !i.reasons.includes(source)) return false;
+      if (q) {
+        const hay = `${i.title} ${i.repo}#${i.number} ${i.author}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [items, unreadOnly, snoozed, source, query]);
 
   // The "now playing" item: clamp the cursor into range as the feed changes.
   const safeIdx = visible.length ? Math.min(focusIdx, visible.length - 1) : 0;
@@ -221,6 +241,39 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         )}
       </header>
 
+      {/* Search + source filter (hidden by CSS in the short "bar" layout). */}
+      <div className="aw-controls">
+        <input
+          className="aw-search"
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setFocusIdx(0);
+          }}
+          placeholder="Search PRs…"
+          spellCheck={false}
+        />
+        {sources.length > 1 && (
+          <select
+            className="aw-source"
+            value={source}
+            onChange={(e) => {
+              setSource(e.target.value);
+              setFocusIdx(0);
+            }}
+            title="Filter by source"
+          >
+            <option value="all">All sources</option>
+            {sources.map((s) => (
+              <option key={s} value={s}>
+                {reasonLabel(s)}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
       {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
       {focus && (
         <div className="aw-focus">
@@ -260,7 +313,13 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       {/* Tier 2 — the feed. */}
       <div className="aw-feed">
         {visible.length === 0 ? (
-          <div className="aw-empty">{unreadOnly ? "Nothing unread" : "No PR activity yet"}</div>
+          <div className="aw-empty">
+            {query.trim() || source !== "all"
+              ? "No matches"
+              : unreadOnly
+                ? "Nothing unread"
+                : "No PR activity yet"}
+          </div>
         ) : (
           visible.map((item) => (
             <ActivityRow key={item.prUrl} item={item} onActivate={activate} />

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -235,26 +235,25 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         </span>
         {unreadCount > 0 && <span className="aw-head__badge">{unreadCount}</span>}
         <span className="aw-head__spacer" />
-        {/* The floating window is glance-and-jump: any click activates Marrow,
-            which the app-active poll treats as "you're back" and hides the
-            widget — so its only useful action is clicking a PR row. The
-            interactive controls live on the in-app dock, where they work. */}
+        {/* Interactive controls work in BOTH variants now: the floating panel
+            hides only when the MAIN window gains focus, and clicking these
+            focuses the panel, not main — so they don't dismiss it. */}
+        <button
+          className={`aw-iconbtn ${unreadOnly ? "aw-iconbtn--on" : ""}`}
+          onClick={() => setUnreadOnly((v) => !v)}
+          title={unreadOnly ? "Showing unread" : "Showing all"}
+        >
+          {unreadOnly ? "Unread" : "All"}
+        </button>
+        <button
+          className={`aw-iconbtn ${showControls || query.trim() || source !== "all" ? "aw-iconbtn--on" : ""}`}
+          onClick={() => setShowControls((v) => !v)}
+          title="Search & filter"
+        >
+          ⌕
+        </button>
         {variant === "dock" && (
           <>
-            <button
-              className={`aw-iconbtn ${unreadOnly ? "aw-iconbtn--on" : ""}`}
-              onClick={() => setUnreadOnly((v) => !v)}
-              title={unreadOnly ? "Showing unread" : "Showing all"}
-            >
-              {unreadOnly ? "Unread" : "All"}
-            </button>
-            <button
-              className={`aw-iconbtn ${showControls || query.trim() || source !== "all" ? "aw-iconbtn--on" : ""}`}
-              onClick={() => setShowControls((v) => !v)}
-              title="Search & filter"
-            >
-              ⌕
-            </button>
             <button
               className={`aw-iconbtn ${floatingEnabled ? "aw-iconbtn--on" : ""}`}
               onClick={toggleFloating}
@@ -321,38 +320,35 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
       {focus && (
         <div className="aw-focus">
-          {/* Transport is interactive, so dock-only (see header note). */}
-          {variant === "dock" && (
-            <div className="aw-focus__transport">
-              <button
-                className="aw-iconbtn"
-                onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
-                disabled={safeIdx === 0}
-                title="Previous"
-              >
-                ‹
-              </button>
-              <button
-                className="aw-iconbtn"
-                onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
-                disabled={safeIdx >= visible.length - 1}
-                title="Next"
-              >
-                ›
-              </button>
-              <span className="aw-focus__pos">
-                {safeIdx + 1}/{visible.length}
-              </span>
-              <span className="aw-head__spacer" />
-              <button
-                className="aw-iconbtn"
-                onClick={() => snooze(focus)}
-                title="Snooze until this PR changes"
-              >
-                Snooze
-              </button>
-            </div>
-          )}
+          <div className="aw-focus__transport">
+            <button
+              className="aw-iconbtn"
+              onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
+              disabled={safeIdx === 0}
+              title="Previous"
+            >
+              ‹
+            </button>
+            <button
+              className="aw-iconbtn"
+              onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
+              disabled={safeIdx >= visible.length - 1}
+              title="Next"
+            >
+              ›
+            </button>
+            <span className="aw-focus__pos">
+              {safeIdx + 1}/{visible.length}
+            </span>
+            <span className="aw-head__spacer" />
+            <button
+              className="aw-iconbtn"
+              onClick={() => snooze(focus)}
+              title="Snooze until this PR changes"
+            >
+              Snooze
+            </button>
+          </div>
           <ActivityRow item={focus} onActivate={activate} />
         </div>
       )}

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -160,6 +160,36 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     invoke("set_mini_player_enabled", { enabled: next }).catch(() => {});
   }
 
+  // Floating window: hide itself when Marrow is reactivated (Cmd+Tab / dock).
+  // The widget can't be the key window while the app is inactive, so it only
+  // gains focus when the app becomes active. If that focus did NOT come from a
+  // pointer interaction in the widget, the user returned to Marrow (rather than
+  // clicking the widget to use it) → hide. A recent pointerdown keeps it open
+  // so clicking its controls/dragging it doesn't dismiss it.
+  useEffect(() => {
+    if (variant !== "window") return;
+    let interacting = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const markInteract = () => {
+      interacting = true;
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        interacting = false;
+      }, 600);
+    };
+    window.addEventListener("pointerdown", markInteract, true);
+    const unlisten = getCurrentWindow().onFocusChanged(({ payload: focused }) => {
+      if (focused && !interacting) {
+        getCurrentWindow().hide().catch(() => {});
+      }
+    });
+    return () => {
+      window.removeEventListener("pointerdown", markInteract, true);
+      unlisten.then((fn) => fn());
+      if (timer) clearTimeout(timer);
+    };
+  }, [variant]);
+
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
   useEffect(() => {

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { PrActivityItem } from "../types";
+import type { PrActivityItem, Watch } from "../types";
 import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
 
 interface ActivityWidgetProps {
@@ -131,14 +131,24 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   // Temporary feed filters (not persisted).
   const [query, setQuery] = useState("");
   const [source, setSource] = useState("all"); // a raw reason string, or "all"
+  const [watchLabels, setWatchLabels] = useState<string[]>([]);
 
-  // The distinct sources present in the feed (watch labels, review-requested,
-  // notifications, …), for the source dropdown.
+  // Load configured watches so the source dropdown lists every watch — even one
+  // that currently has no activity in the feed.
+  useEffect(() => {
+    invoke<Watch[]>("get_watches")
+      .then((ws) => setWatchLabels(ws.map((w) => w.label).filter(Boolean)))
+      .catch(() => {});
+  }, []);
+
+  // Distinct sources: configured watches plus any other reasons present in the
+  // feed (review-requested, notifications, …).
   const sources = useMemo(() => {
     const set = new Set<string>();
+    for (const l of watchLabels) set.add(`watching:${l}`);
     for (const i of items) for (const r of i.reasons) set.add(r);
     return Array.from(set).sort();
-  }, [items]);
+  }, [watchLabels, items]);
 
   function setCollapsedPersist(v: boolean) {
     setCollapsed(v);

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -235,22 +235,26 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         </span>
         {unreadCount > 0 && <span className="aw-head__badge">{unreadCount}</span>}
         <span className="aw-head__spacer" />
-        <button
-          className={`aw-iconbtn ${unreadOnly ? "aw-iconbtn--on" : ""}`}
-          onClick={() => setUnreadOnly((v) => !v)}
-          title={unreadOnly ? "Showing unread" : "Showing all"}
-        >
-          {unreadOnly ? "Unread" : "All"}
-        </button>
-        <button
-          className={`aw-iconbtn ${showControls || query.trim() || source !== "all" ? "aw-iconbtn--on" : ""}`}
-          onClick={() => setShowControls((v) => !v)}
-          title="Search & filter"
-        >
-          ⌕
-        </button>
+        {/* The floating window is glance-and-jump: any click activates Marrow,
+            which the app-active poll treats as "you're back" and hides the
+            widget — so its only useful action is clicking a PR row. The
+            interactive controls live on the in-app dock, where they work. */}
         {variant === "dock" && (
           <>
+            <button
+              className={`aw-iconbtn ${unreadOnly ? "aw-iconbtn--on" : ""}`}
+              onClick={() => setUnreadOnly((v) => !v)}
+              title={unreadOnly ? "Showing unread" : "Showing all"}
+            >
+              {unreadOnly ? "Unread" : "All"}
+            </button>
+            <button
+              className={`aw-iconbtn ${showControls || query.trim() || source !== "all" ? "aw-iconbtn--on" : ""}`}
+              onClick={() => setShowControls((v) => !v)}
+              title="Search & filter"
+            >
+              ⌕
+            </button>
             <button
               className={`aw-iconbtn ${floatingEnabled ? "aw-iconbtn--on" : ""}`}
               onClick={toggleFloating}
@@ -317,35 +321,38 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
       {focus && (
         <div className="aw-focus">
-          <div className="aw-focus__transport">
-            <button
-              className="aw-iconbtn"
-              onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
-              disabled={safeIdx === 0}
-              title="Previous"
-            >
-              ‹
-            </button>
-            <button
-              className="aw-iconbtn"
-              onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
-              disabled={safeIdx >= visible.length - 1}
-              title="Next"
-            >
-              ›
-            </button>
-            <span className="aw-focus__pos">
-              {safeIdx + 1}/{visible.length}
-            </span>
-            <span className="aw-head__spacer" />
-            <button
-              className="aw-iconbtn"
-              onClick={() => snooze(focus)}
-              title="Snooze until this PR changes"
-            >
-              Snooze
-            </button>
-          </div>
+          {/* Transport is interactive, so dock-only (see header note). */}
+          {variant === "dock" && (
+            <div className="aw-focus__transport">
+              <button
+                className="aw-iconbtn"
+                onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
+                disabled={safeIdx === 0}
+                title="Previous"
+              >
+                ‹
+              </button>
+              <button
+                className="aw-iconbtn"
+                onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
+                disabled={safeIdx >= visible.length - 1}
+                title="Next"
+              >
+                ›
+              </button>
+              <span className="aw-focus__pos">
+                {safeIdx + 1}/{visible.length}
+              </span>
+              <span className="aw-head__spacer" />
+              <button
+                className="aw-iconbtn"
+                onClick={() => snooze(focus)}
+                title="Snooze until this PR changes"
+              >
+                Snooze
+              </button>
+            </div>
+          )}
           <ActivityRow item={focus} onActivate={activate} />
         </div>
       )}

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { PrActivityItem, Settings, Watch } from "../types";
 import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
+import { timeAgo } from "../utils";
 
 interface ActivityWidgetProps {
   /** Open a PR in the main window (an `owner/repo#number` ref). */
@@ -12,19 +13,6 @@ interface ActivityWidgetProps {
    * `window` = fills a dedicated floating window (Phase 3).
    */
   variant?: "dock" | "window";
-}
-
-function timeAgo(dateStr: string): string {
-  const then = new Date(dateStr).getTime();
-  if (Number.isNaN(then)) return "";
-  const mins = Math.floor((Date.now() - then) / 60000);
-  if (mins < 1) return "just now";
-  if (mins < 60) return `${mins}m`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h`;
-  const days = Math.floor(hrs / 24);
-  if (days < 30) return `${days}d`;
-  return `${Math.floor(days / 30)}mo`;
 }
 
 const DELTA_LABELS: Record<string, string> = {
@@ -54,8 +42,6 @@ function ciGlyph(state?: string | null): { glyph: string; cls: string } | null {
     case "failure":
     case "error":
       return { glyph: "✗", cls: "aw-ci--bad" };
-    case "pending":
-      return { glyph: "●", cls: "aw-ci--pending" };
     default:
       return { glyph: "●", cls: "aw-ci--pending" };
   }
@@ -106,7 +92,7 @@ function ActivityRow({
             {item.unresolvedThreads}
           </span>
         )}
-        <span className="aw-row__time">{timeAgo(item.updatedAt)}</span>
+        <span className="aw-row__time">{timeAgo(item.updatedAt, true)}</span>
       </span>
     </button>
   );

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -132,6 +132,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   const [query, setQuery] = useState("");
   const [source, setSource] = useState("all"); // a raw reason string, or "all"
   const [watchLabels, setWatchLabels] = useState<string[]>([]);
+  const [showControls, setShowControls] = useState(false);
 
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
@@ -226,6 +227,13 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         >
           {unreadOnly ? "Unread" : "All"}
         </button>
+        <button
+          className={`aw-iconbtn ${showControls || query.trim() || source !== "all" ? "aw-iconbtn--on" : ""}`}
+          onClick={() => setShowControls((v) => !v)}
+          title="Search & filter"
+        >
+          ⌕
+        </button>
         {variant === "dock" && (
           <>
             <button
@@ -251,7 +259,9 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
         )}
       </header>
 
-      {/* Search + source filter (hidden by CSS in the short "bar" layout). */}
+      {/* Search + source filter — collapsed by default, toggled from the header
+          (and hidden by CSS in the short "bar" layout). */}
+      {showControls && (
       <div className="aw-controls">
         <input
           className="aw-search"
@@ -283,6 +293,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
           </select>
         )}
       </div>
+      )}
 
       {/* Tier 1 — "now playing". Hidden by CSS in the tall list layout. */}
       {focus && (

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -157,6 +157,27 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     invoke("set_mini_player_enabled", { enabled: next }).catch(() => {});
   }
 
+  // Floating window: report pointer activity so the backend keeps the panel up
+  // while you're using it (and lets it hide when macOS merely re-focuses it on a
+  // Cmd+Tab back, where there's no pointer activity).
+  useEffect(() => {
+    if (variant !== "window") return;
+    let last = 0;
+    const mark = () => {
+      const now = Date.now();
+      if (now - last > 150) {
+        last = now;
+        invoke("mark_widget_interaction").catch(() => {});
+      }
+    };
+    window.addEventListener("pointermove", mark);
+    window.addEventListener("pointerdown", mark);
+    return () => {
+      window.removeEventListener("pointermove", mark);
+      window.removeEventListener("pointerdown", mark);
+    };
+  }, [variant]);
+
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
   useEffect(() => {

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -123,8 +123,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   });
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [focusIdx, setFocusIdx] = useState(0);
-  // Session snooze: hide a PR until its `updatedAt` moves (i.e. until it changes).
-  const [snoozed, setSnoozed] = useState<Record<string, string>>({});
   // Temporary feed filters (not persisted).
   const [query, setQuery] = useState("");
   const [source, setSource] = useState("all"); // a raw reason string, or "all"
@@ -187,7 +185,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     const q = query.trim().toLowerCase();
     return items.filter((i) => {
       if (unreadOnly && !i.unread) return false;
-      if (snoozed[i.prUrl] === i.updatedAt) return false;
       if (source !== "all" && !i.reasons.includes(source)) return false;
       if (q) {
         const hay = `${i.title} ${i.repo}#${i.number} ${i.author}`.toLowerCase();
@@ -195,7 +192,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       }
       return true;
     });
-  }, [items, unreadOnly, snoozed, source, query]);
+  }, [items, unreadOnly, source, query]);
 
   // The "now playing" item: clamp the cursor into range as the feed changes.
   const safeIdx = visible.length ? Math.min(focusIdx, visible.length - 1) : 0;
@@ -204,11 +201,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   function activate(item: PrActivityItem) {
     markSeen(item);
     onOpenPr(prRefOf(item));
-  }
-
-  function snooze(item: PrActivityItem) {
-    setSnoozed((s) => ({ ...s, [item.prUrl]: item.updatedAt }));
-    setFocusIdx(0);
   }
 
   // Collapsed → glanceable pill (Tier 0). Only the in-app dock collapses; the
@@ -340,14 +332,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
             <span className="aw-focus__pos">
               {safeIdx + 1}/{visible.length}
             </span>
-            <span className="aw-head__spacer" />
-            <button
-              className="aw-iconbtn"
-              onClick={() => snooze(focus)}
-              title="Snooze until this PR changes"
-            >
-              Snooze
-            </button>
           </div>
           <ActivityRow item={focus} onActivate={activate} />
         </div>

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -157,27 +157,6 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     invoke("set_mini_player_enabled", { enabled: next }).catch(() => {});
   }
 
-  // Floating window: report pointer activity so the backend keeps the panel up
-  // while you're using it (and lets it hide when macOS merely re-focuses it on a
-  // Cmd+Tab back, where there's no pointer activity).
-  useEffect(() => {
-    if (variant !== "window") return;
-    let last = 0;
-    const mark = () => {
-      const now = Date.now();
-      if (now - last > 150) {
-        last = now;
-        invoke("mark_widget_interaction").catch(() => {});
-      }
-    };
-    window.addEventListener("pointermove", mark);
-    window.addEventListener("pointerdown", mark);
-    return () => {
-      window.removeEventListener("pointermove", mark);
-      window.removeEventListener("pointerdown", mark);
-    };
-  }, [variant]);
-
   // Load configured watches so the source dropdown lists every watch — even one
   // that currently has no activity in the feed.
   useEffect(() => {

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -235,18 +235,9 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
           ⌕
         </button>
         {variant === "dock" && (
-          <>
-            <button
-              className="aw-iconbtn"
-              onClick={() => invoke("open_activity_window").catch(() => {})}
-              title="Pop out to floating window"
-            >
-              ⧉
-            </button>
-            <button className="aw-iconbtn" onClick={() => setCollapsedPersist(true)} title="Collapse">
-              –
-            </button>
-          </>
+          <button className="aw-iconbtn" onClick={() => setCollapsedPersist(true)} title="Collapse">
+            –
+          </button>
         )}
         {variant === "window" && (
           <button

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -26,7 +26,6 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [geminiKey, setGeminiKey] = useState("");
   const [provider, setProvider] = useState("");
   const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
-  const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
   const [saving, setSaving] = useState(false);
@@ -48,7 +47,6 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setGeminiKey(s.gemini_api_key || "");
         setProvider(s.provider || "");
         setOpenaiBaseUrl(s.openai_base_url || "");
-        setCurrentSettings(s);
         setPerWatchCap(s.activity_per_watch_cap || 50);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
@@ -73,8 +71,13 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
     e.preventDefault();
     setSaving(true);
     try {
+      // Re-read fresh and override only the fields this modal edits, so settings
+      // changed elsewhere since the modal opened (e.g. activity_mini_player via
+      // the dock toggle or the floating ✕) aren't clobbered by a stale snapshot.
+      const fresh = await invoke<Settings>("get_settings");
       await invoke("save_settings", {
         settings: {
+          ...fresh,
           model: model.trim(),
           github_token: githubToken.trim(),
           aws_profile: awsProfile.trim(),
@@ -83,15 +86,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           gemini_api_key: geminiKey.trim(),
           provider: provider.trim(),
           openai_base_url: openaiBaseUrl.trim(),
-          filter_older: currentSettings?.filter_older ?? true,
-          filter_team: currentSettings?.filter_team ?? true,
-          view_mode: currentSettings?.view_mode ?? "split",
-          show_hunk_significance: currentSettings?.show_hunk_significance ?? true,
-          show_ai_notes: currentSettings?.show_ai_notes ?? true,
-          hunk_filter: currentSettings?.hunk_filter ?? "all",
           activity_per_watch_cap: perWatchCap,
-          // Controlled by the dock toggle / floating ✕; preserve it here.
-          activity_mini_player: currentSettings?.activity_mini_player ?? true,
         },
       });
       // Persist watches alongside settings, dropping blank rows.

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -29,7 +29,6 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
-  const [miniPlayer, setMiniPlayer] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -51,7 +50,6 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setCurrentSettings(s);
         setPerWatchCap(s.activity_per_watch_cap || 50);
-        setMiniPlayer(s.activity_mini_player ?? true);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -92,7 +90,8 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           show_ai_notes: currentSettings?.show_ai_notes ?? true,
           hunk_filter: currentSettings?.hunk_filter ?? "all",
           activity_per_watch_cap: perWatchCap,
-          activity_mini_player: miniPlayer,
+          // Controlled by the dock toggle / floating ✕; preserve it here.
+          activity_mini_player: currentSettings?.activity_mini_player ?? true,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -341,18 +340,6 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
               + Add watch
             </button>
           </div>
-
-          <label className="settings-checkbox">
-            <input
-              type="checkbox"
-              checked={miniPlayer}
-              onChange={(e) => {
-                setMiniPlayer(e.target.checked);
-                setSaved(false);
-              }}
-            />
-            Show the floating mini-player when Marrow is in the background
-          </label>
 
           <label className="settings-label" htmlFor="per-watch-cap">
             Max PRs per watch

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import type { Settings } from "../types";
+import type { Settings, Watch } from "../types";
+
+function newWatchId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? crypto.randomUUID()
+    : `w-${Date.now()}-${Math.floor(performance.now())}`;
+}
 
 // Keep in sync with browser-extension/content.js getPrRef()
 const BOOKMARKLET_HREF =
@@ -21,6 +27,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [provider, setProvider] = useState("");
   const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
+  const [watches, setWatches] = useState<Watch[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -42,9 +49,23 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setCurrentSettings(s);
       });
+      invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
     }
   }, [open]);
+
+  function updateWatch(id: string, field: "label" | "query", value: string) {
+    setWatches((ws) => ws.map((w) => (w.id === id ? { ...w, [field]: value } : w)));
+    setSaved(false);
+  }
+  function addWatch() {
+    setWatches((ws) => [...ws, { id: newWatchId(), label: "", query: "" }]);
+    setSaved(false);
+  }
+  function removeWatch(id: string) {
+    setWatches((ws) => ws.filter((w) => w.id !== id));
+    setSaved(false);
+  }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
@@ -67,6 +88,12 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           show_ai_notes: currentSettings?.show_ai_notes ?? true,
           hunk_filter: currentSettings?.hunk_filter ?? "all",
         },
+      });
+      // Persist watches alongside settings, dropping blank rows.
+      await invoke("save_watches", {
+        watches: watches
+          .map((w) => ({ ...w, label: w.label.trim(), query: w.query.trim() }))
+          .filter((w) => w.query !== ""),
       });
       setSaved(true);
       setTimeout(() => onClose(), 600);
@@ -267,6 +294,47 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             spellCheck={false}
             autoComplete="off"
           />
+
+          <div className="settings-divider" />
+          <h3 className="settings-section-title">PR Activity Watches</h3>
+          <p className="settings-hint">
+            Saved GitHub searches that feed the activity mini-player — including
+            repos/orgs where you aren't a requested reviewer. Use GitHub search
+            syntax, e.g. <code>is:pr is:open repo:acme/web -is:draft</code>.
+          </p>
+          <div className="watch-editor">
+            {watches.map((w) => (
+              <div className="watch-row" key={w.id}>
+                <input
+                  className="settings-input watch-row__label"
+                  type="text"
+                  value={w.label}
+                  onChange={(e) => updateWatch(w.id, "label", e.target.value)}
+                  placeholder="Label"
+                  spellCheck={false}
+                />
+                <input
+                  className="settings-input watch-row__query"
+                  type="text"
+                  value={w.query}
+                  onChange={(e) => updateWatch(w.id, "query", e.target.value)}
+                  placeholder="is:pr is:open repo:owner/name"
+                  spellCheck={false}
+                />
+                <button
+                  type="button"
+                  className="watch-row__remove"
+                  onClick={() => removeWatch(w.id)}
+                  aria-label="Remove watch"
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+            <button type="button" className="watch-add" onClick={addWatch}>
+              + Add watch
+            </button>
+          </div>
 
           <div className="settings-divider" />
           <h3 className="settings-section-title">Browser Integration</h3>

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -28,6 +28,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [openaiBaseUrl, setOpenaiBaseUrl] = useState("");
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [watches, setWatches] = useState<Watch[]>([]);
+  const [perWatchCap, setPerWatchCap] = useState(50);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -48,6 +49,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setProvider(s.provider || "");
         setOpenaiBaseUrl(s.openai_base_url || "");
         setCurrentSettings(s);
+        setPerWatchCap(s.activity_per_watch_cap || 50);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -87,6 +89,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           show_hunk_significance: currentSettings?.show_hunk_significance ?? true,
           show_ai_notes: currentSettings?.show_ai_notes ?? true,
           hunk_filter: currentSettings?.hunk_filter ?? "all",
+          activity_per_watch_cap: perWatchCap,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -335,6 +338,26 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
               + Add watch
             </button>
           </div>
+
+          <label className="settings-label" htmlFor="per-watch-cap">
+            Max PRs per watch
+          </label>
+          <p className="settings-hint">
+            How many PRs each watch surfaces in the mini-player; the rest show as
+            "+N more". Raise this for org-wide watches that match many PRs.
+          </p>
+          <input
+            id="per-watch-cap"
+            className="settings-input"
+            type="number"
+            min={1}
+            max={200}
+            value={perWatchCap}
+            onChange={(e) => {
+              setPerWatchCap(Math.max(1, Number(e.target.value) || 1));
+              setSaved(false);
+            }}
+          />
 
           <div className="settings-divider" />
           <h3 className="settings-section-title">Browser Integration</h3>

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -29,6 +29,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [currentSettings, setCurrentSettings] = useState<Settings | null>(null);
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
+  const [miniPlayer, setMiniPlayer] = useState(true);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -50,6 +51,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setCurrentSettings(s);
         setPerWatchCap(s.activity_per_watch_cap || 50);
+        setMiniPlayer(s.activity_mini_player ?? true);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -90,6 +92,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           show_ai_notes: currentSettings?.show_ai_notes ?? true,
           hunk_filter: currentSettings?.hunk_filter ?? "all",
           activity_per_watch_cap: perWatchCap,
+          activity_mini_player: miniPlayer,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -338,6 +341,18 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
               + Add watch
             </button>
           </div>
+
+          <label className="settings-checkbox">
+            <input
+              type="checkbox"
+              checked={miniPlayer}
+              onChange={(e) => {
+                setMiniPlayer(e.target.checked);
+                setSaved(false);
+              }}
+            />
+            Show the floating mini-player when Marrow is in the background
+          </label>
 
           <label className="settings-label" htmlFor="per-watch-cap">
             Max PRs per watch

--- a/app/src/hooks/useActivityFeed.ts
+++ b/app/src/hooks/useActivityFeed.ts
@@ -3,6 +3,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import type { PrActivityItem, PrActivityPayload } from "../types";
 
+// Stable empties so the no-data render doesn't hand fresh references to
+// downstream memos (which would defeat their memoization until the first event).
+const EMPTY_ITEMS: PrActivityItem[] = [];
+const EMPTY_TRUNCATED: Record<string, number> = {};
+
 /**
  * Subscribe to the Rust-owned `pr-activity` event and expose the de-duplicated,
  * pre-sorted feed plus the actions both the dock and floating widget need. The
@@ -21,8 +26,8 @@ export function useActivityFeed() {
     };
   }, []);
 
-  const items = payload?.items ?? [];
-  const truncated = payload?.truncated ?? {};
+  const items = payload?.items ?? EMPTY_ITEMS;
+  const truncated = payload?.truncated ?? EMPTY_TRUNCATED;
 
   const unreadCount = useMemo(() => items.filter((i) => i.unread).length, [items]);
   const truncatedTotal = useMemo(
@@ -57,7 +62,7 @@ export function useActivityFeed() {
     );
   }, []);
 
-  return { items, truncated, truncatedTotal, unreadCount, markSeen };
+  return { items, truncatedTotal, unreadCount, markSeen };
 }
 
 /** `owner/repo#number` ref used by the deep-link / fetch entry points. */

--- a/app/src/hooks/useActivityFeed.ts
+++ b/app/src/hooks/useActivityFeed.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import type { PrActivityItem, PrActivityPayload } from "../types";
+
+/**
+ * Subscribe to the Rust-owned `pr-activity` event and expose the de-duplicated,
+ * pre-sorted feed plus the actions both the dock and floating widget need. The
+ * backend is the single source of truth, so every window that calls this hook
+ * stays in sync automatically.
+ */
+export function useActivityFeed() {
+  const [payload, setPayload] = useState<PrActivityPayload | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<PrActivityPayload>("pr-activity", (event) => {
+      setPayload(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const items = payload?.items ?? [];
+  const truncated = payload?.truncated ?? {};
+
+  const unreadCount = useMemo(() => items.filter((i) => i.unread).length, [items]);
+  const truncatedTotal = useMemo(
+    () => Object.values(truncated).reduce((a, b) => a + b, 0),
+    [truncated]
+  );
+
+  /**
+   * Acknowledge a PR: persist its current observable state so the backend's
+   * next poll no longer flags it unread. Optimistically clears the local flag
+   * too, so the UI responds instantly without waiting for the next event.
+   */
+  const markSeen = useCallback((item: PrActivityItem) => {
+    invoke("mark_pr_seen", {
+      prUrl: item.prUrl,
+      observed: {
+        updated_at: item.updatedAt,
+        review_state: item.reviewState ?? null,
+        unresolved_threads: item.unresolvedThreads ?? null,
+        ci_state: item.ciState ?? null,
+      },
+    }).catch(() => {});
+    setPayload((prev) =>
+      prev
+        ? {
+            ...prev,
+            items: prev.items.map((i) =>
+              i.prUrl === item.prUrl ? { ...i, unread: false, deltas: [] } : i
+            ),
+          }
+        : prev
+    );
+  }, []);
+
+  return { items, truncated, truncatedTotal, unreadCount, markSeen };
+}
+
+/** `owner/repo#number` ref used by the deep-link / fetch entry points. */
+export function prRefOf(item: PrActivityItem): string {
+  return `${item.owner}/${item.repo}#${item.number}`;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3955,3 +3955,283 @@ mark.search-highlight-current {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+/* ============================================================
+   Mini-player: PR activity widget
+   One component, four layouts driven by CSS container queries:
+   pill (collapsed) · bar (short) · card (default) · list (tall).
+   ============================================================ */
+
+.activity-widget {
+  --aw-radius: 12px;
+  font-family: var(--font-sans);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+/* In-app dock: a resizable, fixed-corner panel. `container-type: size` lets the
+   inner layout respond to the panel's own width AND height. */
+.activity-widget--dock {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: 340px;
+  height: 440px;
+  min-width: 210px;
+  min-height: 132px;
+  max-width: 92vw;
+  max-height: 88vh;
+  resize: both;
+  overflow: hidden;
+  z-index: 50;
+  container: aw / size;
+  display: flex;
+  flex-direction: column;
+  background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
+  border: 1px solid var(--border);
+  border-radius: var(--aw-radius);
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
+  transition: box-shadow 0.2s ease;
+}
+
+/* Floating window variant fills the OS window; the window itself is the
+   resize surface, the container queries do the reflow. */
+.activity-widget--window {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  container: aw / size;
+  display: flex;
+  flex-direction: column;
+  /* The OS window is frameless + transparent; the widget paints its own
+     rounded, translucent surface so it reads as a floating card. */
+  background: color-mix(in srgb, var(--bg-secondary) 90%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 14px 44px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+  /* WebKit samples backdrop-filter on the rectangular box and leaks past
+     border-radius at the corners; clip-path hard-clips the backdrop too. */
+  clip-path: inset(0 round 12px);
+}
+.activity-widget--window .aw-head { cursor: grab; }
+.activity-widget--window .aw-head:active { cursor: grabbing; }
+/* Tauri starts a window drag only when the clicked element itself is the drag
+   region. Let clicks on the header's decorative children fall through to the
+   <header> (which carries data-tauri-drag-region); buttons keep their clicks. */
+.activity-widget--window .aw-head > *:not(button) { pointer-events: none; }
+
+/* ---- Collapsed pill (Tier 0) ---- */
+.activity-widget--pill {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  width: auto;
+  height: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  z-index: 50;
+  cursor: pointer;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+}
+.activity-widget--pill:hover { border-color: var(--accent); }
+.activity-widget--alert { animation: aw-pulse 2s ease-in-out infinite; }
+.aw-pill__count {
+  font-weight: 600;
+  font-size: 13px;
+  min-width: 16px;
+  text-align: center;
+}
+
+/* ---- Header ---- */
+.aw-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  flex: none;
+}
+.aw-head__title { font-size: 13px; font-weight: 600; letter-spacing: 0.02em; }
+.aw-head__spacer { flex: 1; }
+.aw-head__badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--bg-primary);
+  background: var(--accent);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.aw-iconbtn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-secondary);
+  border-radius: 6px;
+  padding: 2px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  line-height: 1.4;
+}
+.aw-iconbtn:hover:not(:disabled) { background: var(--bg-tertiary); color: var(--text-primary); }
+.aw-iconbtn:disabled { opacity: 0.35; cursor: default; }
+.aw-iconbtn--on { color: var(--accent); border-color: var(--accent); }
+
+/* ---- Equalizer (the Spotify nod) ---- */
+.aw-eq { display: inline-flex; align-items: flex-end; gap: 2px; height: 14px; }
+.aw-eq i {
+  width: 3px;
+  background: var(--accent);
+  border-radius: 1px;
+  animation: aw-eq-bounce 1s ease-in-out infinite;
+}
+.aw-eq i:nth-child(1) { height: 6px; animation-delay: -0.2s; }
+.aw-eq i:nth-child(2) { height: 12px; animation-delay: -0.4s; }
+.aw-eq i:nth-child(3) { height: 8px; animation-delay: -0.1s; }
+
+/* ---- "Now playing" focus block (Tier 1) ---- */
+.aw-focus {
+  flex: none;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+.aw-focus__transport { display: flex; align-items: center; gap: 4px; margin-bottom: 4px; }
+.aw-focus__pos { font-size: 11px; color: var(--text-muted); margin-left: 4px; }
+
+/* ---- Feed (Tier 2) ---- */
+.aw-feed { flex: 1; overflow-y: auto; padding: 4px; }
+.aw-empty, .aw-truncated {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+  padding: 14px 8px;
+}
+.aw-truncated { padding: 8px; font-style: italic; }
+
+/* ---- Row ---- */
+.aw-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 7px 8px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.aw-row:hover { background: var(--bg-tertiary); }
+.aw-row__dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: transparent; flex: none;
+}
+.aw-row--unread .aw-row__dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.aw-row--unread .aw-row__title { font-weight: 600; }
+.aw-row__avatar { width: 22px; height: 22px; border-radius: 50%; flex: none; background: var(--bg-tertiary); }
+.aw-row__avatar--blank { display: inline-block; }
+.aw-row__main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.aw-row__title {
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aw-row__meta { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.aw-row__repo {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.aw-chip {
+  font-size: 10px;
+  padding: 0 6px;
+  border-radius: 999px;
+  white-space: nowrap;
+  line-height: 1.6;
+}
+.aw-chip--delta { color: var(--diff-add-text); background: var(--diff-add-bg); }
+.aw-chip--reason { color: var(--text-secondary); background: var(--bg-tertiary); }
+.aw-row__status { display: flex; align-items: center; gap: 6px; flex: none; }
+.aw-row__time { font-size: 11px; color: var(--text-muted); }
+.aw-ci { font-size: 12px; }
+.aw-ci--ok { color: var(--diff-add-text); }
+.aw-ci--bad { color: var(--risk-critical); }
+.aw-ci--pending { color: var(--risk-medium); }
+.aw-threads {
+  font-size: 10px;
+  color: var(--risk-high);
+  background: var(--risk-high-bg);
+  border-radius: 999px;
+  padding: 0 6px;
+}
+
+/* ---- Container-query layouts ---- */
+
+/* List (tall): the feed is the star; drop the duplicated focus block. */
+@container aw (min-height: 360px) {
+  .aw-focus { display: none; }
+}
+
+/* Bar (short): a single horizontal strip — focus + transport, no scroll feed. */
+@container aw (max-height: 150px) {
+  .activity-widget { flex-direction: column; }
+  .aw-feed { display: none; }
+  .aw-focus { flex: 1; border-bottom: none; display: flex; align-items: center; gap: 10px; }
+  .aw-focus__transport { margin-bottom: 0; }
+}
+
+/* Narrow: shed chips and time to stay tidy. */
+@container aw (max-width: 248px) {
+  .aw-chip--reason, .aw-row__time { display: none; }
+}
+
+/* ---- Watch-list editor (settings) ---- */
+.watch-editor { display: flex; flex-direction: column; gap: 8px; }
+.watch-row { display: flex; gap: 8px; align-items: center; }
+.watch-row__label { flex: 0 0 120px; }
+.watch-row__query { flex: 1; font-family: var(--font-mono); font-size: 12px; }
+.watch-row__remove {
+  flex: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+.watch-row__remove:hover { color: var(--risk-critical); border-color: var(--risk-critical); }
+.watch-add {
+  align-self: flex-start;
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--text-secondary);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.watch-add:hover { color: var(--accent); border-color: var(--accent); }
+
+@keyframes aw-eq-bounce {
+  0%, 100% { transform: scaleY(0.5); }
+  50% { transform: scaleY(1); }
+}
+@keyframes aw-pulse {
+  0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); }
+  50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent), 0 8px 24px rgba(0, 0, 0, 0.45); }
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -3969,8 +3969,9 @@ mark.search-highlight-current {
   box-sizing: border-box;
 }
 
-/* In-app dock: a resizable, fixed-corner panel. `container-type: size` lets the
-   inner layout respond to the panel's own width AND height. */
+/* In-app dock: a resizable, fixed-corner panel. `container-type: inline-size`
+   lets the inner layout respond to the panel's own width; height tiers are
+   JS-driven (block-axis container queries don't match in the WKWebView). */
 .activity-widget--dock {
   position: fixed;
   right: 16px;
@@ -3984,7 +3985,7 @@ mark.search-highlight-current {
   resize: both;
   overflow: hidden;
   z-index: 50;
-  container: aw / size;
+  container: aw / inline-size;
   display: flex;
   flex-direction: column;
   background: color-mix(in srgb, var(--bg-secondary) 92%, transparent);
@@ -4002,7 +4003,7 @@ mark.search-highlight-current {
   inset: 0;
   width: 100vw;
   height: 100vh;
-  container: aw / size;
+  container: aw / inline-size;
   display: flex;
   flex-direction: column;
   /* The OS window is frameless + transparent; the widget paints its own
@@ -4209,32 +4210,28 @@ mark.search-highlight-current {
   padding: 0 6px;
 }
 
-/* ---- Container-query layouts ---- */
+/* ---- Layout tiers ---- */
 
-/* List (tall): the feed is the star; drop the duplicated focus block. */
-@container aw (min-height: 360px) {
-  .aw-focus { display: none; }
+/* Compact (short): a single horizontal strip — the "now playing" PR + transport,
+   no scrolling feed. Driven by `.aw--compact` (toggled in JS from a measured
+   height) because height-axis container queries don't match in the macOS
+   WKWebView. The list/focus swap itself is done by conditional render. */
+.activity-widget.aw--compact .aw-controls { display: none; }
+.activity-widget.aw--compact .aw-focus {
+  flex: 1;
+  border-bottom: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
+.activity-widget.aw--compact .aw-focus__transport { margin-bottom: 0; flex: none; }
+/* Let the PR row consume the remaining width so the title isn't truncated
+   while empty space sits to its right. */
+.activity-widget.aw--compact .aw-focus .aw-row { flex: 1; min-width: 0; }
 
-/* Bar (short): a single horizontal strip — focus + transport, no scroll feed. */
-@container aw (max-height: 150px) {
-  .activity-widget { flex-direction: column; }
-  .aw-feed, .aw-controls { display: none; }
-  .aw-focus {
-    flex: 1;
-    border-bottom: none;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    min-width: 0;
-  }
-  .aw-focus__transport { margin-bottom: 0; flex: none; }
-  /* Let the PR row consume the remaining width so the title isn't truncated
-     while empty space sits to its right. */
-  .aw-focus .aw-row { flex: 1; min-width: 0; }
-}
-
-/* Narrow: shed chips and time to stay tidy. */
+/* Narrow: shed chips and time to stay tidy. (Width-axis container queries do
+   work in the WKWebView, so this one stays a container query.) */
 @container aw (max-width: 248px) {
   .aw-chip--reason, .aw-row__time { display: none; }
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4219,8 +4219,18 @@ mark.search-highlight-current {
 @container aw (max-height: 150px) {
   .activity-widget { flex-direction: column; }
   .aw-feed, .aw-controls { display: none; }
-  .aw-focus { flex: 1; border-bottom: none; display: flex; align-items: center; gap: 10px; }
-  .aw-focus__transport { margin-bottom: 0; }
+  .aw-focus {
+    flex: 1;
+    border-bottom: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+  .aw-focus__transport { margin-bottom: 0; flex: none; }
+  /* Let the PR row consume the remaining width so the title isn't truncated
+     while empty space sits to its right. */
+  .aw-focus .aw-row { flex: 1; min-width: 0; }
 }
 
 /* Narrow: shed chips and time to stay tidy. */

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4239,16 +4239,6 @@ mark.search-highlight-current {
   .aw-chip--reason, .aw-row__time { display: none; }
 }
 
-.settings-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 12px 0;
-  font-size: 13px;
-  color: var(--text-primary);
-  cursor: pointer;
-}
-
 /* ---- Watch-list editor (settings) ---- */
 .watch-editor { display: flex; flex-direction: column; gap: 8px; }
 .watch-row { display: flex; gap: 8px; align-items: center; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4239,6 +4239,16 @@ mark.search-highlight-current {
   .aw-chip--reason, .aw-row__time { display: none; }
 }
 
+.settings-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+  font-size: 13px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
 /* ---- Watch-list editor (settings) ---- */
 .watch-editor { display: flex; flex-direction: column; gap: 8px; }
 .watch-row { display: flex; gap: 8px; align-items: center; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4085,6 +4085,37 @@ mark.search-highlight-current {
 .aw-iconbtn:disabled { opacity: 0.35; cursor: default; }
 .aw-iconbtn--on { color: var(--accent); border-color: var(--accent); }
 
+/* ---- Search + source filter ---- */
+.aw-controls {
+  display: flex;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  flex: none;
+}
+.aw-search {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.aw-search:focus { outline: none; border-color: var(--accent); }
+.aw-source {
+  flex: none;
+  max-width: 42%;
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 4px 6px;
+  cursor: pointer;
+}
+
 /* ---- Equalizer (the Spotify nod) ---- */
 .aw-eq { display: inline-flex; align-items: flex-end; gap: 2px; height: 14px; }
 .aw-eq i {
@@ -4187,7 +4218,7 @@ mark.search-highlight-current {
 /* Bar (short): a single horizontal strip — focus + transport, no scroll feed. */
 @container aw (max-height: 150px) {
   .activity-widget { flex-direction: column; }
-  .aw-feed { display: none; }
+  .aw-feed, .aw-controls { display: none; }
   .aw-focus { flex: 1; border-bottom: none; display: flex; align-items: center; gap: 10px; }
   .aw-focus__transport { margin-bottom: 0; }
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4178,7 +4178,8 @@ mark.search-highlight-current {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.aw-row__meta { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.aw-row__meta { display: flex; align-items: center; gap: 6px; min-width: 0; overflow: hidden; }
+.aw-row__meta > * { flex: none; }
 .aw-row__repo {
   font-family: var(--font-mono);
   font-size: 11px;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -231,3 +231,48 @@ export interface SessionState {
   open_prs: SessionPrEntry[];
   active_pr: string | null;
 }
+
+// ---- Mini-player: PR activity widget ----
+
+/** A saved GitHub search that surfaces PRs into the activity feed. */
+export interface Watch {
+  id: string;
+  label: string;
+  query: string;
+}
+
+/** Observable PR state used for diffing; camelCase mirrors Rust's `Observed`. */
+export interface Observed {
+  updated_at: string;
+  review_state?: string | null;
+  unresolved_threads?: number | null;
+  head_sha?: string | null;
+  comment_count?: number | null;
+  ci_state?: string | null;
+}
+
+/** A row in the activity feed (matches Rust `PrActivityItem`, camelCase wire). */
+export interface PrActivityItem {
+  prUrl: string;
+  owner: string;
+  repo: string;
+  number: number;
+  title: string;
+  author: string;
+  avatarUrl: string;
+  updatedAt: string;
+  draft: boolean;
+  reasons: string[];
+  deltas: string[];
+  reviewState?: string | null;
+  unresolvedThreads?: number | null;
+  ciState?: string | null;
+  unread: boolean;
+}
+
+/** Payload of the `pr-activity` event (matches Rust `PrActivityPayload`). */
+export interface PrActivityPayload {
+  items: PrActivityItem[];
+  truncated: Record<string, number>;
+  fetchedAt: string;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -161,6 +161,7 @@ export interface Settings {
   show_ai_notes: boolean;
   hunk_filter: HunkSignificanceFilter;
   activity_per_watch_cap: number;
+  activity_mini_player: boolean;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -160,6 +160,7 @@ export interface Settings {
   show_hunk_significance: boolean;
   show_ai_notes: boolean;
   hunk_filter: HunkSignificanceFilter;
+  activity_per_watch_cap: number;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -36,6 +36,24 @@ export function extractPrRef(input: string): string | null {
   return match ? match[1] : null;
 }
 
+/**
+ * Normalize a GitHub PR URL or an `owner/repo#number` ref to a single
+ * comparable key (`owner/repo#number`, lowercased), or null if neither shape
+ * matches. Used to tell whether two references point at the same PR.
+ */
+export function canonicalPrKey(input: string): string | null {
+  let owner: string | undefined, repo: string | undefined, number: string | undefined;
+  const urlMatch = input.match(/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+  if (urlMatch) {
+    [, owner, repo, number] = urlMatch;
+  } else {
+    const refMatch = input.match(/^([^/]+)\/([^/#]+)#(\d+)$/);
+    if (!refMatch) return null;
+    [, owner, repo, number] = refMatch;
+  }
+  return `${owner}/${repo}#${number}`.toLowerCase();
+}
+
 export function timeAgo(dateStr: string): string {
   const now = Date.now();
   const then = new Date(dateStr).getTime();

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -54,17 +54,19 @@ export function canonicalPrKey(input: string): string | null {
   return `${owner}/${repo}#${number}`.toLowerCase();
 }
 
-export function timeAgo(dateStr: string): string {
-  const now = Date.now();
+/** Relative time. `short` drops the " ago" suffix (for compact chips). */
+export function timeAgo(dateStr: string, short = false): string {
   const then = new Date(dateStr).getTime();
-  const seconds = Math.floor((now - then) / 1000);
+  if (Number.isNaN(then)) return "";
+  const seconds = Math.floor((Date.now() - then) / 1000);
   if (seconds < 60) return "just now";
+  const suffix = short ? "" : " ago";
   const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
+  if (minutes < 60) return `${minutes}m${suffix}`;
   const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
+  if (hours < 24) return `${hours}h${suffix}`;
   const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
+  if (days < 30) return `${days}d${suffix}`;
   const months = Math.floor(days / 30);
-  return `${months}mo ago`;
+  return `${months}mo${suffix}`;
 }

--- a/app/src/widget.tsx
+++ b/app/src/widget.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { ActivityWidget } from "./components/ActivityWidget";
+import "./styles.css";
+
+/**
+ * Entry point for the floating mini-player window. Renders the *same*
+ * `ActivityWidget` as the in-app dock, in `window` variant. Opening a PR routes
+ * back to the main window via a Tauri command (this window can't drive the main
+ * window's React state directly).
+ */
+function openInMain(prRef: string) {
+  invoke("open_pr_in_main", { prRef }).catch(() => {});
+}
+
+ReactDOM.createRoot(document.getElementById("widget-root")!).render(
+  <React.StrictMode>
+    <ActivityWidget variant="window" onOpenPr={openInMain} />
+  </React.StrictMode>
+);

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { fileURLToPath } from "node:url";
 
 const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig({
   plugins: [react()],
   clearScreen: false,
+  build: {
+    rollupOptions: {
+      input: {
+        // The main app window and the floating mini-player window share one
+        // build but mount different roots.
+        main: fileURLToPath(new URL("./index.html", import.meta.url)),
+        widget: fileURLToPath(new URL("./widget.html", import.meta.url)),
+      },
+    },
+  },
   server: {
     port: 1420,
     strictPort: true,

--- a/app/widget.html
+++ b/app/widget.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Marrow Activity</title>
+    <style>
+      /* Frameless, transparent window: the shared styles.css paints an opaque
+         body background, so override it (!important) to keep the window
+         transparent — otherwise the square window shows through the panel's
+         rounded corners. */
+      html, body, #widget-root {
+        margin: 0;
+        height: 100%;
+        background: transparent !important;
+        overflow: hidden;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="widget-root"></div>
+    <script type="module" src="/src/widget.tsx"></script>
+  </body>
+</html>

--- a/docs/mini-player.md
+++ b/docs/mini-player.md
@@ -1,0 +1,224 @@
+# Mini-Player: PR Activity Widget
+
+Design doc for [issue #74](https://github.com/Besendorfer/marrow/issues/74).
+
+## Goal
+
+A Spotify-style "mini player" that surfaces PR activity quickly and cleanly — new
+comments, status changes, new commits, review requests — across the PRs you care
+about. It works alongside the full Marrow window, can optionally **float** as a
+separate always-on-top window, is **resizable**, and stays beautiful and
+**responsive at any size**. Updates are **near real-time**.
+
+Crucially, it can watch PRs in **orgs/repos where you are not a requested
+reviewer** — via saved GitHub searches — not just PRs assigned to you.
+
+## Why it's worth building deliberately
+
+The two surfaces (in-app dock + floating window) are built **in parallel** off one
+shared component. That only works if the contract between backend and frontend is
+pinned down first: the activity event shape, the seen-state schema, and the watch
+config. This doc is that contract.
+
+---
+
+## Architecture overview
+
+```
+                 ┌──────────────────────────────────────┐
+   GitHub APIs   │            Rust background watcher      │
+  ┌───────────┐  │  ┌────────────┐  diff vs  ┌──────────┐ │
+  │ /notifs   │─▶│  │ Notifs poll│──────────▶│activity. │ │
+  │ /search   │─▶│  │ Search poll│  seen-st  │  json    │ │   emit "pr-activity"
+  │ check_pr  │─▶│  │ Focus diff │◀──────────│ (per-PR) │ │──────────────┐
+  └───────────┘  │  └────────────┘           └──────────┘ │              │
+                 └──────────────────────────────────────┘                │
+                                                                          ▼
+                          ┌───────────────────────────┐   ┌───────────────────────────┐
+                          │  Main window               │   │  Floating widget window     │
+                          │  <ActivityWidget> (dock)   │   │  <ActivityWidget> (frameless│
+                          │                            │   │   transparent, always-top)  │
+                          └───────────────────────────┘   └───────────────────────────┘
+                                   actions (open / snooze / mark-seen)
+                                   ──────────────▶ Tauri commands + relevantreviews:// deep link
+```
+
+**Source of truth is Rust.** A single background watcher merges all three GitHub
+sources, de-dupes by PR URL, diffs against persisted seen-state, and emits a
+`pr-activity` event to **all** windows. Both UI surfaces are pure subscribers. This
+sidesteps the fact that the frontend has no shared state store (all state currently
+lives in `app/src/App.tsx`), and it keeps activity flowing even when the floating
+widget is the only focused window.
+
+---
+
+## The three activity sources (hybrid)
+
+| Source | Covers | Cadence | Cost |
+|---|---|---|---|
+| **Notifications API** (`/notifications`) | PRs you're *involved in* (requested, mentioned, commented, subscribed) | Driven by the `X-Poll-Interval` response header; `If-Modified-Since` → 304s are free | Very cheap |
+| **Search API** (`/search/issues?q=…`) | **Any** repo/org/author/label — the watch-list unlock | ~60–120s, ETag conditional requests | ~30 req/min budget |
+| **Focused diff-poll** (`check_pr_updates`, existing) | Precise CI / review-state on the PR you're actively viewing | 30–60s while focused | Targeted, one PR |
+
+The Notifications API is the near-real-time channel: GitHub literally tells us the
+minimum poll interval and 304-responses don't count against the rate limit. The
+Search API is what lets us watch arbitrary repos/orgs. The focused diff-poll reuses
+what already exists for high-fidelity status on the PR in front of you.
+
+### Watch lists
+
+A first-class config concept — a small set of saved GitHub searches:
+
+```jsonc
+// part of marrow config
+"watches": [
+  { "id": "acme-web", "label": "Acme web", "query": "is:pr is:open repo:acme/web -is:draft" },
+  { "id": "my-org",   "label": "Acme org", "query": "is:pr is:open org:acme review-requested:@me" }
+]
+```
+
+Same query language as GitHub's own search bar. Bounded: we cap result counts,
+paginate sensibly, and **surface what was truncated** rather than silently hiding
+PRs. Each watch maps to a `reason` on the PRs it returns.
+
+---
+
+## Data contract
+
+### Seen-state — `~/.config/marrow/activity.json`
+
+Keyed by PR URL, independent of which source surfaced the PR:
+
+```jsonc
+{
+  "https://github.com/acme/web/pull/42": {
+    "last_seen_at": "2026-06-28T18:00:00Z",   // when the user last opened/acked it
+    "last_comment_count": 7,
+    "last_head_sha": "abc123",
+    "last_review_state": "changes_requested",
+    "last_ci_state": "success"
+  }
+}
+```
+
+"New activity" = any field differs from the live fetch. Opening a PR (or an explicit
+mark-seen) writes the current values back, clearing its unread state.
+
+### `pr-activity` event payload (Rust → all windows)
+
+```jsonc
+{
+  "items": [
+    {
+      "pr_url": "https://github.com/acme/web/pull/42",
+      "number": 42,
+      "repo": "acme/web",
+      "title": "Fix flaky upload test",
+      "author": { "login": "octocat", "avatar_url": "…" },
+      "updated_at": "2026-06-28T18:42:00Z",
+      "reasons": ["review-requested", "watching:acme-web"],  // can be multiple
+      "deltas": ["new-comment", "ci-failed"],                 // what changed since seen
+      "ci_state": "failure",
+      "review_state": "pending",
+      "unresolved_threads": 2,
+      "draft": false,
+      "unread": true
+    }
+  ],
+  "truncated": { "acme-web": 12 },   // counts dropped per source, for honest UI
+  "fetched_at": "2026-06-28T18:42:05Z"
+}
+```
+
+`reasons[]` and `deltas[]` are the two arrays that drive the UI's "why is this here"
+and "what's new" affordances.
+
+---
+
+## UI: one component, four layout modes
+
+The three screenshots in the issue are **not three features — they're one component
+at three sizes.** Driven by **CSS container queries** (responding to the widget's own
+box, not the viewport), with a spring/ease transition on layout change so resizing
+feels alive.
+
+| Mode | Footprint | Issue screenshot | Content |
+|---|---|---|---|
+| **Pill** | tiny | — | Tier 0: attention count + pulse on new activity |
+| **Bar** | wide & short | 633×83 | Tier 1 focused PR + activity ticker + transport |
+| **Card** | small square | 343×219 | Tier 1 rich + "N others" |
+| **List** | tall & narrow | 247×888 | Tier 1 header + full Tier 2 feed |
+
+### Glance tiers (progressive disclosure)
+
+- **Tier 0 — the pulse:** count of PRs needing attention + subtle animation on new
+  events. Always visible, even at pill size.
+- **Tier 1 — "now playing":** the single highest-priority item (active PR, or freshest
+  activity). Title, repo#, author avatar, and *what changed*.
+- **Tier 2 — the feed:** PRs sorted by recent activity. Each row: avatar · title ·
+  status glyph cluster (CI ●✓✗ · review state · unresolved-thread count · draft) ·
+  unread dot · time-ago · source reason chip.
+- **Tier 3 — transport + filter:** prev/next through the attention queue, "play" =
+  open in main window, snooze/pin, filter chip (*needs my review* / *has updates* /
+  *all* / per-watch).
+
+### Looking "super nice"
+
+- Reuse `app/src/styles.css` design tokens for theme cohesion: `--bg-primary #0d1117`,
+  `--accent #58a6ff`, the `--risk-*` and `--diff-*` palettes for status colors,
+  `--font-sans` / `--font-mono`.
+- Motion: equalizer-style activity indicator (the Spotify nod), avatar stacks, soft
+  pulse on new events, eased layout transitions on resize.
+- Floating window chrome: frameless + transparent + rounded corners + macOS vibrancy
+  blur; small min-size so it can shrink to the pill.
+
+---
+
+## Two surfaces, one component
+
+Build `<ActivityWidget>` fully self-contained and event-driven — **no dependence on
+`App.tsx` internals.** It takes activity items as props/subscription and emits
+intent callbacks (open, snooze, mark-seen).
+
+- **In-app:** mount as a collapsible dock panel inside the main window (currently the
+  single `Marrow` 1400×900 window in `tauri.conf.json`).
+- **Floating:** a second `WebviewWindow` — frameless, transparent, always-on-top,
+  `resizable: true` with a small min-size — loading a `widget.html` entry that mounts
+  the same component.
+- **State sync:** Rust emits `pr-activity` to both windows; actions return via Tauri
+  commands and the existing `relevantreviews://` deep link to open a PR in the main
+  window.
+
+---
+
+## Rate limits & "near real-time"
+
+- Notifications: poll-interval-header-driven + `If-Modified-Since`; quiet periods are
+  nearly free.
+- Search: slower beat, ETag conditional requests; the 30 req/min ceiling means we
+  batch/cap watch queries.
+- **Adaptive cadence:** faster when the app is focused or a PR is "hot," slower when
+  idle.
+- **Honest truncation:** if a watch returns more than the cap, the UI shows "+N more"
+  rather than pretending it covered everything.
+
+---
+
+## Build order
+
+Each step is independently useful:
+
+1. **Foundation** — seen-state (`activity.json`) + watch config + Rust background
+   watcher emitting `pr-activity`. Start with diff-poll + Search; layer Notifications.
+2. **Shared component** — container-query `<ActivityWidget>` (pill → bar → card →
+   list), proven in-app as a dock panel.
+3. **Floating window** — promote the same component into a resizable frameless
+   always-on-top `WebviewWindow`.
+4. **Polish** — adaptive cadence, watch-management UX, motion/vibrancy.
+
+## Open questions
+
+- Notifications API coverage: does it carry enough signal (CI? review state?) or is it
+  mainly a "something changed, go look" trigger that we enrich via diff-poll?
+- Watch-list management UX: raw GitHub search string vs. structured builder.
+- Snooze semantics: per-PR mute until next change, or time-based?


### PR DESCRIPTION
Closes #74. Design doc: `docs/mini-player.md`.

A Spotify-style widget that surfaces PR activity — new comments, status changes, new commits, review requests — across the PRs you care about, **including repos/orgs where you aren't a requested reviewer** (via saved GitHub searches, "watches"). It works both as an in-app dock and as a resizable floating window, built from one shared component.

## What's included

**Backend (marrow-core + Tauri)**
- `watches.rs` — saved GitHub searches (`watches.json` sidecar).
- `activity.rs` — per-PR seen-state (`activity.json`) + pure diffing → unread/delta info, with unit tests.
- `github.rs` `collect_activity()` — hybrid sources: review-requests + `/notifications` + per-watch `/search/issues`, de-duped by PR url with per-watch truncation counts. Notifications use `If-Modified-Since` and honor `X-Poll-Interval`.
- `lib.rs` — background `tokio` watcher emits a `pr-activity` event to all windows on an adaptive cadence; commands `get_watches`, `save_watches`, `mark_pr_seen`, `open_activity_window`, `open_pr_in_main`.

**Frontend (React)**
- `ActivityWidget` — one component, four CSS container-query layouts (pill / bar / card / list), CI/review/thread glyphs, transport, session snooze, default-collapse with persistence.
- `useActivityFeed` hook — single subscription, optimistic mark-seen.
- In-app dock mounted in `App.tsx`; watch-list editor in `SettingsModal`.

**Floating window**
- Vite multi-entry (`widget.html` + `widget.tsx` render the *same* component); frameless, transparent, always-on-top, resizable; native shadow off + `clip-path` so rounded corners read cleanly; draggable header; close button. `capabilities/mini-player.json` grants the window perms (`start-dragging`, `close`).

## Verification
- `cargo test -p marrow-core` green (5 activity tests + existing).
- `tsc` + `bun run build` clean (multi-entry emits both windows).
- Manually verified live: dock + floating window render, watches populate the feed, drag/close/pop-out work, rounded corners clean.

## Notes / follow-ups
- Watch queries use raw GitHub search syntax — a repo needs `repo:owner/name` (bare `owner/name` is treated as free text). Considered lenient auto-prefixing; deferred.
- Deferred polish: in-app dock resize-anchor ergonomics; explicit rate-limit backoff on 403/429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)