### PR TITLE
feat(gui): first-run setup with live validation, stale-cache confirm

### DIFF
--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -230,6 +230,19 @@ impl AiBackend {
     }
 }
 
+/// End-to-end provider check for setup/settings: build the backend from the
+/// candidate settings and send a one-word prompt. Returns the provider label
+/// on success so the UI can say what actually answered.
+pub async fn validate_provider(s: &Settings) -> Result<String, String> {
+    let label = provider_for_settings(s).label().to_string();
+    let backend = AiBackend::from_settings(s).await?;
+    backend
+        .invoke("Reply with the single word: ok")
+        .await
+        .map_err(|e| format!("{label}: {e}"))?;
+    Ok(label)
+}
+
 /// Upper bound on generated tokens for the Anthropic API (required by the API;
 /// generous so classification of large PRs isn't truncated).
 const ANTHROPIC_MAX_TOKENS: u32 = 8192;
@@ -362,8 +375,15 @@ fn resolve_claude_binary() -> &'static str {
 }
 
 async fn invoke_claude_cli(model: &str, prompt: &str) -> Result<String, String> {
+    // No model configured → let the CLI use its own default. `--model ""` is a
+    // 400 from the API.
+    let mut args: Vec<&str> = Vec::new();
+    if !model.is_empty() {
+        args.extend(["--model", model]);
+    }
+    args.push("--print");
     let mut child = Command::new(resolve_claude_binary())
-        .args(["--model", model, "--print"])
+        .args(&args)
         .env("CLAUDECODE", "") // prevent recursive Claude Code invocation
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -104,6 +104,7 @@ fn default_settings() -> Settings {
         activity_per_watch_cap: 50,
         activity_mini_player: true,
         show_approved_prs: false,
+        setup_done: false,
     }
 }
 
@@ -135,6 +136,7 @@ pub fn load_settings() -> Settings {
     let mut activity_per_watch_cap = 50u64;
     let mut activity_mini_player = true;
     let mut show_approved_prs = false;
+    let mut setup_done = false;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -173,6 +175,8 @@ pub fn load_settings() -> Settings {
             activity_mini_player = val == "true";
         } else if let Some(val) = line.strip_prefix("show_approved_prs=") {
             show_approved_prs = val == "true";
+        } else if let Some(val) = line.strip_prefix("setup_done=") {
+            setup_done = val == "true";
         }
     }
 
@@ -194,6 +198,7 @@ pub fn load_settings() -> Settings {
         activity_per_watch_cap,
         activity_mini_player,
         show_approved_prs,
+        setup_done,
     }
 }
 
@@ -241,6 +246,7 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
         settings.activity_mini_player
     ));
     content.push_str(&format!("show_approved_prs={}\n", settings.show_approved_prs));
+    content.push_str(&format!("setup_done={}\n", settings.setup_done));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -130,6 +130,10 @@ pub struct Settings {
     /// once you approve a PR, it drops out of the feed.
     #[serde(default)]
     pub show_approved_prs: bool,
+    /// True once the first-run welcome has been completed or skipped, so it
+    /// never auto-shows again (config via env vars alone also suppresses it).
+    #[serde(default)]
+    pub setup_done: bool,
 }
 
 fn default_true() -> bool {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -41,6 +41,32 @@ pub fn save_settings(settings: Settings) -> Result<(), String> {
     save_settings_to_disk(&settings)
 }
 
+/// True when the first-run welcome should show: setup never completed/skipped
+/// and no GitHub token resolves from config or env.
+#[command]
+pub fn needs_setup() -> bool {
+    let settings = load_settings();
+    !settings.setup_done && resolve_github_token(&settings).is_none()
+}
+
+/// Check a GitHub token by fetching the authenticated user. Takes the token
+/// directly (not saved settings) so setup can validate before saving.
+#[command]
+pub async fn validate_github_token(token: String) -> Result<String, String> {
+    let trimmed = token.trim().to_string();
+    if trimmed.is_empty() {
+        return Err("No token provided".into());
+    }
+    GithubClient::new(Some(trimmed)).get_authenticated_user().await
+}
+
+/// Check the AI provider config end-to-end with a one-word prompt. Takes the
+/// candidate settings so setup can validate before saving.
+#[command]
+pub async fn validate_ai_provider(settings: Settings) -> Result<String, String> {
+    marrow_core::ai::validate_provider(&settings).await
+}
+
 #[command]
 pub fn load_manifest(path: String) -> Result<ReviewManifest, String> {
     let content =

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -218,6 +218,9 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::get_pending_deep_link,
             commands::signal_frontend_ready,
+            commands::needs_setup,
+            commands::validate_github_token,
+            commands::validate_ai_provider,
             commands::load_manifest,
             commands::get_initial_manifest_path,
             commands::fetch_pr,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -18,13 +18,14 @@ import { KeyboardHelp } from "./components/KeyboardHelp";
 import { ReviewPicker } from "./components/ReviewPicker";
 import { ToastContainer, createToast, type ToastData } from "./components/Toast";
 import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
+import { WelcomeSetup } from "./components/WelcomeSetup";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
@@ -44,6 +45,9 @@ function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
+  // Cached PR whose head moved — re-analyzing costs an AI pass, so confirm.
+  const [staleConfirm, setStaleConfirm] = useState<{ prRef: string; title: string } | null>(null);
   const [reviewPickerOpen, setReviewPickerOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [queueFilter, setQueueFilter] = useState("");
@@ -168,6 +172,25 @@ function App() {
     [searchMatches, searchCurrentIndex, selectedFilePath]
   );
 
+  // Opening from the "Recently analyzed" cache: if the PR's head moved, the
+  // backend would silently run a full AI re-analysis — surface that first.
+  async function handleOpenCachedPr(prRef: string, info: CachedPrInfo) {
+    try {
+      const status = await invoke<PrUpdateStatus>("check_pr_updates", {
+        prUrl: info.pr_url,
+        currentHeadSha: info.head_sha,
+        currentCommentCount: 0,
+      });
+      if (status.head_sha_changed) {
+        setStaleConfirm({ prRef, title: info.pr_title });
+        return;
+      }
+    } catch {
+      // Status check failing (offline, rate limit) shouldn't block opening.
+    }
+    handleFetchStart(prRef);
+  }
+
   // ── Guided review path ──────────────────────────────────────────────────
   // The review order is the sidebar's visible order (falls back to relevant
   // files in manifest order before the sidebar reports in).
@@ -252,7 +275,9 @@ function App() {
       onOpenSearch: () => searchRef.current?.open("local"),
       onToggleHelp: () => setHelpOpen((o) => !o),
       onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); setPaletteOpen(false); },
-      onTogglePalette: () => setPaletteOpen((v) => !v),
+      // Not during first-run setup — the palette would open invisibly under
+      // the welcome card and pop up when setup closes.
+      onTogglePalette: () => { if (!welcomeOpen) setPaletteOpen((v) => !v); },
       onNextTab: () => selectAdjacentTab(1),
       onPrevTab: () => selectAdjacentTab(-1),
       onCloseTab: () => { if (activeTabId) closeTab(activeTabId); },
@@ -432,6 +457,12 @@ function App() {
       // Tell the backend it's safe to skip cold-start buffering — from now on
       // hot-open emits go straight to the listener above.
       invoke("signal_frontend_ready").catch(() => {});
+
+      // First run (no token anywhere, never completed/skipped setup) shows the
+      // two-step welcome instead of a blank queue + hidden settings.
+      invoke<boolean>("needs_setup")
+        .then((needed) => { if (needed) setWelcomeOpen(true); })
+        .catch(() => {});
     }
 
     initSession();
@@ -1500,6 +1531,12 @@ function App() {
 
   const overlays = (
     <>
+      {welcomeOpen && (
+        <WelcomeSetup
+          onDone={() => setWelcomeOpen(false)}
+          onOpenSettings={() => setSettingsOpen(true)}
+        />
+      )}
       <CommandPalette
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
@@ -1625,9 +1662,33 @@ function App() {
               )}
               <ReviewRequestList
                 onSelectPr={(ref) => handleFetchStart(ref, activeTab.id)}
+                onSelectCachedPr={handleOpenCachedPr}
                 openPrUrls={openPrUrls}
                 filter={queueFilter}
               />
+              {staleConfirm && (
+                <div className="settings-overlay" onMouseDown={() => setStaleConfirm(null)}>
+                  <div className="welcome-card" onMouseDown={(e) => e.stopPropagation()}>
+                    <h3>This PR has new commits</h3>
+                    <p>
+                      "{staleConfirm.title}" changed since it was analyzed.
+                      Opening it now will run the AI analysis again on the
+                      latest version.
+                    </p>
+                    <div className="welcome-actions">
+                      <button
+                        className="welcome-primary"
+                        onClick={() => { const ref = staleConfirm.prRef; setStaleConfirm(null); handleFetchStart(ref, activeTab.id); }}
+                      >
+                        Analyze updated PR
+                      </button>
+                      <button className="welcome-skip" onClick={() => setStaleConfirm(null)}>
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
               <div className="queue-drop-hint">
                 Tip: drop a manifest JSON file anywhere here to load a review.
               </div>

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -4,6 +4,9 @@ import type { ReviewRequestItem, ReviewStatus, Settings, CachedPrInfo } from "..
 
 interface ReviewRequestListProps {
   onSelectPr: (prRef: string) => void;
+  /** Cached rows pass their cache info so the app can warn before an
+   *  unexpected AI re-analysis when the PR has moved on. */
+  onSelectCachedPr?: (prRef: string, info: CachedPrInfo) => void;
   openPrUrls: Set<string>;
   /** Text filter from the omnibox — matches repo, title, and author. */
   filter?: string;
@@ -49,7 +52,7 @@ const STATUS_CLASSES: Record<ReviewStatus, string> = {
   pending: "",
 };
 
-export function ReviewRequestList({ onSelectPr, openPrUrls, filter }: ReviewRequestListProps) {
+export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, filter }: ReviewRequestListProps) {
   const [cachedPrs, setCachedPrs] = useState<CachedPrInfo[]>([]);
   const [recentItems, setRecentItems] = useState<ReviewRequestItem[]>([]);
   const [olderItems, setOlderItems] = useState<ReviewRequestItem[]>([]);
@@ -272,7 +275,7 @@ export function ReviewRequestList({ onSelectPr, openPrUrls, filter }: ReviewRequ
       </div>
       <div className="review-requests-list">
         {filteredCached.length > 0 && (
-          <CachedPrSection items={filteredCached} onSelectPr={onSelectPr} />
+          <CachedPrSection items={filteredCached} onSelectPr={onSelectPr} onSelectCachedPr={onSelectCachedPr} />
         )}
         {noFilterResults ? (
           <div className="review-requests-empty">Nothing in the queue matches.</div>
@@ -405,9 +408,11 @@ function ReviewRequestRow({
 function CachedPrSection({
   items,
   onSelectPr,
+  onSelectCachedPr,
 }: {
   items: CachedPrInfo[];
   onSelectPr: (prRef: string) => void;
+  onSelectCachedPr?: (prRef: string, info: CachedPrInfo) => void;
 }) {
   const [collapsed, setCollapsed] = useState(false);
 
@@ -429,7 +434,7 @@ function CachedPrSection({
               <button
                 key={pr.pr_url}
                 className="queue-row queue-row--dim"
-                onClick={() => onSelectPr(prRef)}
+                onClick={() => (onSelectCachedPr ? onSelectCachedPr(prRef, pr) : onSelectPr(prRef))}
               >
                 <span className="queue-avatar" aria-hidden="true">{initials(pr.repo)}</span>
                 <span className="queue-main">

--- a/app/src/components/WelcomeSetup.tsx
+++ b/app/src/components/WelcomeSetup.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { Settings } from "../types";
+
+interface WelcomeSetupProps {
+  onDone: () => void;
+  onOpenSettings: () => void;
+}
+
+type CheckState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "ok"; detail: string }
+  | { status: "error"; message: string };
+
+// Two-step first-run setup. Each step validates against the live service
+// before moving on, so a bad token or key can't fail thirty seconds into the
+// first PR fetch. Skippable — config files and env vars still work.
+export function WelcomeSetup({ onDone, onOpenSettings }: WelcomeSetupProps) {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [token, setToken] = useState("");
+  const [tokenCheck, setTokenCheck] = useState<CheckState>({ status: "idle" });
+  const [model, setModel] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [aiCheck, setAiCheck] = useState<CheckState>({ status: "idle" });
+  const [saving, setSaving] = useState(false);
+
+  async function checkToken() {
+    setTokenCheck({ status: "checking" });
+    try {
+      const login = await invoke<string>("validate_github_token", { token });
+      setTokenCheck({ status: "ok", detail: login });
+    } catch (e) {
+      setTokenCheck({ status: "error", message: String(e) });
+    }
+  }
+
+  async function mergedSettings(): Promise<Settings> {
+    const current = await invoke<Settings>("get_settings");
+    return {
+      ...current,
+      github_token: token.trim() || current.github_token,
+      model: model.trim() || current.model,
+      anthropic_api_key: apiKey.trim() || current.anthropic_api_key,
+      setup_done: true,
+    };
+  }
+
+  async function checkAi() {
+    setAiCheck({ status: "checking" });
+    try {
+      const candidate = await mergedSettings();
+      const provider = await invoke<string>("validate_ai_provider", { settings: candidate });
+      setAiCheck({ status: "ok", detail: provider });
+    } catch (e) {
+      setAiCheck({ status: "error", message: String(e) });
+    }
+  }
+
+  async function finish(markDone: boolean) {
+    setSaving(true);
+    try {
+      const settings = markDone
+        ? await mergedSettings()
+        : { ...(await invoke<Settings>("get_settings")), setup_done: true };
+      await invoke("save_settings", { settings });
+    } catch {
+      // Saving is best-effort here — worst case the welcome shows again.
+    } finally {
+      setSaving(false);
+      onDone();
+    }
+  }
+
+  return (
+    <div className="settings-overlay">
+      <div className="welcome-card">
+        {step === 1 ? (
+          <>
+            <div className="welcome-step">Welcome to Marrow · Step 1 of 2</div>
+            <h3>Connect GitHub</h3>
+            <p>
+              Marrow reads pull requests with a personal access token (classic
+              or fine-grained, with repo read access). It stays on this Mac.
+            </p>
+            <label className="welcome-label">Personal access token</label>
+            <input
+              className="settings-input"
+              type="password"
+              value={token}
+              onChange={(e) => {
+                setToken(e.target.value);
+                setTokenCheck({ status: "idle" });
+              }}
+              placeholder="ghp_… or github_pat_…"
+              autoFocus
+            />
+            {tokenCheck.status === "ok" ? (
+              <div className="welcome-check welcome-check--ok">
+                ✓ Connected as @{tokenCheck.detail}
+              </div>
+            ) : tokenCheck.status === "error" ? (
+              <div className="welcome-check welcome-check--err">
+                {tokenCheck.message}
+              </div>
+            ) : null}
+            <div className="welcome-actions">
+              {tokenCheck.status === "ok" ? (
+                <button className="welcome-primary" onClick={() => setStep(2)}>
+                  Continue → AI provider
+                </button>
+              ) : (
+                <button
+                  className="welcome-primary"
+                  onClick={checkToken}
+                  disabled={!token.trim() || tokenCheck.status === "checking"}
+                >
+                  {tokenCheck.status === "checking" ? "Checking…" : "Test connection"}
+                </button>
+              )}
+              <button className="welcome-skip" onClick={() => finish(false)} disabled={saving}>
+                I'll do this later
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="welcome-step">Welcome to Marrow · Step 2 of 2</div>
+            <h3>Choose an AI provider</h3>
+            <p>
+              The AI finds the files and lines worth your attention. Enter a
+              model and key — or leave both empty to use the local{" "}
+              <code>claude</code> CLI if it's installed.
+            </p>
+            <label className="welcome-label">Model</label>
+            <input
+              className="settings-input"
+              type="text"
+              value={model}
+              onChange={(e) => {
+                setModel(e.target.value);
+                setAiCheck({ status: "idle" });
+              }}
+              placeholder="e.g. claude-sonnet-4-5, gpt-5.2, gemini-3-pro"
+            />
+            <label className="welcome-label">Anthropic API key (for claude-* models)</label>
+            <input
+              className="settings-input"
+              type="password"
+              value={apiKey}
+              onChange={(e) => {
+                setApiKey(e.target.value);
+                setAiCheck({ status: "idle" });
+              }}
+              placeholder="sk-ant-… (leave empty for the claude CLI)"
+            />
+            <div className="welcome-hint">
+              OpenAI, Gemini, Bedrock, and custom endpoints are configurable in{" "}
+              <button className="welcome-link" onClick={() => { onDone(); onOpenSettings(); }}>
+                Settings
+              </button>
+              .
+            </div>
+            {aiCheck.status === "ok" ? (
+              <div className="welcome-check welcome-check--ok">
+                ✓ Provider responded ({aiCheck.detail})
+              </div>
+            ) : aiCheck.status === "error" ? (
+              <div className="welcome-check welcome-check--err">{aiCheck.message}</div>
+            ) : null}
+            <div className="welcome-actions">
+              {aiCheck.status === "ok" ? (
+                <button className="welcome-primary" onClick={() => finish(true)} disabled={saving}>
+                  Finish setup
+                </button>
+              ) : (
+                <button
+                  className="welcome-primary"
+                  onClick={checkAi}
+                  disabled={aiCheck.status === "checking"}
+                >
+                  {aiCheck.status === "checking" ? "Checking…" : "Test provider"}
+                </button>
+              )}
+              {aiCheck.status !== "ok" && (
+                <button className="welcome-skip" onClick={() => finish(true)} disabled={saving}>
+                  Skip — finish anyway
+                </button>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4962,3 +4962,139 @@ mark.search-highlight-current {
   font-size: 10.5px;
   color: var(--text-muted);
 }
+
+/* ─── First-run welcome ───────────────────────────────────────────────── */
+.welcome-card {
+  width: 440px;
+  max-width: 92vw;
+  background: var(--bg-secondary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-3);
+  padding: var(--space-5) 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.welcome-step {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.welcome-card h3 {
+  font-size: 17px;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.welcome-card p {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 0 4px;
+}
+
+.welcome-card code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  padding: 0 4px;
+}
+
+.welcome-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-top: 4px;
+}
+
+.welcome-check {
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.welcome-check--ok {
+  color: var(--diff-add-text);
+}
+
+.welcome-check--err {
+  color: var(--diff-remove-text);
+  word-break: break-word;
+}
+
+.welcome-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-top: var(--space-2);
+}
+
+.welcome-primary {
+  padding: 6px 16px;
+  background: var(--accent-strong);
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--white);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.welcome-primary:hover:not(:disabled) {
+  background: var(--accent-strong-hover);
+}
+
+.welcome-primary:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.welcome-skip {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12.5px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 0;
+}
+
+.welcome-skip:hover {
+  color: var(--text-primary);
+}
+
+.welcome-hint {
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+
+.welcome-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 11.5px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 0;
+}
+
+.welcome-link:hover {
+  text-decoration: underline;
+}
+
+/* hljs's markdown grammar can match emphasis across lines when highlighting a
+   mid-file excerpt (a diff hunk), italicizing everything after the false
+   match. Diffs show markup source, so suppress font-style theatrics there —
+   color classes still apply. */
+.diff-content .hljs-emphasis {
+  font-style: normal;
+}
+.diff-content .hljs-strong {
+  font-weight: inherit;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -166,6 +166,7 @@ export interface Settings {
   activity_per_watch_cap: number;
   activity_mini_player: boolean;
   show_approved_prs: boolean;
+  setup_done: boolean;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";


### PR DESCRIPTION
> Top of the stack: #139 → #140 → #141 → this. Retarget as parents merge.

## Summary
- **First-run welcome**: two validated steps replace the blank-queue-plus-hidden-gear cold start. Step 1 tests the GitHub token live ("✓ Connected as @you"); step 2 tests the AI provider end-to-end with a one-word prompt ("✓ Provider responded (claude-cli)"). Skippable at both steps; a new `Settings.setup_done` flag (config-format + TS + Rust) prevents re-showing, and env-var-only setups never see it (`needs_setup` checks the *resolved* token).
- **Stale-cache confirm**: opening a "Recently analyzed" PR whose head moved used to silently start a full AI re-analysis. Now the head sha is checked first and a modal asks before spending an AI pass ("Analyze updated PR" / Cancel; status-check failures fall through to a normal open).
- **Three real bugs fixed along the way** (each found by exercising the flow for real): the claude-CLI backend sent `--model ""` when no model is configured (API 400 — now omits the flag), hljs markdown emphasis could leak across diff lines italicizing whole files (neutralized within `.diff-content`), and ⌘K could open the palette invisibly beneath the welcome card.

## Changes
- `crates/core/src/ai.rs` — `validate_provider` (backend + one-word invoke, provider label in errors); claude-CLI empty-model fix
- `crates/core/src/{types,config}.rs` — `setup_done` through struct/default/parse/save
- `src-tauri/src/{commands,lib}.rs` — `needs_setup` / `validate_github_token` / `validate_ai_provider` commands + registration
- `app/src/components/WelcomeSetup.tsx` (new) — the two-step flow; `App.tsx` — wiring, stale-confirm modal, ⌘K guard; `ReviewRequestList.tsx` — cached rows pass `CachedPrInfo`; `styles.css` — welcome styles + hljs emphasis fix; `types.ts` — `setup_done`

## Test Plan
- [x] `bun run build` + `cargo check` clean; `cargo test -p marrow-core --lib` 19/19
- [x] **Live first-run test** with a scratch `XDG_CONFIG_HOME` (also caught that the legacy-config migration seeds "fresh" dirs — pre-existing, intended behavior): welcome auto-shows, real-token validation returns the login, provider check passes via claude CLI after the fix, Finish persists `setup_done=true` + token to the scratch config only
- [x] Adversarial verifier pass — all 8 spec items; its one finding (⌘K under the welcome) fixed
- [ ] Stale-cache confirm with a genuinely-moved cached PR (verified the check wiring + no-spurious-confirm on comment counts; the moved-head path needs a real stale cache)
- [ ] Markdown diff (e.g. a README PR) no longer renders italic after the first emphasis marker

🤖 Generated with [Claude Code](https://claude.com/claude-code)