### PR TITLE
feat: surface PR author, approvals, and draft state

### DIFF
--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -1186,6 +1186,26 @@ impl<'a> App<'a> {
             ),
             Span::raw(format!(" {} #{}", self.manifest.pr_title, self.manifest.pr_number)),
         ];
+        if !self.manifest.author.is_empty() {
+            header.push(Span::styled(
+                format!(" by {}", self.manifest.author),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        let is_draft = self
+            .my_review_state
+            .as_ref()
+            .map(|s| s.draft)
+            .unwrap_or(self.manifest.draft);
+        if is_draft {
+            header.push(Span::styled(
+                " DRAFT ",
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Gray)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
         if let Some(state) = &self.my_review_state {
             if state.is_merged {
                 header.push(Span::styled(
@@ -1203,6 +1223,11 @@ impl<'a> App<'a> {
                         .fg(Color::Black)
                         .bg(Color::Green)
                         .add_modifier(Modifier::BOLD),
+                ));
+            } else if !state.approved_by.is_empty() {
+                header.push(Span::styled(
+                    format!(" ✓ {} approved ", state.approved_by.len()),
+                    Style::default().fg(Color::Green),
                 ));
             }
         }
@@ -2231,6 +2256,8 @@ mod tests {
             head_ref: "feature".to_string(),
             base_sha: "aaa".to_string(),
             head_sha: "bbb".to_string(),
+            author: String::new(),
+            draft: false,
             summary: String::new(),
             change_groups: Vec::new(),
             files: vec![

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -59,6 +59,8 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let head_ref = metadata.head.ref_name;
     let base_sha = metadata.base.sha;
     let head_sha = metadata.head.sha;
+    let author = metadata.user.as_ref().map(|u| u.login.clone()).unwrap_or_default();
+    let draft = metadata.draft.unwrap_or(false);
 
     if let Some(cached) = manifest_cache::load_cached_manifest(&parsed.owner, &parsed.repo, parsed.number) {
         if cached.head_sha == head_sha {
@@ -314,6 +316,8 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         head_ref,
         base_sha,
         head_sha,
+        author,
+        draft,
         summary,
         change_groups,
         files: file_diffs,

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -167,6 +167,44 @@ fn resolve_user_review_status(reviews: &[serde_json::Value], username: &str) -> 
     status
 }
 
+/// Compute the set of reviewers whose latest opinionated review is APPROVED,
+/// mirroring GitHub's "latest review per reviewer" semantics used by
+/// `resolve_user_review_status`: per-author (case-insensitive identity, but
+/// original casing preserved for display), track the latest state among
+/// APPROVED / CHANGES_REQUESTED / DISMISSED (COMMENTED never clears a prior
+/// approval; DISMISSED does). Returns authors with a final APPROVED state, in
+/// first-review order.
+fn resolve_approvers(reviews: &[serde_json::Value]) -> Vec<String> {
+    let mut order: Vec<String> = Vec::new();
+    let mut latest: HashMap<String, (String, String)> = HashMap::new(); // key(lower) -> (display, state)
+
+    for review in reviews {
+        let author = match review.pointer("/author/login").and_then(|l| l.as_str()) {
+            Some(a) => a,
+            None => continue,
+        };
+        let state = match review.get("state").and_then(|s| s.as_str()) {
+            Some(s) => s,
+            None => continue,
+        };
+        if !matches!(state, "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED") {
+            continue;
+        }
+        let key = author.to_lowercase();
+        if !latest.contains_key(&key) {
+            order.push(key.clone());
+        }
+        latest.insert(key, (author.to_string(), state.to_string()));
+    }
+
+    order
+        .into_iter()
+        .filter_map(|key| latest.get(&key))
+        .filter(|(_, state)| state == "APPROVED")
+        .map(|(display, _)| display.clone())
+        .collect()
+}
+
 /// Parse the viewer's `(review_status, is_re_requested)` from a `pullRequest`
 /// GraphQL node carrying `reviews { nodes { author{login} state } }` and
 /// `reviewRequests { nodes { requestedReviewer { ... on User { login } } } }`.
@@ -528,15 +566,15 @@ impl GithubClient {
         // Search for PRs where user is a requested reviewer, has reviewed, or has commented
         // This covers: pending requests, submitted reviews, and pending reviews with comments
         let requested_query = format!(
-            "is:pr is:open review-requested:{} -is:draft {}",
+            "is:pr is:open review-requested:{} {}",
             username, date_filter
         );
         let reviewed_query = format!(
-            "is:pr is:open reviewed-by:{} -author:{} -is:draft {}",
+            "is:pr is:open reviewed-by:{} -author:{} {}",
             username, username, date_filter
         );
         let commented_query = format!(
-            "is:pr is:open commenter:{} -author:{} -is:draft {}",
+            "is:pr is:open commenter:{} -author:{} {}",
             username, username, date_filter
         );
 
@@ -1398,6 +1436,8 @@ impl GithubClient {
                 repository(owner: "{}", name: "{}") {{
                     pullRequest(number: {}) {{
                         merged
+                        isDraft
+                        author {{ login }}
                         reviewRequests(first: 20) {{
                             nodes {{
                                 requestedReviewer {{
@@ -1435,12 +1475,32 @@ impl GithubClient {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
+        let author = pr
+            .pointer("/author/login")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let draft = pr
+            .get("isDraft")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         let (status, is_re_requested) = resolve_review_state(pr, viewer_login);
+
+        let approved_by = pr
+            .pointer("/reviews/nodes")
+            .and_then(|v| v.as_array())
+            .map(|reviews| resolve_approvers(reviews))
+            .unwrap_or_default();
 
         Ok(MyReviewState {
             status,
             is_re_requested,
             is_merged,
+            author,
+            draft,
+            approved_by,
         })
     }
 }

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -74,6 +74,10 @@ pub struct ReviewManifest {
     pub base_sha: String,
     pub head_sha: String,
     #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
     pub summary: String,
     #[serde(default)]
     pub change_groups: Vec<ChangeGroup>,
@@ -186,6 +190,15 @@ pub struct PrMetadata {
     pub number: u64,
     pub base: PrRef,
     pub head: PrRef,
+    #[serde(default)]
+    pub user: Option<PrUser>,
+    #[serde(default)]
+    pub draft: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PrUser {
+    pub login: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -259,6 +272,12 @@ pub struct MyReviewState {
     pub status: String,
     pub is_re_requested: bool,
     pub is_merged: bool,
+    #[serde(default)]
+    pub author: String,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
+    pub approved_by: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1199,6 +1199,9 @@ function App() {
       updateTab(activeTabId, (t) => ({
         ...t,
         myReviewState: {
+          author: t.myReviewState?.author ?? "",
+          draft: t.myReviewState?.draft ?? false,
+          approved_by: t.myReviewState?.approved_by ?? [],
           status: statusMap[event] as MyReviewState["status"],
           is_re_requested: false,
           is_merged: t.myReviewState?.is_merged ?? false,
@@ -1355,6 +1358,9 @@ function App() {
                 : {
                     ...t,
                     myReviewState: {
+                      author: t.myReviewState?.author ?? "",
+                      draft: t.myReviewState?.draft ?? false,
+                      approved_by: t.myReviewState?.approved_by ?? [],
                       status: t.myReviewState?.status ?? "pending",
                       is_re_requested: t.myReviewState?.is_re_requested ?? false,
                       is_merged: true,
@@ -1724,6 +1730,7 @@ function App() {
             <PrOverview
               manifest={activeTab.manifest}
               checksStatus={activeChecks ?? null}
+              reviewState={activeTab.myReviewState ?? null}
               viewedCount={activeTab.viewedFiles.size}
               unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
               hasSubmittedReview={activeTab.myReviewState != null && activeTab.myReviewState.status !== "pending" && activeTab.myReviewState.status !== "dismissed" && !activeTab.myReviewState.is_re_requested}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -138,6 +138,9 @@ export function Header({
                 <span className="stale-badge">{staleCount} changed</span>
               )}
             </span>
+            {(myReviewState ? myReviewState.draft : manifest.draft) && !myReviewState?.is_merged && (
+              <span className="pr-badge pr-badge--draft" title="This PR is a draft">Draft</span>
+            )}
             {myReviewState?.is_merged && (
               <span className="pr-badge pr-badge--merged" title="This PR has been merged">
                 Merged

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -1,9 +1,11 @@
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus } from "../types";
+import { initials } from "./ReviewRequestList";
+import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState } from "../types";
 
 interface PrOverviewProps {
   manifest: ReviewManifest;
   checksStatus?: PrChecksStatus | null;
+  reviewState: MyReviewState | null;
   viewedCount: number;
   unresolvedThreads: number | null;
   hasSubmittedReview: boolean;
@@ -78,6 +80,7 @@ function GroupRow({
 export function PrOverview({
   manifest,
   checksStatus,
+  reviewState,
   viewedCount,
   unresolvedThreads,
   hasSubmittedReview,
@@ -89,6 +92,9 @@ export function PrOverview({
   const setAside = manifest.files.length - relevant.length;
   const byPath = new Map(manifest.files.map((f) => [f.path, f]));
   const groups = manifest.change_groups ?? [];
+  const author = reviewState?.author || manifest.author;
+  const draft = reviewState ? reviewState.draft : manifest.draft;
+  const approvedBy = reviewState?.approved_by ?? [];
   const criticalNotes = relevant.reduce(
     (n, f) => n + (f.highlights?.filter((h) => h.severity === "critical").length ?? 0),
     0
@@ -105,6 +111,12 @@ export function PrOverview({
             <span className="overview-title-num">#{manifest.pr_number}</span>
             {manifest.pr_title}
           </span>
+          {author && (
+            <span className="overview-chip overview-chip--author">
+              <span className="queue-avatar queue-avatar--sm" aria-hidden="true">{initials(author)}</span> {author}
+            </span>
+          )}
+          {draft && <span className="overview-chip overview-chip--draft">Draft</span>}
           {checksStatus && <CiChip checks={checksStatus} />}
           <span className="overview-chip">
             {relevant.length} relevant of {manifest.files.length}{" "}
@@ -173,7 +185,14 @@ export function PrOverview({
           </div>
         </div>
         <div className="overview-card">
-          <h4>Your state</h4>
+          <h4>Review state</h4>
+          {approvedBy.length > 0 ? (
+            <div className="overview-state-line overview-approvals">
+              <span className="risk-dot risk-dot--ok" /> Approved by {approvedBy.join(", ")}
+            </div>
+          ) : (
+            reviewState && <div className="overview-state-line">No approvals yet</div>
+          )}
           <div className="overview-state-line">
             {viewedCount} of {relevant.length} files reviewed
           </div>

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -13,7 +13,7 @@ interface ReviewRequestListProps {
   filter?: string;
 }
 
-function initials(login: string): string {
+export function initials(login: string): string {
   return login.slice(0, 2).toUpperCase();
 }
 
@@ -365,7 +365,7 @@ function ReviewRequestRow({
   const statusClass = STATUS_CLASSES[item.my_review_status];
 
   return (
-    <button className="queue-row" onClick={() => onSelect(prRef)}>
+    <button className={`queue-row${item.draft ? " queue-row--draft" : ""}`} onClick={() => onSelect(prRef)}>
       <span className="queue-avatar" aria-hidden="true">{initials(item.author)}</span>
       <span className="queue-main">
         <span className="queue-title">
@@ -376,6 +376,7 @@ function ReviewRequestRow({
           <span className="queue-why">
             {item.direct_request ? "Review requested" : "Team review request"} by {item.author}
           </span>
+          {item.draft && <span className="queue-draft-chip">Draft</span>}
           {statusLabel && (
             <span className={`review-status-badge ${statusClass}`}>{statusLabel}</span>
           )}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -780,6 +780,11 @@ body {
   color: var(--diff-add-text);
   background: var(--diff-add-bg);
 }
+.pr-badge--draft {
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid var(--chip-border);
+}
 
 /* The AI's one-line file description renders only for the selected file —
    on every row it turns the sidebar into a wall of text. */
@@ -4485,6 +4490,17 @@ mark.search-highlight-current {
   white-space: nowrap;
 }
 
+.overview-chip--author {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.overview-chip--draft {
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .overview-noise {
   font-size: 12.5px;
   color: var(--text-secondary);
@@ -4764,6 +4780,14 @@ mark.search-highlight-current {
   opacity: 1;
 }
 
+.queue-row--draft {
+  opacity: 0.65;
+}
+
+.queue-row--draft:hover {
+  opacity: 1;
+}
+
 .queue-avatar {
   flex-shrink: 0;
   width: 30px;
@@ -4776,6 +4800,23 @@ mark.search-highlight-current {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.queue-avatar--sm {
+  width: 16px;
+  height: 16px;
+  font-size: 9px;
+  display: inline-flex;
+}
+
+.queue-draft-chip {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 0px 7px;
+  white-space: nowrap;
 }
 
 .queue-main {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -40,6 +40,8 @@ export interface ReviewManifest {
   head_ref: string;
   base_sha: string;
   head_sha: string;
+  author: string;
+  draft: boolean;
   summary: string;
   change_groups: ChangeGroup[];
   files: FileDiff[];
@@ -175,6 +177,9 @@ export interface MyReviewState {
   status: ReviewStatus;
   is_re_requested: boolean;
   is_merged: boolean;
+  author: string;
+  draft: boolean;
+  approved_by: string[];
 }
 
 export interface CheckRunInfo {


### PR DESCRIPTION
## Summary
- Closes #145 with **zero new API calls**: author + draft were already in the REST `/pulls/{n}` response (just never deserialized), and the reviewers list was already in `get_my_review_state`'s GraphQL query (fetched, then discarded for everyone but the viewer).
- `ReviewManifest` gains `author`/`draft` (serde-defaulted — old cached manifests still load); `MyReviewState` gains `author`/`draft`/`approved_by` as live values that override the cached snapshot in the UI, so pre-existing caches and stale draft flags self-heal on open.
- `approved_by` mirrors GitHub's semantics via a new `resolve_approvers` helper: latest *opinionated* review per reviewer (COMMENTED doesn't clear a prior approval; DISMISSED does), same state machine as the existing `resolve_user_review_status`.
- The queue's three search queries drop `-is:draft`; draft PRs now appear dimmed with a Draft chip instead of being silently invisible.

## Changes
- **core**: `types.rs` (PrUser + new fields on PrMetadata/ReviewManifest/MyReviewState), `fetch.rs` (populate manifest), `github.rs` (GraphQL `isDraft`/`author`, `resolve_approvers`, de-drafted search queries)
- **cli**: `tui.rs` header — `by {author}`, DRAFT badge (live state falling back to manifest), `✓ N approved` count when others approved
- **gui**: `PrOverview` meta row author chip + Draft chip; "Your state" card → "Review state" with approved-by line ("No approvals yet" only renders once live state loads); `Header` Draft badge (hidden once merged); queue rows dimmed + Draft chip; `types.ts` kept in sync by hand; new token-based styles only

## Test Plan
- [x] `cargo check` clean; `cargo test -p marrow-core -p marrow-cli` (19 + 37) pass
- [x] `bun run build` (tsc) clean
- [x] Adversarial verifier pass — `resolve_approvers` edge cases exercised standalone (COMMENTED-after-APPROVED, DISMISSED-after-APPROVED, null/deleted author), old-cache deserialization path confirmed
- [x] Live-verified in dev app: opened a pre-#145 cached PR — author chip appears via the live override, Review state card correct
- [ ] Untested live: a real draft PR in the queue (no draft review requests available to me right now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)