### PR TITLE
style(gui): close the visual gaps against the overhaul mockups

### DIFF
--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -80,15 +80,15 @@ For each highlight, provide:
 Respond with ONLY a valid JSON array of these highlight objects. If there are no notable changes, return an empty array [].
 Do NOT include any text before or after the JSON array. Just the JSON."#;
 
-pub const SUMMARY_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and AI-generated reasons, write a concise executive summary for a code reviewer.
+pub const SUMMARY_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and AI-generated reasons, write a compact executive summary for a code reviewer.
 
-The summary should:
-1. Start with a 1-2 sentence overview of what this PR does
-2. Call out the most important areas to focus on (security-sensitive changes, API contract changes, infra changes)
-3. Note any patterns across the changes (e.g., "Most changes are in the payment service" or "This is primarily a refactor with one behavioral change in X")
-4. Be 3-5 short paragraphs — enough to orient the reviewer, not a full analysis
+Reviewers skim this in ten seconds. The file list, change groups, and line-level notes shown alongside it carry the detail — do not repeat them.
 
-Format the summary as separate paragraphs separated by blank lines. Each paragraph should cover a distinct aspect (overview, critical areas, patterns, etc.). No JSON, no markdown headers, no bullet points — just well-structured prose paragraphs."#;
+Hard limits: at most 2 short paragraphs, at most 90 words total.
+- Paragraph 1 (1-2 sentences): what the PR does and why.
+- Paragraph 2 (1-2 sentences): where the risk is — name the one or two files or behaviors that deserve the closest look. If nothing is risky, say so in one sentence.
+
+Separate paragraphs with a blank line. No JSON, no markdown, no bullet points, no headers, and no review-strategy advice ("start with…", "verify that…")."#;
 
 pub const GROUPING_PROMPT: &str = r#"You are a code review assistant. Given a PR title and a list of relevant files with their classifications and reasons, group the files into logical change sets.
 

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -41,6 +41,14 @@ pub fn save_settings(settings: Settings) -> Result<(), String> {
     save_settings_to_disk(&settings)
 }
 
+/// Whether `fetch_pr` could open this input. The omnibox uses this to decide
+/// "open" vs "filter" — asking the real parser instead of mirroring its regex
+/// (the AI review caught that as a fifth copy of the quadruplicated pattern).
+#[command]
+pub fn check_pr_ref(input: String) -> bool {
+    marrow_core::pr_parser::parse_pr_ref(&input).is_ok()
+}
+
 /// The authenticated GitHub login for the configured token (queue header chip).
 #[command]
 pub async fn get_viewer_login() -> Result<String, String> {

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -41,6 +41,12 @@ pub fn save_settings(settings: Settings) -> Result<(), String> {
     save_settings_to_disk(&settings)
 }
 
+/// The authenticated GitHub login for the configured token (queue header chip).
+#[command]
+pub async fn get_viewer_login() -> Result<String, String> {
+    github_client().get_authenticated_user().await
+}
+
 /// True when the first-run welcome should show: setup never completed/skipped
 /// and no GitHub token resolves from config or env.
 #[command]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -219,6 +219,7 @@ pub fn run() {
             commands::get_pending_deep_link,
             commands::signal_frontend_ready,
             commands::needs_setup,
+            commands::get_viewer_login,
             commands::validate_github_token,
             commands::validate_ai_provider,
             commands::load_manifest,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -220,6 +220,7 @@ pub fn run() {
             commands::signal_frontend_ready,
             commands::needs_setup,
             commands::get_viewer_login,
+            commands::check_pr_ref,
             commands::validate_github_token,
             commands::validate_ai_provider,
             commands::load_manifest,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -51,6 +51,7 @@ function App() {
   const [reviewPickerOpen, setReviewPickerOpen] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [queueFilter, setQueueFilter] = useState("");
+  const [viewerLogin, setViewerLogin] = useState<string | null>(null);
   const searchRef = useRef<SearchBarHandle>(null);
   const diffViewerRef = useRef<DiffViewerHandle>(null);
   // Visible file order from the sidebar, used by the [ / ] navigation shortcuts.
@@ -193,11 +194,15 @@ function App() {
 
   // ── Guided review path ──────────────────────────────────────────────────
   // The review order is the sidebar's visible order (falls back to relevant
-  // files in manifest order before the sidebar reports in).
+  // files in manifest order before the sidebar reports in). The sidebar is
+  // unmounted while the overview shows, so the ref can hold another tab's
+  // paths — anything not in this manifest is dropped before use.
   function guidedOrder(): string[] {
     if (!activeTab?.manifest) return [];
-    return visibleOrderRef.current.length
-      ? visibleOrderRef.current
+    const inManifest = new Set(activeTab.manifest.files.map((f) => f.path));
+    const visible = visibleOrderRef.current.filter((p) => inManifest.has(p));
+    return visible.length
+      ? visible
       : activeTab.manifest.files
           .filter((f) => f.classification !== "NOT_RELEVANT")
           .map((f) => f.path);
@@ -462,6 +467,9 @@ function App() {
       // two-step welcome instead of a blank queue + hidden settings.
       invoke<boolean>("needs_setup")
         .then((needed) => { if (needed) setWelcomeOpen(true); })
+        .catch(() => {});
+      invoke<string>("get_viewer_login")
+        .then(setViewerLogin)
         .catch(() => {});
     }
 
@@ -1597,8 +1605,6 @@ function App() {
         onSelectTab={handleSelectTab}
         onCloseTab={closeTab}
         onNewReview={handleNewReview}
-        viewMode={viewMode}
-        onViewModeChange={setViewMode}
         viewedCount={activeTab?.viewedFiles.size ?? 0}
         staleCount={activeTab?.staleViewedFiles.size ?? 0}
         onSettingsClick={() => setSettingsOpen(true)}
@@ -1643,6 +1649,7 @@ function App() {
                 onFilterChange={setQueueFilter}
                 onSettingsClick={() => setSettingsOpen(true)}
                 onCheckForUpdates={() => checkForUpdates(false)}
+                viewerLogin={viewerLogin}
               />
               {activeTab.error && (
                 <div className="opener-error" role="alert">
@@ -1713,6 +1720,19 @@ function App() {
           onOpenChange={setSearchOpen}
         />
         <div className="main-content">
+          {activeTab.sidebarView !== "comments" && !activeTab.selectedFile ? (
+            <PrOverview
+              manifest={activeTab.manifest}
+              checksStatus={activeChecks ?? null}
+              viewedCount={activeTab.viewedFiles.size}
+              unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
+              hasSubmittedReview={activeTab.myReviewState != null && activeTab.myReviewState.status !== "pending" && activeTab.myReviewState.status !== "dismissed" && !activeTab.myReviewState.is_re_requested}
+              startTarget={nextUnviewed(guidedOrder(), -1)}
+              onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
+              onSelectFile={setSelectedFile}
+            />
+          ) : (
+          <>
           <FileSidebar
             files={activeTab.manifest.files}
             changeGroups={activeTab.manifest.change_groups ?? []}
@@ -1763,7 +1783,7 @@ function App() {
                 const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
                 return (
                   <>
-                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
                     <NextFileBar
                       index={idx >= 0 ? idx : 0}
                       total={order.length}
@@ -1772,23 +1792,18 @@ function App() {
                       allReviewed={allReviewed}
                       onMarkReviewed={markReviewedAndAdvance}
                       onNext={() => { if (next) setSelectedFile(next); }}
+                      onComment={() => diffViewerRef.current?.commentAtCursor()}
                       onFinishReview={() => setReviewPickerOpen(true)}
                     />
                   </>
                 );
               })()
             ) : (
-              <PrOverview
-                manifest={activeTab.manifest}
-                viewedCount={activeTab.viewedFiles.size}
-                unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
-                hasSubmittedReview={activeTab.myReviewState != null && activeTab.myReviewState.status !== "pending" && activeTab.myReviewState.status !== "dismissed" && !activeTab.myReviewState.is_re_requested}
-                startTarget={nextUnviewed(guidedOrder(), -1)}
-                onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
-                onSelectFile={setSelectedFile}
-              />
+              <div className="no-file-selected">Select a file to review</div>
             )}
           </div>
+          </>
+          )}
         </div>
         </div>
       )}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -98,6 +98,7 @@ interface CommentingOn {
 interface DiffViewerProps {
   file: FileDiff;
   viewMode: DiffViewMode;
+  onViewModeChange?: (mode: DiffViewMode) => void;
   showHunkSignificance: boolean;
   showAiNotes: boolean;
   /** Keys (highlightKey) of AI highlights dismissed for this PR — hidden from the diff. */
@@ -1486,7 +1487,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -2198,6 +2199,24 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
           <button className="hunk-toggle-all" onClick={collapseAll}>
             Collapse all
           </button>
+        )}
+        {onViewModeChange && (
+          <div className="view-toggle">
+            <button
+              className={viewMode === "split" ? "active" : ""}
+              onClick={() => onViewModeChange("split")}
+              title="Side-by-side diff"
+            >
+              Split
+            </button>
+            <button
+              className={viewMode === "unified" ? "active" : ""}
+              onClick={() => onViewModeChange("unified")}
+              title="Single-column diff"
+            >
+              Unified
+            </button>
+          </div>
         )}
       </div>
       {dismissedNotes.length > 0 && (

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -622,6 +622,12 @@ export function FileSidebar({
             </button>
           </div>
         </div>
+        <div className="sidebar-progress">
+          <div
+            className="sidebar-progress-fill"
+            style={{ width: totalCount > 0 ? `${(viewedCount / totalCount) * 100}%` : 0 }}
+          />
+        </div>
         <span className="sidebar-file-count">
           {viewedCount}/{totalCount} viewed
           {staleCount > 0 && (

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import type { ReviewManifest, DiffViewMode, Tab, CommentThreadsState, MyReviewState } from "../types";
+import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState } from "../types";
 
 function useClickOutside(
   ref: React.RefObject<HTMLElement | null>,
@@ -38,8 +38,6 @@ interface HeaderProps {
   onSelectTab: (id: string) => void;
   onCloseTab: (id: string) => void;
   onNewReview: () => void;
-  viewMode: DiffViewMode;
-  onViewModeChange: (mode: DiffViewMode) => void;
   viewedCount: number;
   staleCount: number;
   onSettingsClick: () => void;
@@ -64,8 +62,6 @@ export function Header({
   onSelectTab,
   onCloseTab,
   onNewReview,
-  viewMode,
-  onViewModeChange,
   viewedCount,
   staleCount,
   onSettingsClick,
@@ -180,22 +176,6 @@ export function Header({
             )}
           </div>
           <div className="header-right">
-            <div className="view-toggle">
-              <button
-                className={viewMode === "split" ? "active" : ""}
-                onClick={() => onViewModeChange("split")}
-                title="Side-by-side diff"
-              >
-                Split
-              </button>
-              <button
-                className={viewMode === "unified" ? "active" : ""}
-                onClick={() => onViewModeChange("unified")}
-                title="Single-column diff"
-              >
-                Unified
-              </button>
-            </div>
             {onSubmitReview && <ReviewSubmitButton commentThreads={commentThreads} onSubmitReview={onSubmitReview} prTitle={manifest?.pr_title ?? ""} prUrl={manifest?.pr_url ?? ""} myReviewState={myReviewState} checksBlocking={checksBlocking} />}
             <ToolbarMenu
               onOpenPalette={onOpenPalette}

--- a/app/src/components/NextFileBar.tsx
+++ b/app/src/components/NextFileBar.tsx
@@ -6,6 +6,7 @@ interface NextFileBarProps {
   allReviewed: boolean;
   onMarkReviewed: () => void;
   onNext: () => void;
+  onComment?: () => void;
   onFinishReview: () => void;
 }
 
@@ -17,6 +18,7 @@ export function NextFileBar({
   allReviewed,
   onMarkReviewed,
   onNext,
+  onComment,
   onFinishReview,
 }: NextFileBarProps) {
   return (
@@ -48,6 +50,15 @@ export function NextFileBar({
           </>
         )}
       </span>
+      {onComment && (
+        <button
+          className="next-bar-ghost"
+          onClick={onComment}
+          title="Comment on the line at the cursor (C)"
+        >
+          Comment <kbd className="next-bar-key">C</kbd>
+        </button>
+      )}
       <button
         className={`next-bar-finish${allReviewed ? " next-bar-finish--ready" : ""}`}
         onClick={onFinishReview}

--- a/app/src/components/PrOpener.tsx
+++ b/app/src/components/PrOpener.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { isOpenablePrRef } from "../utils";
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 
 interface PrOpenerProps {
   onFetchStart: (prRef: string) => void;
@@ -10,23 +10,42 @@ interface PrOpenerProps {
   viewerLogin?: string | null;
 }
 
-// One box does both jobs: paste anything that parses as a PR ref and Enter
-// opens it; any other text filters the queue below as you type.
+// One box does both jobs: paste anything the backend parser accepts and Enter
+// opens it; any other text filters the queue below as you type. "Openable" is
+// decided by the real parser (check_pr_ref → pr_parser.rs), not a mirrored
+// regex — the frontend copy was a fifth instance of the quadruplicated
+// PR-ref pattern, flagged by Marrow's own AI review.
 export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onCheckForUpdates, viewerLogin }: PrOpenerProps) {
   const [value, setValue] = useState("");
-  const openable = isOpenablePrRef(value.trim());
+  const [openable, setOpenable] = useState(false);
+  // Guards against out-of-order IPC responses while typing.
+  const checkSeq = useRef(0);
 
-  function handleChange(v: string) {
-    setValue(v);
-    onFilterChange?.(isOpenablePrRef(v.trim()) ? "" : v.trim());
-  }
+  useEffect(() => {
+    const trimmed = value.trim();
+    const seq = ++checkSeq.current;
+    if (!trimmed) {
+      setOpenable(false);
+      return;
+    }
+    invoke<boolean>("check_pr_ref", { input: trimmed })
+      .then((ok) => { if (checkSeq.current === seq) setOpenable(ok); })
+      .catch(() => { if (checkSeq.current === seq) setOpenable(false); });
+  }, [value]);
+
+  // The queue filters on whatever is typed; once the parser says it's an
+  // openable ref, the filter clears so the queue stays visible behind it.
+  useEffect(() => {
+    onFilterChange?.(openable ? "" : value.trim());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value, openable]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = value.trim();
     if (!trimmed || !openable) return;
     onFetchStart(trimmed);
-    handleChange("");
+    setValue("");
   }
 
   return (
@@ -36,7 +55,7 @@ export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onChec
         <input
           type="text"
           value={value}
-          onChange={(e) => handleChange(e.target.value)}
+          onChange={(e) => setValue(e.target.value)}
           placeholder="Paste a PR URL or owner/repo#123, or filter your queue…"
         />
         {openable ? (

--- a/app/src/components/PrOpener.tsx
+++ b/app/src/components/PrOpener.tsx
@@ -6,11 +6,13 @@ interface PrOpenerProps {
   onFilterChange?: (filter: string) => void;
   onSettingsClick?: () => void;
   onCheckForUpdates?: () => void;
+  /** Authenticated GitHub login, once known — shown as a quiet status chip. */
+  viewerLogin?: string | null;
 }
 
 // One box does both jobs: paste anything that parses as a PR ref and Enter
 // opens it; any other text filters the queue below as you type.
-export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onCheckForUpdates }: PrOpenerProps) {
+export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onCheckForUpdates, viewerLogin }: PrOpenerProps) {
   const [value, setValue] = useState("");
   const openable = isOpenablePrRef(value.trim());
 
@@ -37,12 +39,19 @@ export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onChec
           onChange={(e) => handleChange(e.target.value)}
           placeholder="Paste a PR URL or owner/repo#123, or filter your queue…"
         />
-        {openable && (
+        {openable ? (
           <button type="submit" className="queue-omnibox-open">
             Open PR ↵
           </button>
+        ) : (
+          <kbd className="next-bar-key queue-omnibox-hint" title="Command palette">⌘K</kbd>
         )}
       </div>
+      {viewerLogin && (
+        <span className="queue-account" title="GitHub connection is working">
+          <span className="queue-account-dot" /> @{viewerLogin}
+        </span>
+      )}
       {onCheckForUpdates && (
         <button
           type="button"

--- a/app/src/components/PrOpener.tsx
+++ b/app/src/components/PrOpener.tsx
@@ -40,10 +40,17 @@ export function PrOpener({ onFetchStart, onFilterChange, onSettingsClick, onChec
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, openable]);
 
-  function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const trimmed = value.trim();
-    if (!trimmed || !openable) return;
+    if (!trimmed) return;
+    // Enter is authoritative: `openable` lags one IPC roundtrip behind the
+    // input, so paste + instant Enter could no-op on stale state — re-ask
+    // the parser directly rather than trusting the async echo.
+    const ok =
+      openable ||
+      (await invoke<boolean>("check_pr_ref", { input: trimmed }).catch(() => false));
+    if (!ok) return;
     onFetchStart(trimmed);
     setValue("");
   }

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -1,14 +1,32 @@
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import type { ReviewManifest, FileDiff, ChangeGroup } from "../types";
+import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus } from "../types";
 
 interface PrOverviewProps {
   manifest: ReviewManifest;
+  checksStatus?: PrChecksStatus | null;
   viewedCount: number;
   unresolvedThreads: number | null;
   hasSubmittedReview: boolean;
   startTarget: FileDiff | null;
   onStartReview: () => void;
   onSelectFile: (f: FileDiff) => void;
+}
+
+function CiChip({ checks }: { checks: PrChecksStatus }) {
+  // GitHub conclusions arrive uppercase ("FAILURE"); only overall_state is
+  // normalized to lowercase in core.
+  const failing = checks.check_runs.filter((c) => c.conclusion === "FAILURE").length;
+  const { dot, label } =
+    checks.overall_state === "success"
+      ? { dot: "risk-dot--ok", label: "CI passing" }
+      : failing > 0
+        ? { dot: "risk-dot--critical", label: `${failing} CI ${failing === 1 ? "check" : "checks"} failing` }
+        : { dot: "risk-dot--medium", label: "CI running" };
+  return (
+    <span className="overview-chip overview-chip--ci">
+      <span className={`risk-dot ${dot}`} /> {label}
+    </span>
+  );
 }
 
 function fileName(path: string): string {
@@ -59,6 +77,7 @@ function GroupRow({
 
 export function PrOverview({
   manifest,
+  checksStatus,
   viewedCount,
   unresolvedThreads,
   hasSubmittedReview,
@@ -81,6 +100,17 @@ export function PrOverview({
   return (
     <div className="pr-overview">
       <div className="overview-col">
+        <div className="overview-meta">
+          <span className="overview-title">
+            <span className="overview-title-num">#{manifest.pr_number}</span>
+            {manifest.pr_title}
+          </span>
+          {checksStatus && <CiChip checks={checksStatus} />}
+          <span className="overview-chip">
+            {relevant.length} relevant of {manifest.files.length}{" "}
+            {manifest.files.length === 1 ? "file" : "files"}
+          </span>
+        </div>
         {manifest.summary && (
           <div className="overview-card">
             <h4>AI summary</h4>

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import type { ReviewRequestItem, ReviewStatus, Settings, CachedPrInfo } from "../types";
+import { timeAgo } from "../utils";
 
 interface ReviewRequestListProps {
   onSelectPr: (prRef: string) => void;
@@ -14,20 +15,6 @@ interface ReviewRequestListProps {
 
 function initials(login: string): string {
   return login.slice(0, 2).toUpperCase();
-}
-
-function formatTimeAgo(dateStr: string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) return "today";
-  if (diffDays === 1) return "1 day ago";
-  if (diffDays < 30) return `${diffDays} days ago`;
-  const diffMonths = Math.floor(diffDays / 30);
-  if (diffMonths === 1) return "1 month ago";
-  return `${diffMonths} months ago`;
 }
 
 function cutoffDateStr(): string {
@@ -387,8 +374,7 @@ function ReviewRequestRow({
         </span>
         <span className="queue-meta">
           <span className="queue-why">
-            {item.direct_request ? "Review requested" : "Team review request"} by{" "}
-            {item.author} · {formatTimeAgo(item.created_at)}
+            {item.direct_request ? "Review requested" : "Team review request"} by {item.author}
           </span>
           {statusLabel && (
             <span className={`review-status-badge ${statusClass}`}>{statusLabel}</span>
@@ -400,6 +386,7 @@ function ReviewRequestRow({
           )}
         </span>
       </span>
+      <span className="queue-time">{timeAgo(item.created_at, true)}</span>
       <span className="queue-review-btn">Review</span>
     </button>
   );
@@ -444,10 +431,11 @@ function CachedPrSection({
                   </span>
                   <span className="queue-meta">
                     <span className="queue-why">
-                      Analyzed {formatTimeAgo(pr.cached_at)} · {pr.file_count} file{pr.file_count !== 1 ? "s" : ""} · opens instantly
+                      Analyzed · {pr.file_count} file{pr.file_count !== 1 ? "s" : ""} · opens instantly
                     </span>
                   </span>
                 </span>
+                <span className="queue-time">{timeAgo(pr.cached_at, true)}</span>
                 <span className="queue-review-btn">Open</span>
               </button>
             );

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1259,7 +1259,6 @@ tr.cursor-selected td {
 .review-requests {
   margin-top: 24px;
   width: 100%;
-  max-width: 480px;
 }
 
 .review-requests-header {
@@ -1403,8 +1402,6 @@ tr.cursor-selected td {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  max-height: 320px;
-  overflow-y: auto;
 }
 
 .review-requests-section {
@@ -4670,9 +4667,11 @@ mark.search-highlight-current {
 /* ─── Review queue home (opener tab) ──────────────────────────────────── */
 .queue-home {
   width: 100%;
-  max-width: 780px;
+  /* The queue is the whole page, not a form — let it breathe like the mockup
+     (rows span the window, with a sane ceiling on very wide displays). */
+  max-width: 1200px;
   margin: 0 auto;
-  padding: var(--space-5) var(--space-4) var(--space-6);
+  padding: var(--space-5) var(--space-5) var(--space-6);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2496,20 +2496,19 @@ tr.cursor-selected td {
 .hunk-collapsed td {
   padding: 6px 16px;
   text-align: center;
-  color: var(--text-muted);
+  color: var(--accent);
   font-size: 12px;
   font-family: var(--font-sans);
   cursor: pointer;
-  border-top: 1px dashed var(--border);
-  border-bottom: 1px dashed var(--border);
-  background: var(--bg-secondary);
+  border-top: 1px dashed rgba(88, 166, 255, 0.35);
+  border-bottom: 1px dashed rgba(88, 166, 255, 0.35);
+  background: rgba(88, 166, 255, 0.04);
   user-select: none;
   transition: background 0.15s, color 0.15s;
 }
 
 .hunk-collapsed:hover td {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
+  background: var(--accent-bg);
 }
 
 .hunk-collapsed-chevron {
@@ -5097,4 +5096,124 @@ mark.search-highlight-current {
 }
 .diff-content .hljs-strong {
   font-weight: inherit;
+}
+
+/* ─── Mockup-parity polish ────────────────────────────────────────────── */
+.queue-omnibox-hint {
+  flex-shrink: 0;
+}
+
+.queue-account {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 3px 11px;
+  white-space: nowrap;
+}
+
+.queue-account-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--diff-add-text);
+}
+
+.queue-time {
+  flex-shrink: 0;
+  font-size: 11.5px;
+  color: var(--text-muted);
+  min-width: 26px;
+  text-align: right;
+}
+
+/* Queue section labels become quiet uppercase eyebrows with count pills. */
+.review-requests-section-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.review-requests-group-count {
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border-radius: var(--radius-pill);
+  padding: 0 7px;
+  font-size: 10.5px;
+  font-weight: 600;
+}
+
+.risk-dot--ok {
+  background: var(--diff-add-text);
+}
+
+.overview-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 2px 2px 6px;
+  min-width: 0;
+}
+
+.overview-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-right: auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.overview-title-num {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  color: var(--text-muted);
+  margin-right: 8px;
+}
+
+.overview-chip--ci {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sidebar-progress {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--bg-tertiary);
+  overflow: hidden;
+  margin: 6px 0 6px;
+}
+
+.sidebar-progress-fill {
+  height: 100%;
+  background: var(--diff-add-text);
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.next-bar-ghost {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.next-bar-ghost:hover {
+  color: var(--text-primary);
 }

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -37,20 +37,6 @@ export function extractPrRef(input: string): string | null {
 }
 
 /**
- * True when the input is something `fetch_pr` can open: a PR URL, an
- * `owner/repo#123` or `owner/repo/pull/123` ref, or a bare `#123` (resolved
- * against the configured default repo by the backend). Mirrors the accepted
- * shapes in pr_parser.rs — the omnibox uses this to decide "open" vs "filter".
- */
-export function isOpenablePrRef(input: string): boolean {
-  if (extractPrRef(input) !== null) return true;
-  return (
-    /^[A-Za-z0-9][A-Za-z0-9-]{0,38}\/[A-Za-z0-9._-]{1,100}(#\d+|\/pull\/\d+)$/.test(input) ||
-    /^#\d+$/.test(input)
-  );
-}
-
-/**
  * Normalize a GitHub PR URL or an `owner/repo#number` ref to a single
  * comparable key (`owner/repo#number`, lowercased), or null if neither shape
  * matches. Used to tell whether two references point at the same PR.


### PR DESCRIPTION
> Top of the stack: #139 → #140 → #141 → #142 → this. Retarget as parents merge.

## Summary
Side-by-side pass against the original overhaul mockups (the artifact from the design phase), closing the visible gaps:
- **Queue home**: ⌘K hint inside the omnibox, a "● @login" connection chip (new `get_viewer_login` command), quiet uppercase section eyebrows with count pills, right-aligned short times on rows.
- **PR overview** is now a **full-window landing** like the mockup — the file sidebar only mounts once a file is selected — with a title/meta row carrying a CI chip and "N relevant of M files".
- **Review screen**: Split/Unified segmented control moves from the app toolbar into the diff file header; sidebar gets a slim green progress bar; collapsed hunks get the accent dashed fold treatment; next-file bar gains "Comment ⟨C⟩".

## Verification
- [x] `bun run build` + `cargo check` clean
- [x] Adversarial verifier — 2 real findings fixed: CI conclusions compare uppercase (`"FAILURE"`; only `overall_state` is normalized in core), and the unmounted sidebar could leave a previous tab's file order in `visibleOrderRef`, breaking "Start review" on a second tab (guidedOrder now drops paths not in the current manifest)
- [x] Live-app screenshots against all three mockup screens: queue (chip/hint/eyebrows/times), full-window overview (meta chips), review screen (header controls, progress bar, Comment button)

## Known remaining mockup deltas (deliberate, need data/design work)
- CI chips + snooze on queue rows and the "Watching" section — these need the activity system's data folded into the queue (the fragile mini-player subsystem; separate effort)
- Sidebar still offers Groups/Comments/Category/Tree modes vs the mockup's Groups-only + footer toggles — an IA change worth its own discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)