### PR TITLE
feat(gui): review queue home, command palette, and fetch retry

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -17,6 +17,8 @@ import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ReviewPicker } from "./components/ReviewPicker";
 import { ToastContainer, createToast, type ToastData } from "./components/Toast";
+import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
@@ -41,8 +43,10 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const [reviewPickerOpen, setReviewPickerOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
+  const [queueFilter, setQueueFilter] = useState("");
   const searchRef = useRef<SearchBarHandle>(null);
   const diffViewerRef = useRef<DiffViewerHandle>(null);
   // Visible file order from the sidebar, used by the [ / ] navigation shortcuts.
@@ -247,7 +251,8 @@ function App() {
       onRefresh: () => { if (activeTab?.manifest) handleRefreshPr(); },
       onOpenSearch: () => searchRef.current?.open("local"),
       onToggleHelp: () => setHelpOpen((o) => !o),
-      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); },
+      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); setPaletteOpen(false); },
+      onTogglePalette: () => setPaletteOpen((v) => !v),
       onNextTab: () => selectAdjacentTab(1),
       onPrevTab: () => selectAdjacentTab(-1),
       onCloseTab: () => { if (activeTabId) closeTab(activeTabId); },
@@ -275,7 +280,7 @@ function App() {
     },
     {
       enabled: !!activeTab?.manifest,
-      overlayOpen: helpOpen || settingsOpen || searchOpen || showChecksModal || reviewPickerOpen,
+      overlayOpen: helpOpen || settingsOpen || searchOpen || showChecksModal || reviewPickerOpen || paletteOpen,
     },
   );
 
@@ -635,6 +640,7 @@ function App() {
     updateTab(loadingTabId, (t) => ({
       ...t,
       error: null,
+      lastPrRef: prRef,
       loading: { prRef, prTitle: null, progress: null, fileCounts: {} },
     }));
 
@@ -1462,8 +1468,43 @@ function App() {
     }
   }
 
+  // Command palette registry — searchable home for every action, with the
+  // keyboard hint teaching the direct shortcut. Review commands only appear
+  // when a PR is loaded.
+  const paletteCommands: PaletteCommand[] = [];
+  if (activeTab?.manifest) {
+    const m = activeTab.manifest;
+    paletteCommands.push(
+      { id: "overview", section: "Review", title: "Back to overview", run: () => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, selectedFile: null })); } },
+      { id: "next-file", section: "Review", title: "Next file", keys: "]", run: () => selectAdjacentFile(1) },
+      { id: "prev-file", section: "Review", title: "Previous file", keys: "[", run: () => selectAdjacentFile(-1) },
+      { id: "mark-viewed", section: "Review", title: "Mark file reviewed", keys: "V", run: () => { const p = activeTab.selectedFile?.path; if (p) toggleViewed(p); } },
+      { id: "mark-next", section: "Review", title: "Mark reviewed and go to next", run: markReviewedAndAdvance },
+      { id: "finish", section: "Review", title: "Finish review…", keys: "R", run: () => setReviewPickerOpen(true) },
+      { id: "search", section: "Review", title: "Search in diffs", keys: "/", run: () => searchRef.current?.open("local") },
+      { id: "threads", section: "Review", title: "Toggle threads view", keys: "T", run: toggleThreadsView },
+      { id: "refresh", section: "Review", title: "Refresh PR", keys: "⌃R", run: handleRefreshPr },
+      { id: "github", section: "Review", title: "Open PR on GitHub", run: () => { openUrl(m.pr_url); } },
+      { id: "view-split", section: "View", title: "Split diff view", run: () => setViewMode("split") },
+      { id: "view-unified", section: "View", title: "Unified diff view", run: () => setViewMode("unified") },
+      { id: "toggle-sig", section: "View", title: showHunkSignificance ? "Hide hunk significance" : "Show hunk significance", run: () => setShowHunkSignificance((v) => !v) },
+      { id: "toggle-notes", section: "View", title: showAiNotes ? "Hide AI notes" : "Show AI notes", run: () => setShowAiNotes((v) => !v) },
+    );
+  }
+  paletteCommands.push(
+    { id: "new-tab", section: "App", title: "New review tab", keys: "⌃T", run: handleNewReview },
+    { id: "settings", section: "App", title: "Settings…", run: () => setSettingsOpen(true) },
+    { id: "updates", section: "App", title: "Check for updates", run: () => checkForUpdates(false) },
+    { id: "help", section: "App", title: "Keyboard shortcuts", keys: "?", run: () => setHelpOpen(true) },
+  );
+
   const overlays = (
     <>
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        commands={paletteCommands}
+      />
       <UpdateBanner
         status={updateStatus}
         onDownload={handleDownloadUpdate}
@@ -1536,6 +1577,7 @@ function App() {
         myReviewState={activeTab?.myReviewState}
         checksBlocking={showChecksModal}
         onCheckForUpdates={() => checkForUpdates(false)}
+        onOpenPalette={() => setPaletteOpen(true)}
       />
       <SettingsModal
         open={settingsOpen}
@@ -1547,8 +1589,8 @@ function App() {
           onDragOver={(e) => e.preventDefault()}
           onDrop={handleFileDrop}
         >
-          <div className="empty-message">
-            {activeTab.loading ? (
+          {activeTab.loading ? (
+            <div className="empty-message">
               <LoadingView
                 prRef={activeTab.loading.prRef}
                 prTitle={activeTab.loading.prTitle}
@@ -1556,31 +1598,41 @@ function App() {
                 fileCounts={activeTab.loading.fileCounts}
                 onCancel={() => handleFetchCancel(activeTab.id)}
               />
-            ) : (
-              <>
-                {activeTab.error && (
-                  <div className="opener-error" role="alert">
-                    <strong>Failed to load PR</strong>
-                    <pre>{activeTab.error}</pre>
-                  </div>
-                )}
-                <h1>Marrow</h1>
-                <p>
-                  Drop a manifest JSON file here, or enter a PR URL below to start
-                  a review.
-                </p>
-                <PrOpener
-                  onFetchStart={(ref) => handleFetchStart(ref, activeTab.id)}
-                  onSettingsClick={() => setSettingsOpen(true)}
-                  onCheckForUpdates={() => checkForUpdates(false)}
-                />
-                <ReviewRequestList
-                  onSelectPr={(ref) => handleFetchStart(ref, activeTab.id)}
-                  openPrUrls={openPrUrls}
-                />
-              </>
-            )}
-          </div>
+            </div>
+          ) : (
+            <div className="queue-home">
+              <PrOpener
+                onFetchStart={(ref) => handleFetchStart(ref, activeTab.id)}
+                onFilterChange={setQueueFilter}
+                onSettingsClick={() => setSettingsOpen(true)}
+                onCheckForUpdates={() => checkForUpdates(false)}
+              />
+              {activeTab.error && (
+                <div className="opener-error" role="alert">
+                  <strong>
+                    Couldn't load {activeTab.lastPrRef ?? "the PR"}
+                  </strong>
+                  <pre>{activeTab.error}</pre>
+                  {activeTab.lastPrRef && (
+                    <button
+                      className="opener-retry"
+                      onClick={() => handleFetchStart(activeTab.lastPrRef!, activeTab.id)}
+                    >
+                      Try again
+                    </button>
+                  )}
+                </div>
+              )}
+              <ReviewRequestList
+                onSelectPr={(ref) => handleFetchStart(ref, activeTab.id)}
+                openPrUrls={openPrUrls}
+                filter={queueFilter}
+              />
+              <div className="queue-drop-hint">
+                Tip: drop a manifest JSON file anywhere here to load a review.
+              </div>
+            </div>
+          )}
         </div>
       ) : (
         <div className="review-content">

--- a/app/src/components/CommandPalette.tsx
+++ b/app/src/components/CommandPalette.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export interface PaletteCommand {
+  id: string;
+  title: string;
+  section: string;
+  /** Display-only shortcut hint, e.g. "V" or "⌘R". */
+  keys?: string;
+  run: () => void;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+  commands: PaletteCommand[];
+}
+
+// Rank: prefix match beats substring beats in-order subsequence.
+function score(title: string, query: string): number {
+  const t = title.toLowerCase();
+  const q = query.toLowerCase();
+  if (q === "") return 1;
+  if (t.startsWith(q)) return 3;
+  if (t.includes(q)) return 2;
+  let i = 0;
+  for (const ch of t) {
+    if (ch === q[i]) i++;
+    if (i === q.length) return 1;
+  }
+  return 0;
+}
+
+export function CommandPalette({ open, onClose, commands }: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const matches = useMemo(() => {
+    return commands
+      .map((c) => ({ c, s: score(c.title, query.trim()) }))
+      .filter((m) => m.s > 0)
+      .sort((a, b) => b.s - a.s)
+      .map((m) => m.c);
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setSelected(0);
+      // Focus after the overlay renders.
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setSelected(0);
+  }, [query]);
+
+  useEffect(() => {
+    listRef.current
+      ?.querySelector('[data-selected="true"]')
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selected, matches]);
+
+  if (!open) return null;
+
+  function runCommand(cmd: PaletteCommand) {
+    onClose();
+    cmd.run();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelected((s) => Math.min(s + 1, matches.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelected((s) => Math.max(s - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const cmd = matches[selected];
+      if (cmd) runCommand(cmd);
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  }
+
+  let lastSection: string | null = null;
+
+  return (
+    <div className="palette-backdrop" onMouseDown={onClose}>
+      <div className="palette" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="palette-input-row">
+          <span className="palette-icon" aria-hidden="true">⌕</span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a command…"
+            aria-label="Command palette"
+          />
+        </div>
+        <div className="palette-list" ref={listRef}>
+          {matches.length === 0 && (
+            <div className="palette-empty">No matching commands</div>
+          )}
+          {matches.map((cmd, i) => {
+            const showSection = cmd.section !== lastSection;
+            lastSection = cmd.section;
+            return (
+              <div key={cmd.id}>
+                {showSection && (
+                  <div className="palette-section">{cmd.section}</div>
+                )}
+                <button
+                  className={`palette-row${i === selected ? " selected" : ""}`}
+                  data-selected={i === selected}
+                  onMouseEnter={() => setSelected(i)}
+                  onClick={() => runCommand(cmd)}
+                >
+                  <span className="palette-title">{cmd.title}</span>
+                  {cmd.keys && <kbd className="next-bar-key">{cmd.keys}</kbd>}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -55,6 +55,7 @@ interface HeaderProps {
   myReviewState?: MyReviewState;
   checksBlocking?: boolean;
   onCheckForUpdates: () => void;
+  onOpenPalette: () => void;
 }
 
 export function Header({
@@ -80,6 +81,7 @@ export function Header({
   myReviewState,
   checksBlocking,
   onCheckForUpdates,
+  onOpenPalette,
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
@@ -196,6 +198,7 @@ export function Header({
             </div>
             {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} myReviewState={myReviewState} checksBlocking={checksBlocking} />}
             <ToolbarMenu
+              onOpenPalette={onOpenPalette}
               showHunkSignificance={showHunkSignificance}
               onToggleHunkSignificance={onToggleHunkSignificance}
               showAiNotes={showAiNotes}
@@ -217,6 +220,7 @@ export function Header({
 }
 
 function ToolbarMenu({
+  onOpenPalette,
   showHunkSignificance,
   onToggleHunkSignificance,
   showAiNotes,
@@ -225,6 +229,7 @@ function ToolbarMenu({
   onSettingsClick,
   onCheckForUpdates,
 }: {
+  onOpenPalette: () => void;
   showHunkSignificance: boolean;
   onToggleHunkSignificance: () => void;
   showAiNotes: boolean;
@@ -274,6 +279,17 @@ function ToolbarMenu({
           >
             <span className="toolbar-menu-check" />
             View on GitHub
+          </button>
+          <button
+            className="toolbar-menu-item"
+            onClick={() => {
+              onOpenPalette();
+              setIsOpen(false);
+            }}
+          >
+            <span className="toolbar-menu-check" />
+            Command palette
+            <span className="toolbar-menu-hint">⌘K</span>
           </button>
           <button
             className="toolbar-menu-item"

--- a/app/src/components/PrOpener.tsx
+++ b/app/src/components/PrOpener.tsx
@@ -1,68 +1,78 @@
 import { useState } from "react";
+import { isOpenablePrRef } from "../utils";
 
 interface PrOpenerProps {
   onFetchStart: (prRef: string) => void;
+  onFilterChange?: (filter: string) => void;
   onSettingsClick?: () => void;
   onCheckForUpdates?: () => void;
 }
 
-export function PrOpener({ onFetchStart, onSettingsClick, onCheckForUpdates }: PrOpenerProps) {
-  const [prRef, setPrRef] = useState("");
+// One box does both jobs: paste anything that parses as a PR ref and Enter
+// opens it; any other text filters the queue below as you type.
+export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onCheckForUpdates }: PrOpenerProps) {
+  const [value, setValue] = useState("");
+  const openable = isOpenablePrRef(value.trim());
+
+  function handleChange(v: string) {
+    setValue(v);
+    onFilterChange?.(isOpenablePrRef(v.trim()) ? "" : v.trim());
+  }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!prRef.trim()) return;
-    onFetchStart(prRef.trim());
+    const trimmed = value.trim();
+    if (!trimmed || !openable) return;
+    onFetchStart(trimmed);
+    handleChange("");
   }
 
   return (
-    <div className="pr-opener">
-      <form className="pr-opener-form" onSubmit={handleSubmit}>
+    <form className="queue-omnibox-row" onSubmit={handleSubmit}>
+      <div className="queue-omnibox">
+        <span className="queue-omnibox-icon" aria-hidden="true">⌕</span>
         <input
           type="text"
-          className="pr-opener-input"
-          value={prRef}
-          onChange={(e) => setPrRef(e.target.value)}
-          placeholder="PR URL or owner/repo#123 or just #123"
+          value={value}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="Paste a PR URL or owner/repo#123, or filter your queue…"
         />
+        {openable && (
+          <button type="submit" className="queue-omnibox-open">
+            Open PR ↵
+          </button>
+        )}
+      </div>
+      {onCheckForUpdates && (
         <button
-          type="submit"
-          className="pr-opener-button"
-          disabled={!prRef.trim()}
+          type="button"
+          className="pr-opener-gear"
+          onClick={onCheckForUpdates}
+          title="Check for updates"
+          aria-label="Check for updates"
         >
-          Open PR
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M17 1v6h-6" />
+            <path d="M3 10a7 7 0 0 1 11.9-5l2.1 2" />
+            <path d="M3 19v-6h6" />
+            <path d="M17 10a7 7 0 0 1-11.9 5l-2.1-2" />
+          </svg>
         </button>
-        {onCheckForUpdates && (
-          <button
-            type="button"
-            className="pr-opener-gear"
-            onClick={onCheckForUpdates}
-            title="Check for Updates"
-            aria-label="Check for updates"
-          >
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M17 1v6h-6" />
-              <path d="M3 10a7 7 0 0 1 11.9-5l2.1 2" />
-              <path d="M3 19v-6h6" />
-              <path d="M17 10a7 7 0 0 1-11.9 5l-2.1-2" />
-            </svg>
-          </button>
-        )}
-        {onSettingsClick && (
-          <button
-            type="button"
-            className="pr-opener-gear"
-            onClick={onSettingsClick}
-            title="Settings"
-            aria-label="Settings"
-          >
-            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
-              <path d="M16.2 12.5a1.4 1.4 0 0 0 .28 1.54l.05.05a1.7 1.7 0 1 1-2.4 2.4l-.06-.05a1.4 1.4 0 0 0-1.54-.28 1.4 1.4 0 0 0-.85 1.28v.14a1.7 1.7 0 1 1-3.4 0v-.07a1.4 1.4 0 0 0-.91-1.28 1.4 1.4 0 0 0-1.54.28l-.05.05a1.7 1.7 0 1 1-2.4-2.4l.05-.06a1.4 1.4 0 0 0 .28-1.54 1.4 1.4 0 0 0-1.28-.85h-.14a1.7 1.7 0 1 1 0-3.4h.07a1.4 1.4 0 0 0 1.28-.91 1.4 1.4 0 0 0-.28-1.54l-.05-.05a1.7 1.7 0 1 1 2.4-2.4l.06.05a1.4 1.4 0 0 0 1.54.28h.07a1.4 1.4 0 0 0 .85-1.28v-.14a1.7 1.7 0 1 1 3.4 0v.07a1.4 1.4 0 0 0 .85 1.28 1.4 1.4 0 0 0 1.54-.28l.05-.05a1.7 1.7 0 1 1 2.4 2.4l-.05.06a1.4 1.4 0 0 0-.28 1.54v.07a1.4 1.4 0 0 0 1.28.85h.14a1.7 1.7 0 0 1 0 3.4h-.07a1.4 1.4 0 0 0-1.28.85Z" />
-            </svg>
-          </button>
-        )}
-      </form>
-    </div>
+      )}
+      {onSettingsClick && (
+        <button
+          type="button"
+          className="pr-opener-gear"
+          onClick={onSettingsClick}
+          title="Settings"
+          aria-label="Settings"
+        >
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" />
+            <path d="M16.2 12.5a1.4 1.4 0 0 0 .28 1.54l.05.05a1.7 1.7 0 1 1-2.4 2.4l-.06-.05a1.4 1.4 0 0 0-1.54-.28 1.4 1.4 0 0 0-.85 1.28v.14a1.7 1.7 0 1 1-3.4 0v-.07a1.4 1.4 0 0 0-.91-1.28 1.4 1.4 0 0 0-1.54.28l-.05.05a1.7 1.7 0 1 1-2.4-2.4l.05-.06a1.4 1.4 0 0 0 .28-1.54 1.4 1.4 0 0 0-1.28-.85h-.14a1.7 1.7 0 1 1 0-3.4h.07a1.4 1.4 0 0 0 1.28-.91 1.4 1.4 0 0 0-.28-1.54l-.05-.05a1.7 1.7 0 1 1 2.4-2.4l.06.05a1.4 1.4 0 0 0 1.54.28h.07a1.4 1.4 0 0 0 .85-1.28v-.14a1.7 1.7 0 1 1 3.4 0v.07a1.4 1.4 0 0 0 .85 1.28 1.4 1.4 0 0 0 1.54-.28l.05-.05a1.7 1.7 0 1 1 2.4 2.4l-.05.06a1.4 1.4 0 0 0-.28 1.54v.07a1.4 1.4 0 0 0 1.28.85h.14a1.7 1.7 0 0 1 0 3.4h-.07a1.4 1.4 0 0 0-1.28.85Z" />
+          </svg>
+        </button>
+      )}
+    </form>
   );
 }

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -5,6 +5,12 @@ import type { ReviewRequestItem, ReviewStatus, Settings, CachedPrInfo } from "..
 interface ReviewRequestListProps {
   onSelectPr: (prRef: string) => void;
   openPrUrls: Set<string>;
+  /** Text filter from the omnibox — matches repo, title, and author. */
+  filter?: string;
+}
+
+function initials(login: string): string {
+  return login.slice(0, 2).toUpperCase();
 }
 
 function formatTimeAgo(dateStr: string): string {
@@ -43,7 +49,7 @@ const STATUS_CLASSES: Record<ReviewStatus, string> = {
   pending: "",
 };
 
-export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListProps) {
+export function ReviewRequestList({ onSelectPr, openPrUrls, filter }: ReviewRequestListProps) {
   const [cachedPrs, setCachedPrs] = useState<CachedPrInfo[]>([]);
   const [recentItems, setRecentItems] = useState<ReviewRequestItem[]>([]);
   const [olderItems, setOlderItems] = useState<ReviewRequestItem[]>([]);
@@ -154,24 +160,38 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
     });
   }
 
+  const needle = (filter ?? "").trim().toLowerCase();
+  const matchesFilter = useCallback(
+    (repo: string, title: string, author: string) =>
+      needle === "" ||
+      repo.toLowerCase().includes(needle) ||
+      title.toLowerCase().includes(needle) ||
+      author.toLowerCase().includes(needle),
+    [needle]
+  );
+
   const filteredRecent = useMemo(() => {
     return recentItems.filter((item) => {
       if (!item.direct_request && !showTeam) return false;
-      return true;
+      return matchesFilter(`${item.owner}/${item.repo}`, item.title, item.author);
     });
-  }, [recentItems, showTeam]);
+  }, [recentItems, showTeam, matchesFilter]);
 
   const filteredOlder = useMemo(() => {
     if (!showOlder) return [];
     return olderItems.filter((item) => {
       if (!item.direct_request && !showTeam) return false;
-      return true;
+      return matchesFilter(`${item.owner}/${item.repo}`, item.title, item.author);
     });
-  }, [olderItems, showOlder, showTeam]);
+  }, [olderItems, showOlder, showTeam, matchesFilter]);
 
   const filteredCached = useMemo(() => {
-    return cachedPrs.filter((pr) => !openPrUrls.has(pr.pr_url));
-  }, [cachedPrs, openPrUrls]);
+    return cachedPrs.filter(
+      (pr) =>
+        !openPrUrls.has(pr.pr_url) &&
+        matchesFilter(`${pr.owner}/${pr.repo}`, pr.pr_title, "")
+    );
+  }, [cachedPrs, openPrUrls, matchesFilter]);
 
   const hasRecent = recentItems.length > 0;
   const hasOlder = olderItems.length > 0;
@@ -201,7 +221,7 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
     return (
       <div className="review-requests">
         <div className="review-requests-header">
-          <span className="review-requests-title">Review Requests</span>
+          <span className="review-requests-title">Review queue</span>
         </div>
         <div className="review-requests-loading">
           <div className="loading-view-spinner" />
@@ -215,7 +235,7 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
     return (
       <div className="review-requests">
         <div className="review-requests-header">
-          <span className="review-requests-title">Review Requests</span>
+          <span className="review-requests-title">Review queue</span>
         </div>
         <div className="review-requests-error">
           <span>{error}</span>
@@ -231,10 +251,10 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
     return (
       <div className="review-requests">
         <div className="review-requests-header">
-          <span className="review-requests-title">Review Requests</span>
+          <span className="review-requests-title">Review queue</span>
           <button className="review-requests-refresh" onClick={refreshAll}>Refresh</button>
         </div>
-        <div className="review-requests-empty">No pending review requests</div>
+        <div className="review-requests-empty">You're all caught up — no PRs are waiting on your review.</div>
       </div>
     );
   }
@@ -246,7 +266,7 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
   return (
     <div className="review-requests">
       <div className="review-requests-header">
-        <span className="review-requests-title">Review Requests</span>
+        <span className="review-requests-title">Review queue</span>
         {filterBar}
         <button className="review-requests-refresh" onClick={refreshAll}>Refresh</button>
       </div>
@@ -255,12 +275,12 @@ export function ReviewRequestList({ onSelectPr, openPrUrls }: ReviewRequestListP
           <CachedPrSection items={filteredCached} onSelectPr={onSelectPr} />
         )}
         {noFilterResults ? (
-          <div className="review-requests-empty">No results match current filters</div>
+          <div className="review-requests-empty">Nothing in the queue matches.</div>
         ) : (
           <>
             {filteredRecent.length > 0 && (
               <ReviewRequestSection
-                label="Last 30 days"
+                label="Needs your review"
                 items={filteredRecent}
                 onSelectPr={onSelectPr}
                 showGroupHeaders={showTeam && filteredRecent.some((i) => i.direct_request) && filteredRecent.some((i) => !i.direct_request)}
@@ -355,27 +375,29 @@ function ReviewRequestRow({
   const statusClass = STATUS_CLASSES[item.my_review_status];
 
   return (
-    <button
-      className="review-request-item"
-      onClick={() => onSelect(prRef)}
-    >
-      <div className="review-request-item-top">
-        <span className="review-request-repo">{item.owner}/{item.repo}</span>
-        <span className="review-request-number">#{item.number}</span>
-        {statusLabel && (
-          <span className={`review-status-badge ${statusClass}`}>{statusLabel}</span>
-        )}
-        {item.unresolved_thread_count > 0 && (
-          <span className="review-threads-badge">
-            {item.unresolved_thread_count} unresolved
+    <button className="queue-row" onClick={() => onSelect(prRef)}>
+      <span className="queue-avatar" aria-hidden="true">{initials(item.author)}</span>
+      <span className="queue-main">
+        <span className="queue-title">
+          <span className="queue-repo">{item.owner}/{item.repo}#{item.number}</span>
+          {item.title}
+        </span>
+        <span className="queue-meta">
+          <span className="queue-why">
+            {item.direct_request ? "Review requested" : "Team review request"} by{" "}
+            {item.author} · {formatTimeAgo(item.created_at)}
           </span>
-        )}
-      </div>
-      <div className="review-request-title">{item.title}</div>
-      <div className="review-request-meta">
-        <span className="review-request-author">{item.author}</span>
-        <span className="review-request-time">{formatTimeAgo(item.created_at)}</span>
-      </div>
+          {statusLabel && (
+            <span className={`review-status-badge ${statusClass}`}>{statusLabel}</span>
+          )}
+          {item.unresolved_thread_count > 0 && (
+            <span className="review-threads-badge">
+              {item.unresolved_thread_count} unresolved
+            </span>
+          )}
+        </span>
+      </span>
+      <span className="queue-review-btn">Review</span>
     </button>
   );
 }
@@ -396,7 +418,7 @@ function CachedPrSection({
         onClick={() => setCollapsed((v) => !v)}
       >
         <span className={`collapse-chevron ${collapsed ? "collapsed" : ""}`}>&#9662;</span>
-        <span className="review-requests-section-label">Recently Analyzed</span>
+        <span className="review-requests-section-label">Recently analyzed</span>
         <span className="review-requests-group-count">{items.length}</span>
       </button>
       {!collapsed && (
@@ -406,19 +428,22 @@ function CachedPrSection({
             return (
               <button
                 key={pr.pr_url}
-                className="review-request-item cached-pr-item"
+                className="queue-row queue-row--dim"
                 onClick={() => onSelectPr(prRef)}
               >
-                <div className="review-request-item-top">
-                  <span className="review-request-repo">{pr.owner}/{pr.repo}</span>
-                  <span className="review-request-number">#{pr.pr_number}</span>
-                  <span className="cached-badge" title="Loads instantly from cache">&#9889;</span>
-                </div>
-                <div className="review-request-title">{pr.pr_title}</div>
-                <div className="review-request-meta">
-                  <span className="review-request-author">{pr.file_count} file{pr.file_count !== 1 ? "s" : ""}</span>
-                  <span className="review-request-time">{formatTimeAgo(pr.cached_at)}</span>
-                </div>
+                <span className="queue-avatar" aria-hidden="true">{initials(pr.repo)}</span>
+                <span className="queue-main">
+                  <span className="queue-title">
+                    <span className="queue-repo">{pr.owner}/{pr.repo}#{pr.pr_number}</span>
+                    {pr.pr_title}
+                  </span>
+                  <span className="queue-meta">
+                    <span className="queue-why">
+                      Analyzed {formatTimeAgo(pr.cached_at)} · {pr.file_count} file{pr.file_count !== 1 ? "s" : ""} · opens instantly
+                    </span>
+                  </span>
+                </span>
+                <span className="queue-review-btn">Open</span>
               </button>
             );
           })}

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -45,6 +45,8 @@ export interface ShortcutHandlers {
   onReviewPicker: () => void;
   onReply: () => void;
   onResolve: () => void;
+  /** Toggle the command palette (Cmd/Ctrl+K) — works everywhere, even in fields. */
+  onTogglePalette: () => void;
 }
 
 export interface ShortcutOptions {
@@ -102,6 +104,14 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
           if (!isEditable(e.target)) h.onCloseTab();
           return;
         }
+      }
+
+      // Cmd/Ctrl+K toggles the command palette from anywhere — including from
+      // inside inputs (its own input closes it with the same chord).
+      if ((e.metaKey || e.ctrlKey) && !e.altKey && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        h.onTogglePalette();
+        return;
       }
 
       // Typing into a field never triggers shortcuts.

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -100,18 +100,24 @@ body {
   flex: 1;
   min-height: 0;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
   overflow: hidden;
 }
 
+/* Loading view still centers itself inside the tab. */
+.opener-tab .empty-message {
+  align-self: center;
+}
+
 .opener-error {
-  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
   padding: 12px 16px;
-  border: 1px solid var(--diff-remove-text);
-  border-radius: 6px;
+  border: 1px solid rgba(248, 81, 73, 0.5);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
   text-align: left;
-  max-width: 600px;
 }
 
 .opener-error strong {
@@ -4660,4 +4666,299 @@ mark.search-highlight-current {
 
 .sidebar-overview-link.active {
   color: var(--accent);
+}
+
+/* ─── Review queue home (opener tab) ──────────────────────────────────── */
+.queue-home {
+  width: 100%;
+  max-width: 780px;
+  margin: 0 auto;
+  padding: var(--space-5) var(--space-4) var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  overflow-y: auto;
+  height: 100%;
+}
+
+.queue-omnibox-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.queue-omnibox {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  padding: 9px 14px;
+}
+
+.queue-omnibox:focus-within {
+  border-color: var(--accent);
+}
+
+.queue-omnibox-icon {
+  color: var(--text-muted);
+  font-size: 15px;
+}
+
+.queue-omnibox input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-family: var(--font-sans);
+}
+
+.queue-omnibox input::placeholder {
+  color: var(--text-muted);
+}
+
+.queue-omnibox-open {
+  flex-shrink: 0;
+  padding: 3px 12px;
+  background: var(--accent-strong);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--white);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.queue-omnibox-open:hover {
+  background: var(--accent-strong-hover);
+}
+
+.queue-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 10px var(--space-3);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.queue-row:hover {
+  background: var(--bg-secondary);
+  border-color: var(--chip-border);
+}
+
+.queue-row--dim {
+  opacity: 0.6;
+}
+
+.queue-row--dim:hover {
+  opacity: 1;
+}
+
+.queue-avatar {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.queue-main {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.queue-title {
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.queue-repo {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-right: 8px;
+}
+
+.queue-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.queue-why {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.queue-review-btn {
+  flex-shrink: 0;
+  padding: 3px 12px;
+  border-radius: var(--radius-md);
+  background: var(--accent-strong);
+  color: var(--white);
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.queue-row:hover .queue-review-btn {
+  opacity: 1;
+}
+
+.queue-drop-hint {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  text-align: center;
+  padding-top: var(--space-3);
+}
+
+.opener-retry {
+  align-self: flex-start;
+  margin-top: 8px;
+  padding: 4px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.opener-retry:hover {
+  border-color: var(--text-muted);
+}
+
+/* ─── Command palette ─────────────────────────────────────────────────── */
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 8, 12, 0.55);
+  z-index: 90;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 14vh;
+}
+
+.palette {
+  width: 520px;
+  max-width: 90vw;
+  background: var(--bg-secondary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-3);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.palette-input-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--chip-border);
+}
+
+.palette-icon {
+  color: var(--accent);
+  font-size: 15px;
+}
+
+.palette-input-row input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-family: var(--font-sans);
+}
+
+.palette-list {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 6px 8px 10px;
+}
+
+.palette-section {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 10px 10px 3px;
+}
+
+.palette-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.palette-row.selected {
+  background: var(--accent-bg);
+}
+
+.palette-title {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.palette-empty {
+  padding: 16px 10px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+}
+
+.toolbar-menu-hint {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-muted);
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -116,6 +116,8 @@ export interface Tab {
   unread?: boolean;
   /** error message from a failed fetch in this (still pending) tab; null otherwise */
   error?: string | null;
+  /** last PR ref this tab tried to fetch — lets a failed fetch offer Retry */
+  lastPrRef?: string | null;
   selectedFile: FileDiff | null;
   viewedFiles: Set<string>;
   staleViewedFiles: Set<string>;

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -37,6 +37,20 @@ export function extractPrRef(input: string): string | null {
 }
 
 /**
+ * True when the input is something `fetch_pr` can open: a PR URL, an
+ * `owner/repo#123` or `owner/repo/pull/123` ref, or a bare `#123` (resolved
+ * against the configured default repo by the backend). Mirrors the accepted
+ * shapes in pr_parser.rs — the omnibox uses this to decide "open" vs "filter".
+ */
+export function isOpenablePrRef(input: string): boolean {
+  if (extractPrRef(input) !== null) return true;
+  return (
+    /^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]{1,100}(#\d+|\/pull\/\d+)$/.test(input) ||
+    /^#\d+$/.test(input)
+  );
+}
+
+/**
  * Normalize a GitHub PR URL or an `owner/repo#number` ref to a single
  * comparable key (`owner/repo#number`, lowercased), or null if neither shape
  * matches. Used to tell whether two references point at the same PR.


### PR DESCRIPTION
> Stacked on #140 (guided review flow), which stacks on #139 — retarget as parents merge.

## Summary
- **Review Queue home**: the blank opener tab becomes a prioritized inbox. One omnibox both opens PR refs (URL / `owner/repo#N` / `owner/repo/pull/N` / `#N`) and live-filters the queue by repo/title/author; sections are "Needs your review", "Older", and dimmed "Recently analyzed" cache rows with an instant-open affordance. No data-fetch logic changed — this is presentation over the existing review-request + cache sources.
- **⌘K command palette**: fuzzy-searchable registry of every review/view/app action with inline shortcut hints (teaching the keyboard layer), arrow/enter/escape/click, section grouping, and a "Command palette ⌘K" entry in the ⋯ menu. Single-key shortcuts suppress while open.
- **Fetch retry**: failed loads keep their ref (`Tab.lastPrRef`) and show "Couldn't load <ref>" + **Try again** instead of a dead-end exception dump.

## Changes
- `app/src/components/PrOpener.tsx` — rewritten as the omnibox (open vs filter via new `utils.isOpenablePrRef`)
- `app/src/components/ReviewRequestList.tsx` — queue-row markup, filter prop, renamed sections, friendlier empty states (data logic untouched)
- `app/src/components/CommandPalette.tsx` (new) + `app/src/hooks/useKeyboardShortcuts.ts` (Cmd/Ctrl+K before the typing guard) + registry in `App.tsx`
- `app/src/App.tsx` — queue-home layout, filter state, retry wiring, palette state/registry
- `app/src/components/Header.tsx` — ⋯ menu palette entry; `app/src/types.ts` — `lastPrRef`; `app/src/styles.css` — queue/palette/retry styles on the tokens

## Test Plan
- [x] `bun run build` + `cargo check` clean
- [x] Adversarial verifier pass — 2 findings fixed (omnibox rejected the shorthand `owner/repo#N` its own placeholder advertises; duplicate "Review" section header in the palette)
- [x] Live-app verification: queue renders with real data (review request, cached PR row), omnibox filter narrows/restores the list live, cancel-during-fetch returns to the queue intact
- [ ] Press ⌘K in the app: palette opens, arrows/enter run commands, Esc closes, single-key shortcuts suppressed while open (global-chord path can't be exercised by synthetic events, needs one human keypress)
- [ ] Force a failed fetch (bogus PR ref) → error card shows the ref + Try again refetches

🤖 Generated with [Claude Code](https://claude.com/claude-code)