### PR TITLE
feat(gui): summary-first landing and guided review path

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -11,7 +11,8 @@ import { ActivityWidget } from "./components/ActivityWidget";
 import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
-import { SummaryParagraphs } from "./components/SummaryParagraphs";
+import { PrOverview } from "./components/PrOverview";
+import { NextFileBar } from "./components/NextFileBar";
 import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ReviewPicker } from "./components/ReviewPicker";
@@ -163,6 +164,42 @@ function App() {
     [searchMatches, searchCurrentIndex, selectedFilePath]
   );
 
+  // ── Guided review path ──────────────────────────────────────────────────
+  // The review order is the sidebar's visible order (falls back to relevant
+  // files in manifest order before the sidebar reports in).
+  function guidedOrder(): string[] {
+    if (!activeTab?.manifest) return [];
+    return visibleOrderRef.current.length
+      ? visibleOrderRef.current
+      : activeTab.manifest.files
+          .filter((f) => f.classification !== "NOT_RELEVANT")
+          .map((f) => f.path);
+  }
+
+  // First unviewed file after `fromIdx` in review order (wrapping), treating
+  // `alsoViewed` as already reviewed — used when the current file was just
+  // marked but state hasn't committed yet.
+  function nextUnviewed(order: string[], fromIdx: number, alsoViewed?: string): FileDiff | null {
+    if (!activeTab?.manifest || order.length === 0) return null;
+    const viewed = activeTab.viewedFiles;
+    for (let step = 1; step <= order.length; step++) {
+      const p = order[(fromIdx + step + order.length) % order.length];
+      if (!viewed.has(p) && p !== alsoViewed) {
+        return activeTab.manifest.files.find((f) => f.path === p) ?? null;
+      }
+    }
+    return null;
+  }
+
+  function markReviewedAndAdvance() {
+    if (!activeTab?.selectedFile) return;
+    const path = activeTab.selectedFile.path;
+    const order = guidedOrder();
+    if (!activeTab.viewedFiles.has(path)) toggleViewed(path);
+    const next = nextUnviewed(order, order.indexOf(path), path);
+    if (next) setSelectedFile(next);
+  }
+
   // ── Keyboard shortcuts (ported from the CLI/TUI; see useKeyboardShortcuts) ──
   function selectAdjacentFile(delta: 1 | -1) {
     if (!activeTab?.manifest || !activeTab.selectedFile) return;
@@ -248,7 +285,9 @@ function App() {
       id,
       manifest,
       loading: null,
-      selectedFile: manifest.files.length > 0 ? manifest.files[0] : null,
+      // Land on the overview (summary + change groups), not a file — the
+      // "Start review" CTA and sidebar are the ways in.
+      selectedFile: null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
@@ -733,10 +772,14 @@ function App() {
         isRefreshing: false,
         viewedFiles: preservedViewed,
         staleViewedFiles: newStale,
+        // No selection (the overview) stays on the overview after a refresh;
+        // a selected file follows to the refreshed manifest if it still exists.
         selectedFile:
-          tab.selectedFile && newPaths.has(tab.selectedFile.path)
-            ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? newManifest.files[0] ?? null
-            : newManifest.files[0] ?? null,
+          tab.selectedFile == null
+            ? null
+            : newPaths.has(tab.selectedFile.path)
+              ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? null
+              : newManifest.files[0] ?? null,
         commentThreads: { status: "idle" },
       };
 
@@ -1574,6 +1617,7 @@ function App() {
             selectedCommentFile={activeTab.selectedCommentFile}
             onSelectCommentFile={handleSelectCommentFile}
             onVisibleFilesChange={handleVisibleFilesChange}
+            onShowOverview={() => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, selectedFile: null })); }}
           />
           <div className="diff-pane">
             {activeTab.sidebarView === "comments" ? (
@@ -1597,14 +1641,39 @@ function App() {
                 <div className="no-file-selected">Switch to Comments tab to load threads</div>
               )
             ) : activeTab.selectedFile ? (
-              <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
-            ) : activeTab.manifest.summary ? (
-              <div className="pr-summary">
-                <h3>PR Summary</h3>
-                <SummaryParagraphs text={activeTab.manifest.summary} />
-              </div>
+              (() => {
+                const order = guidedOrder();
+                const idx = order.indexOf(activeTab.selectedFile.path);
+                const allReviewed = order.length > 0 && order.every((p) => activeTab.viewedFiles.has(p));
+                // Exclude the open file so "Next" never points at itself when
+                // it's the last unviewed one.
+                const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
+                return (
+                  <>
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <NextFileBar
+                      index={idx >= 0 ? idx : 0}
+                      total={order.length}
+                      isViewed={activeTab.viewedFiles.has(activeTab.selectedFile.path)}
+                      nextName={next ? next.path.split("/").pop() ?? next.path : null}
+                      allReviewed={allReviewed}
+                      onMarkReviewed={markReviewedAndAdvance}
+                      onNext={() => { if (next) setSelectedFile(next); }}
+                      onFinishReview={() => setReviewPickerOpen(true)}
+                    />
+                  </>
+                );
+              })()
             ) : (
-              <div className="no-file-selected">Select a file to review</div>
+              <PrOverview
+                manifest={activeTab.manifest}
+                viewedCount={activeTab.viewedFiles.size}
+                unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
+                hasSubmittedReview={activeTab.myReviewState != null && activeTab.myReviewState.status !== "pending" && activeTab.myReviewState.status !== "dismissed" && !activeTab.myReviewState.is_re_requested}
+                startTarget={nextUnviewed(guidedOrder(), -1)}
+                onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
+                onSelectFile={setSelectedFile}
+              />
             )}
           </div>
         </div>

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -20,6 +20,7 @@ interface FileSidebarProps {
   onSelectCommentFile: (path: string) => void;
   /** Emits the visible file paths in manifest order, for keyboard file navigation. */
   onVisibleFilesChange?: (paths: string[]) => void;
+  onShowOverview?: () => void;
 }
 
 function getMaxHunkSignificance(file: FileDiff): string {
@@ -412,6 +413,7 @@ export function FileSidebar({
   selectedCommentFile,
   onSelectCommentFile,
   onVisibleFilesChange,
+  onShowOverview,
 }: FileSidebarProps) {
   const hasGroups = changeGroups.length > 0;
   const prevHasGroups = useRef(hasGroups);
@@ -575,6 +577,15 @@ export function FileSidebar({
 
   return (
     <aside className="file-sidebar">
+      {onShowOverview && view !== "comments" && (
+        <button
+          className={`sidebar-overview-link${selectedFile === null ? " active" : ""}`}
+          onClick={onShowOverview}
+          title="Back to the PR summary and change groups"
+        >
+          ← Overview
+        </button>
+      )}
       <div className="sidebar-header">
         <div className="sidebar-header-top">
           <span className="sidebar-title">Files</span>

--- a/app/src/components/NextFileBar.tsx
+++ b/app/src/components/NextFileBar.tsx
@@ -1,0 +1,60 @@
+interface NextFileBarProps {
+  index: number;
+  total: number;
+  isViewed: boolean;
+  nextName: string | null;
+  allReviewed: boolean;
+  onMarkReviewed: () => void;
+  onNext: () => void;
+  onFinishReview: () => void;
+}
+
+export function NextFileBar({
+  index,
+  total,
+  isViewed,
+  nextName,
+  allReviewed,
+  onMarkReviewed,
+  onNext,
+  onFinishReview,
+}: NextFileBarProps) {
+  return (
+    <div className="next-bar">
+      <button
+        className={`next-bar-mark${isViewed ? " next-bar-mark--done" : ""}`}
+        onClick={onMarkReviewed}
+        title={
+          isViewed
+            ? "Already reviewed — go to the next unreviewed file"
+            : "Mark this file reviewed and go to the next one (V toggles without advancing)"
+        }
+      >
+        {isViewed ? "Reviewed ✓" : "Mark reviewed"}
+        {!isViewed && <kbd className="next-bar-key">V</kbd>}
+      </button>
+      <span className="next-bar-pos">
+        {allReviewed ? (
+          "All files reviewed"
+        ) : (
+          <>
+            file {index + 1} of {total}
+            {nextName && (
+              <button className="next-bar-next" onClick={onNext} title="Next file">
+                Next: <span className="next-bar-file">{nextName}</span>
+                <kbd className="next-bar-key">]</kbd>
+              </button>
+            )}
+          </>
+        )}
+      </span>
+      <button
+        className={`next-bar-finish${allReviewed ? " next-bar-finish--ready" : ""}`}
+        onClick={onFinishReview}
+        title="Submit your review (R)"
+      >
+        Finish review…
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -1,0 +1,163 @@
+import { SummaryParagraphs } from "./SummaryParagraphs";
+import type { ReviewManifest, FileDiff, ChangeGroup } from "../types";
+
+interface PrOverviewProps {
+  manifest: ReviewManifest;
+  viewedCount: number;
+  unresolvedThreads: number | null;
+  hasSubmittedReview: boolean;
+  startTarget: FileDiff | null;
+  onStartReview: () => void;
+  onSelectFile: (f: FileDiff) => void;
+}
+
+function fileName(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+function GroupRow({
+  group,
+  files,
+  onSelectFile,
+}: {
+  group: ChangeGroup;
+  files: FileDiff[];
+  onSelectFile: (f: FileDiff) => void;
+}) {
+  if (files.length === 0) return null;
+  const criticalNotes = files.reduce(
+    (n, f) => n + (f.highlights?.filter((h) => h.severity === "critical").length ?? 0),
+    0
+  );
+  const highRisk = files.filter(
+    (f) => f.risk_level === "critical" || f.risk_level === "high"
+  ).length;
+  return (
+    <button className="overview-group" onClick={() => onSelectFile(files[0])}>
+      <div className="overview-group-main">
+        <div className="overview-group-name">{group.label}</div>
+        {group.description && (
+          <div className="overview-group-desc">{group.description}</div>
+        )}
+      </div>
+      <div className="overview-group-side">
+        {criticalNotes > 0 && (
+          <span className="risk-badge risk-critical">
+            {criticalNotes} critical
+          </span>
+        )}
+        {criticalNotes === 0 && highRisk > 0 && (
+          <span className="risk-badge risk-high">{highRisk} high</span>
+        )}
+        <span className="overview-chip">
+          {files.length} {files.length === 1 ? "file" : "files"}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+export function PrOverview({
+  manifest,
+  viewedCount,
+  unresolvedThreads,
+  hasSubmittedReview,
+  startTarget,
+  onStartReview,
+  onSelectFile,
+}: PrOverviewProps) {
+  const relevant = manifest.files.filter((f) => f.classification !== "NOT_RELEVANT");
+  const setAside = manifest.files.length - relevant.length;
+  const byPath = new Map(manifest.files.map((f) => [f.path, f]));
+  const groups = manifest.change_groups ?? [];
+  const criticalNotes = relevant.reduce(
+    (n, f) => n + (f.highlights?.filter((h) => h.severity === "critical").length ?? 0),
+    0
+  );
+  const highRisk = relevant.filter(
+    (f) => f.risk_level === "critical" || f.risk_level === "high"
+  ).length;
+
+  return (
+    <div className="pr-overview">
+      <div className="overview-col">
+        {manifest.summary && (
+          <div className="overview-card">
+            <h4>AI summary</h4>
+            <SummaryParagraphs text={manifest.summary} />
+          </div>
+        )}
+        {groups.length > 0 && (
+          <div className="overview-card">
+            <h4>Change groups</h4>
+            {groups.map((g, i) => (
+              <GroupRow
+                key={i}
+                group={g}
+                files={g.file_paths
+                  .map((p) => byPath.get(p))
+                  .filter((f): f is FileDiff => !!f)}
+                onSelectFile={onSelectFile}
+              />
+            ))}
+          </div>
+        )}
+        {setAside > 0 && (
+          <div className="overview-card overview-noise">
+            {setAside} {setAside === 1 ? "file" : "files"} set aside as noise —
+            lockfiles, generated code, and other changes the AI judged not worth
+            your review time.
+          </div>
+        )}
+      </div>
+      <div className="overview-rail">
+        <div className="overview-card">
+          <h4>Start reviewing</h4>
+          <div className="overview-risk-strip">
+            {criticalNotes > 0 && (
+              <span>
+                <span className="risk-dot risk-dot--critical" /> {criticalNotes}{" "}
+                critical {criticalNotes === 1 ? "note" : "notes"}
+              </span>
+            )}
+            {highRisk > 0 && (
+              <span>
+                <span className="risk-dot risk-dot--high" /> {highRisk} high-risk{" "}
+                {highRisk === 1 ? "file" : "files"}
+              </span>
+            )}
+            {criticalNotes === 0 && highRisk === 0 && (
+              <span>No high-risk changes flagged</span>
+            )}
+          </div>
+          {startTarget ? (
+            <button className="overview-start" onClick={onStartReview}>
+              Start review → {fileName(startTarget.path)}
+            </button>
+          ) : (
+            <div className="overview-state-line">All files reviewed</div>
+          )}
+          <div className="overview-start-sub">
+            {relevant.length} relevant {relevant.length === 1 ? "file" : "files"},
+            in review order
+          </div>
+        </div>
+        <div className="overview-card">
+          <h4>Your state</h4>
+          <div className="overview-state-line">
+            {viewedCount} of {relevant.length} files reviewed
+          </div>
+          <div className="overview-state-line">
+            {hasSubmittedReview ? "Review submitted" : "No review submitted yet"}
+          </div>
+          {unresolvedThreads !== null && unresolvedThreads > 0 && (
+            <div className="overview-state-line">
+              {unresolvedThreads} unresolved{" "}
+              {unresolvedThreads === 1 ? "thread" : "threads"}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -935,7 +935,8 @@ body {
 .diff-viewer {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  flex: 1;
+  min-height: 0;
 }
 
 .diff-header {
@@ -4066,7 +4067,8 @@ mark.search-highlight-current {
 .activity-widget--dock {
   position: fixed;
   right: 16px;
-  bottom: 16px;
+  /* Clears the next-file bar at the bottom of the diff pane. */
+  bottom: 64px;
   width: 340px;
   height: 440px;
   min-width: 210px;
@@ -4120,7 +4122,8 @@ mark.search-highlight-current {
 .activity-widget--pill {
   position: fixed;
   right: 16px;
-  bottom: 16px;
+  /* Clears the next-file bar at the bottom of the diff pane. */
+  bottom: 64px;
   width: auto;
   height: auto;
   display: inline-flex;
@@ -4364,4 +4367,297 @@ mark.search-highlight-current {
 @keyframes aw-pulse {
   0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); }
   50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent), 0 8px 24px rgba(0, 0, 0, 0.45); }
+}
+
+/* ─── PR Overview (summary-first landing) ─────────────────────────────── */
+.pr-overview {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-5);
+  padding: var(--space-5);
+}
+
+.overview-col {
+  flex: 1.5;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.overview-rail {
+  flex: 1;
+  max-width: 320px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  position: sticky;
+  top: 0;
+}
+
+.overview-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
+}
+
+.overview-card h4 {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+}
+
+.overview-card p {
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+  max-width: 68ch;
+}
+
+.overview-card p:last-child {
+  margin-bottom: 0;
+}
+
+.overview-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 10px 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--chip-border);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.overview-group:first-of-type {
+  border-top: none;
+}
+
+.overview-group:hover .overview-group-name {
+  color: var(--accent);
+}
+
+.overview-group-main {
+  min-width: 0;
+}
+
+.overview-group-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.overview-group-desc {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.overview-group-side {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.overview-chip {
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 1px 9px;
+  white-space: nowrap;
+}
+
+.overview-noise {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+
+.overview-risk-strip {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-3);
+}
+
+.overview-risk-strip .risk-dot {
+  display: inline-block;
+  margin-right: 4px;
+}
+
+.overview-start {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 16px;
+  background: var(--accent-strong);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--white);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.overview-start:hover {
+  background: var(--accent-strong-hover);
+}
+
+.overview-start-sub {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+
+.overview-state-line {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  padding: 3px 0;
+}
+
+/* ─── Next-file bar (guided review path) ──────────────────────────────── */
+.next-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: 8px var(--space-4);
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+
+.next-bar-mark {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.next-bar-mark:hover {
+  border-color: var(--text-muted);
+}
+
+.next-bar-mark--done {
+  color: var(--diff-add-text);
+  background: transparent;
+}
+
+.next-bar-pos {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+
+.next-bar-next {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 2px 4px;
+}
+
+.next-bar-next:hover .next-bar-file {
+  color: var(--accent);
+}
+
+.next-bar-file {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.next-bar-key {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: var(--bg-primary);
+  border: 1px solid var(--chip-border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-sm);
+  padding: 0 5px;
+  line-height: 15px;
+}
+
+.next-bar-finish {
+  margin-left: auto;
+  padding: 4px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.next-bar-finish:hover {
+  border-color: var(--text-muted);
+}
+
+.next-bar-finish--ready {
+  background: var(--accent-strong);
+  border-color: transparent;
+  color: var(--white);
+}
+
+.next-bar-finish--ready:hover {
+  background: var(--accent-strong-hover);
+  border-color: transparent;
+}
+
+.sidebar-overview-link {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.sidebar-overview-link:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.sidebar-overview-link.active {
+  color: var(--accent);
 }


### PR DESCRIPTION
> Stacked on #139 (calm visual pass) — retarget to `main` after it merges.

## Summary
- Opening a PR now lands on an **Overview**: AI summary, change groups with severity totals, "N files set aside as noise", and a **Start review** CTA that enters the first unviewed file in review order. Previously the summary hid behind a "Show Summary" button and the app dropped you into the first file.
- A **next-file bar** under the diff keeps the review linear: *Mark reviewed* advances to the next unviewed file, *Next: file (n of m)* mirrors `]`, and *Finish review…* turns primary once everything is reviewed and opens the review picker.
- "← Overview" link atop the sidebar returns to the landing; refreshing while on the overview stays on the overview.
- Frontend-only; reuses existing state (viewed files, sidebar visible order, review picker).

## Changes
- `app/src/components/PrOverview.tsx` (new) — landing view: summary, groups (click → first file of group), noise count, risk strip, Start review, "Your state" card
- `app/src/components/NextFileBar.tsx` (new) — guided bottom bar
- `app/src/App.tsx` — land on overview (`selectedFile: null`), guided-order helpers (`guidedOrder`/`nextUnviewed`/`markReviewedAndAdvance`), bar + overview wiring, refresh keeps overview
- `app/src/components/FileSidebar.tsx` — "← Overview" link
- `app/src/styles.css` — overview/next-bar styles on the new tokens; mini-player dock/pill raised to clear the bar

## Test Plan
- [x] `bun run build` clean (`cargo check` clean; no Rust changes)
- [x] Adversarial verifier pass — 3 findings (noise line gated behind groups, "Next" pointing at the open file when it's the last unviewed, `is_re_requested` omitted from "Review submitted") all fixed, plus the refresh-kicks-to-first-file fallback
- [x] Live-app verification (dev build, PR #134): overview renders with real summary/groups/state, Start review enters `fetch.rs`, bar shows "file 1 of 12 · Next: ai.rs", mini-player pill clears the bar
- [ ] Mark-reviewed auto-advance and the all-reviewed → primary "Finish review…" state on a real review session

🤖 Generated with [Claude Code](https://claude.com/claude-code)