### PR TITLE
feat(gui): resolution states for AI notes — fixed/intentional/noise + reasons (#148)

### DIFF
--- a/app/src-tauri/crates/core/src/dismissed_highlights.rs
+++ b/app/src-tauri/crates/core/src/dismissed_highlights.rs
@@ -1,14 +1,39 @@
 use crate::config::app_config_dir;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
 /// Per-PR set of dismissed AI highlights. `keys` are opaque, frontend-computed
 /// stable identifiers (path + line range + comment hash) so a dismissal survives
 /// re-fetches but re-surfaces if the underlying note changes.
+///
+/// Invariant: `keys` remains the authoritative hidden-set — every key in
+/// `resolutions` must also be in `keys`; `resolutions` is best-effort metadata
+/// layered on top (why/how a note was resolved). Old files (keys only) load
+/// fine with empty resolutions; old app versions reading a new file ignore the
+/// unknown `resolutions` field via ordinary serde behavior (no
+/// `deny_unknown_fields` here, intentionally).
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct DismissedHighlights {
     pub keys: Vec<String>,
+    /// key → how/why it was resolved. Absent for pre-resolution-state dismissals.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub resolutions: HashMap<String, NoteResolution>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NoteResolution {
+    /// "fixed" | "intentional" | "noise". Defaulted so one malformed entry
+    /// can't fail the whole file's parse and resurface every dismissed note
+    /// (the UI renders an empty state as a plain "Dismissed").
+    #[serde(default)]
+    pub state: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub reason: String,
+    /// ISO-8601; set by the frontend (core stays clock-free here).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub at: String,
 }
 
 fn dismissed_dir() -> PathBuf {
@@ -54,4 +79,61 @@ pub fn save_dismissed(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_format_json_loads() {
+        // Pre-resolution-state files only ever had `keys`.
+        let json = r#"{"keys":["a.rs:1-2:abc","b.rs:3-4:def"]}"#;
+        let parsed: DismissedHighlights = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.keys, vec!["a.rs:1-2:abc", "b.rs:3-4:def"]);
+        assert!(parsed.resolutions.is_empty());
+    }
+
+    #[test]
+    fn new_format_round_trips() {
+        let mut resolutions = HashMap::new();
+        resolutions.insert(
+            "a.rs:1-2:abc".to_string(),
+            NoteResolution {
+                state: "fixed".to_string(),
+                reason: "addressed in follow-up commit".to_string(),
+                at: "2026-07-21T00:00:00.000Z".to_string(),
+            },
+        );
+        let original = DismissedHighlights {
+            keys: vec!["a.rs:1-2:abc".to_string()],
+            resolutions,
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: DismissedHighlights = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.keys, original.keys);
+        assert_eq!(parsed.resolutions.len(), 1);
+        let res = &parsed.resolutions["a.rs:1-2:abc"];
+        assert_eq!(res.state, "fixed");
+        assert_eq!(res.reason, "addressed in follow-up commit");
+        assert_eq!(res.at, "2026-07-21T00:00:00.000Z");
+    }
+
+    #[test]
+    fn resolution_without_matching_key_is_tolerated_on_load() {
+        // `resolutions` is best-effort metadata; a stale/orphaned entry (its key
+        // no longer in `keys`) must not fail to parse.
+        let json = r#"{
+            "keys": ["a.rs:1-2:abc"],
+            "resolutions": {
+                "b.rs:3-4:def": { "state": "noise", "reason": "", "at": "" }
+            }
+        }"#;
+        let parsed: DismissedHighlights = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.keys, vec!["a.rs:1-2:abc"]);
+        assert_eq!(parsed.resolutions.len(), 1);
+        assert!(parsed.resolutions.contains_key("b.rs:3-4:def"));
+    }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -26,7 +26,7 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
@@ -333,6 +333,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
@@ -358,6 +359,7 @@ function App() {
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
+      noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
       selectedCommentFile: null,
@@ -631,24 +633,59 @@ function App() {
     if (!tab.manifest) return;
     try {
       const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
-      const saved = await invoke<{ keys: string[] } | null>("load_dismissed_highlights", { owner, repo, prNumber: number });
+      const saved = await invoke<{ keys: string[]; resolutions?: Record<string, NoteResolution> } | null>("load_dismissed_highlights", { owner, repo, prNumber: number });
       if (saved && saved.keys.length > 0) {
-        updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: new Set(saved.keys) }));
+        updateTab(tab.id, (t) => ({
+          ...t,
+          dismissedHighlights: new Set(saved.keys),
+          noteResolutions: new Map(Object.entries(saved.resolutions ?? {})),
+        }));
       }
     } catch {
       // Non-critical: start with nothing dismissed on failure
     }
   }
 
-  function toggleHighlightDismissed(key: string) {
+  /** Persist the current tab's dismissed-set + resolutions in one write. */
+  function saveDismissedState(tab: Tab, keys: Set<string>, resolutions: Map<string, NoteResolution>) {
+    if (!tab.manifest) return;
+    const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
+    invoke("save_dismissed_highlights", {
+      owner,
+      repo,
+      prNumber: number,
+      state: { keys: [...keys], resolutions: Object.fromEntries(resolutions) },
+    }).catch(() => addToast("error", "Couldn't save — this dismissal may not persist"));
+  }
+
+  /** Dismiss (hide) a note, optionally recording how/why it was resolved.
+   * `resolution: null` is a plain/quick dismiss — no resolution metadata is
+   * recorded (renders as the legacy "Dismissed" chip, same as noise). */
+  function resolveHighlight(key: string, resolution: NoteResolution | null) {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab || !tab.manifest) return;
-    const next = new Set(tab.dismissedHighlights);
-    if (next.has(key)) next.delete(key); else next.add(key);
-    updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: next }));
-    const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
-    invoke("save_dismissed_highlights", { owner, repo, prNumber: number, state: { keys: [...next] } })
-      .catch(() => addToast("error", "Couldn't save — this dismissal may not persist"));
+    const nextKeys = new Set(tab.dismissedHighlights);
+    nextKeys.add(key);
+    const nextResolutions = new Map(tab.noteResolutions);
+    if (resolution) {
+      nextResolutions.set(key, { ...resolution, at: new Date().toISOString() });
+    } else {
+      nextResolutions.delete(key);
+    }
+    updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: nextKeys, noteResolutions: nextResolutions }));
+    saveDismissedState(tab, nextKeys, nextResolutions);
+  }
+
+  /** Restore a previously-dismissed note, clearing any recorded resolution. */
+  function restoreHighlight(key: string) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab || !tab.manifest) return;
+    const nextKeys = new Set(tab.dismissedHighlights);
+    nextKeys.delete(key);
+    const nextResolutions = new Map(tab.noteResolutions);
+    nextResolutions.delete(key);
+    updateTab(tab.id, (t) => ({ ...t, dismissedHighlights: nextKeys, noteResolutions: nextResolutions }));
+    saveDismissedState(tab, nextKeys, nextResolutions);
   }
 
   async function loadChatHistory(tab: Tab) {
@@ -1624,12 +1661,22 @@ function App() {
       for (const tab of tabsRef.current) {
         if (!tab.manifest) continue;
         const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
-        invoke<{ keys: string[] } | null>("load_dismissed_highlights", { owner, repo, prNumber: number })
+        invoke<{ keys: string[]; resolutions?: Record<string, NoteResolution> } | null>("load_dismissed_highlights", { owner, repo, prNumber: number })
           .then((saved) => {
             const keys = saved?.keys ?? [];
+            const resolutions = saved?.resolutions ?? {};
             updateTab(tab.id, (t) => {
-              const same = t.dismissedHighlights.size === keys.length && keys.every((k) => t.dismissedHighlights.has(k));
-              return same ? t : { ...t, dismissedHighlights: new Set(keys) };
+              const sameKeys = t.dismissedHighlights.size === keys.length && keys.every((k) => t.dismissedHighlights.has(k));
+              // Resolutions must be compared too, or a metadata-only change
+              // (e.g. the resolve script adding a reason to an existing key)
+              // would be invisible until restart.
+              const entries = Object.entries(resolutions);
+              const sameRes = t.noteResolutions.size === entries.length && entries.every(([k, r]) => {
+                const cur = t.noteResolutions.get(k);
+                return !!cur && cur.state === r.state && (cur.reason ?? "") === (r.reason ?? "") && (cur.at ?? "") === (r.at ?? "");
+              });
+              if (sameKeys && sameRes) return t;
+              return { ...t, dismissedHighlights: new Set(keys), noteResolutions: new Map(entries) };
             });
           })
           .catch(() => {});
@@ -1963,7 +2010,7 @@ function App() {
                 const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
                 return (
                   <>
-                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} onToggleHighlightDismissed={toggleHighlightDismissed} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
                     <NextFileBar
                       index={idx >= 0 ? idx : 0}
                       total={order.length}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import { Fragment, createContext, forwardRef, memo, useContext, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
-import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch } from "../types";
+import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch, NoteResolution } from "../types";
 import { timeAgo, highlightKey } from "../utils";
 
 const extToLang: Record<string, string> = {
@@ -103,7 +103,12 @@ interface DiffViewerProps {
   showAiNotes: boolean;
   /** Keys (highlightKey) of AI highlights dismissed for this PR — hidden from the diff. */
   dismissedHighlights?: Set<string>;
-  onToggleHighlightDismissed?: (key: string) => void;
+  /** Resolution metadata (state + reason) for dismissed highlights, keyed by highlightKey. */
+  noteResolutions?: Map<string, NoteResolution>;
+  /** Dismiss a note, optionally recording how/why (null = plain dismiss, no resolution recorded). */
+  onResolveHighlight?: (key: string, resolution: NoteResolution | null) => void;
+  /** Restore a previously-dismissed note, clearing any recorded resolution. */
+  onRestoreHighlight?: (key: string) => void;
   onCreateComment?: (path: string, endLine: number, side: "LEFT" | "RIGHT", body: string, startLine?: number, startSide?: "LEFT" | "RIGHT") => Promise<void>;
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
@@ -846,10 +851,30 @@ const severityLabel: Record<string, string> = {
 // Dismissal used to live on the top-of-file banner list; now that notes render
 // only inline, the action reaches HighlightMarker via context rather than
 // threading a prop through every hunk-rendering layer.
-const HighlightDismissContext = createContext<((h: Highlight) => void) | null>(null);
+const HighlightDismissContext = createContext<{ resolve: (h: Highlight, resolution: NoteResolution | null) => void } | null>(null);
 
 function HighlightMarker({ highlight, onPostAsComment }: { highlight: Highlight; onPostAsComment?: (h: Highlight) => void }) {
-  const onDismiss = useContext(HighlightDismissContext);
+  const ctx = useContext(HighlightDismissContext);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [resolveState, setResolveState] = useState<"fixed" | "intentional">("fixed");
+  const [reason, setReason] = useState("");
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+    function onOutside(e: MouseEvent) {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) setPopoverOpen(false);
+    }
+    document.addEventListener("mousedown", onOutside);
+    return () => document.removeEventListener("mousedown", onOutside);
+  }, [popoverOpen]);
+
+  function confirmResolve(state: "fixed" | "intentional") {
+    ctx?.resolve(highlight, { state, reason: reason.trim() || undefined });
+    setPopoverOpen(false);
+    setReason("");
+  }
+
   return (
     <div className={`highlight-marker highlight-${highlight.severity}`}>
       <span className="highlight-icon">
@@ -866,10 +891,60 @@ function HighlightMarker({ highlight, onPostAsComment }: { highlight: Highlight;
           Comment…
         </button>
       )}
-      {onDismiss && (
+      {ctx && (
+        <div className="note-resolve-wrap">
+          <button
+            className="note-resolve-btn"
+            onClick={(e) => { e.stopPropagation(); setPopoverOpen((v) => !v); }}
+            title="Mark this note as fixed or intentional"
+          >
+            Resolve…
+          </button>
+          {popoverOpen && (
+            <div
+              ref={popoverRef}
+              className="note-resolve-popover"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") { e.preventDefault(); setPopoverOpen(false); }
+                if (e.key === "Enter") { e.preventDefault(); confirmResolve(resolveState); }
+              }}
+            >
+              <div className="note-resolve-popover-states">
+                <button
+                  type="button"
+                  className={resolveState === "fixed" ? "active" : ""}
+                  onClick={() => setResolveState("fixed")}
+                >
+                  Fixed
+                </button>
+                <button
+                  type="button"
+                  className={resolveState === "intentional" ? "active" : ""}
+                  onClick={() => setResolveState("intentional")}
+                >
+                  Intentional
+                </button>
+              </div>
+              <input
+                type="text"
+                className="note-resolve-reason"
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="Why? (optional — feeds future AI runs)"
+                autoFocus
+              />
+              <button type="button" className="note-resolve-confirm" onClick={() => confirmResolve(resolveState)}>
+                Confirm
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+      {ctx && (
         <button
           className="highlight-dismiss"
-          onClick={(e) => { e.stopPropagation(); onDismiss(highlight); }}
+          onClick={(e) => { e.stopPropagation(); ctx.resolve(highlight, null); }}
           title="Dismiss this AI note"
           aria-label="Dismiss AI note"
         >
@@ -1487,7 +1562,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, onToggleHighlightDismissed, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, noteResolutions, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -1669,12 +1744,13 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   const highlights = allNotes.filter((h) => !dismissed.has(keyFor(h)));
   const dismissedNotes = allNotes.filter((h) => dismissed.has(keyFor(h)));
   const [showDismissed, setShowDismissed] = useState(false);
+  const resolutions = noteResolutions ?? new Map<string, NoteResolution>();
   const dismissHighlight = useMemo(
     () =>
-      onToggleHighlightDismissed
-        ? (h: Highlight) => onToggleHighlightDismissed(highlightKey(file.path, h))
+      onResolveHighlight
+        ? { resolve: (h: Highlight, resolution: NoteResolution | null) => onResolveHighlight(highlightKey(file.path, h), resolution) }
         : null,
-    [onToggleHighlightDismissed, file.path]
+    [onResolveHighlight, file.path]
   );
   // Track original collapsed state so we can restore it when search ends
   const preSearchCollapsed = useRef<Set<number> | null>(null);
@@ -2224,31 +2300,40 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
           <button className="highlights-show-dismissed" onClick={() => setShowDismissed((v) => !v)}>
             {showDismissed ? "Hide" : "Show"} {dismissedNotes.length} dismissed {dismissedNotes.length === 1 ? "note" : "notes"}
           </button>
-          {showDismissed && dismissedNotes.map((h, i) => (
-            <div
-              key={`dismissed-${i}`}
-              className={`highlights-summary-item highlight-${h.severity} highlight-dismissed`}
-              style={{ cursor: "pointer" }}
-              onClick={() => {
-                const el = document.getElementById(`diff-line-${h.start_line}`);
-                el?.scrollIntoView({ behavior: "smooth", block: "center" });
-              }}
-              title="Jump to code"
-            >
-              <span className="highlight-severity-badge">{severityLabel[h.severity] || "Info"}</span>
-              <span className="highlight-lines">{formatLineRange(h.start_line, h.end_line)}</span>
-              <span className="highlight-summary-text">{h.comment}</span>
-              {onToggleHighlightDismissed && (
-                <button
-                  className="highlight-post-comment"
-                  onClick={(e) => { e.stopPropagation(); onToggleHighlightDismissed(keyFor(h)); }}
-                  title="Restore this AI note"
-                >
-                  Restore
-                </button>
-              )}
-            </div>
-          ))}
+          {showDismissed && dismissedNotes.map((h, i) => {
+            const resolution = resolutions.get(keyFor(h));
+            const chipLabel = resolution?.state === "fixed" ? "Fixed" : resolution?.state === "intentional" ? "Intentional" : "Dismissed";
+            const chipModifier = resolution?.state === "fixed" ? "note-res-chip--fixed" : resolution?.state === "intentional" ? "note-res-chip--intentional" : "";
+            return (
+              <div
+                key={`dismissed-${i}`}
+                className={`highlights-summary-item highlight-${h.severity} highlight-dismissed`}
+                style={{ cursor: "pointer" }}
+                onClick={() => {
+                  const el = document.getElementById(`diff-line-${h.start_line}`);
+                  el?.scrollIntoView({ behavior: "smooth", block: "center" });
+                }}
+                title="Jump to code"
+              >
+                <span className="highlight-severity-badge">{severityLabel[h.severity] || "Info"}</span>
+                <span className="highlight-lines">{formatLineRange(h.start_line, h.end_line)}</span>
+                <span className={`note-res-chip ${chipModifier}`}>{chipLabel}</span>
+                <span className="highlight-summary-text">{h.comment}</span>
+                {resolution?.reason && (
+                  <span className="note-res-reason" title={resolution.reason}>{resolution.reason}</span>
+                )}
+                {onRestoreHighlight && (
+                  <button
+                    className="highlight-post-comment"
+                    onClick={(e) => { e.stopPropagation(); onRestoreHighlight(keyFor(h)); }}
+                    title="Restore this AI note"
+                  >
+                    Restore
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
       <div className="diff-content" ref={diffContentRef}>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1913,6 +1913,128 @@ tr.cursor-selected td {
   color: var(--text-primary);
 }
 
+/* "Resolve…" popover on an inline AI note — mark fixed/intentional + optional reason. */
+.note-resolve-wrap {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+}
+
+.note-resolve-btn {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.highlight-marker:hover .note-resolve-btn {
+  opacity: 1;
+}
+.note-resolve-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.note-resolve-popover {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 220px;
+  padding: var(--space-2);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-2);
+}
+
+.note-resolve-popover-states {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.note-resolve-popover-states button {
+  flex: 1;
+  font-size: 11px;
+  padding: 4px 0;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--chip-border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.note-resolve-popover-states button.active {
+  background: var(--accent-strong);
+  border-color: var(--accent);
+  color: var(--white);
+}
+
+.note-resolve-reason {
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 11px;
+  font-family: var(--font-sans);
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--chip-border);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.note-resolve-confirm {
+  align-self: flex-end;
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: var(--accent-strong);
+  color: var(--white);
+  cursor: pointer;
+}
+.note-resolve-confirm:hover {
+  background: var(--accent-strong-hover);
+}
+
+/* Resolution-state chip in the dismissed-notes list. */
+.note-res-chip {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--chip-border);
+  background: var(--chip-bg);
+  color: var(--text-muted);
+}
+
+.note-res-chip--fixed {
+  color: var(--diff-add-text);
+  border-color: rgba(63, 185, 80, 0.4);
+}
+
+.note-res-chip--intentional {
+  color: var(--accent);
+  border-color: rgba(88, 166, 255, 0.4);
+}
+
+.note-res-reason {
+  color: var(--text-muted);
+  font-size: 11px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Highlighted line background tint */
 .highlighted.highlighted-critical {
   background: rgba(248, 81, 73, 0.08) !important;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -134,7 +134,11 @@ export type NoteResolutionState = "fixed" | "intentional" | "noise";
  * `dismissed_highlights.rs` — `reason`/`at` are optional there too (empty
  * string on the wire), kept optional here for the same reason. */
 export interface NoteResolution {
-  state: NoteResolutionState;
+  /** Normally a NoteResolutionState, but Rust serde-defaults a malformed
+   * entry's state to "" rather than failing the whole file, so loaded values
+   * can fall outside the union (rendered as plain "Dismissed"). The
+   * `string & {}` keeps union autocomplete while admitting that. */
+  state: NoteResolutionState | (string & {});
   reason?: string;
   at?: string;
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -128,6 +128,17 @@ export type ChatStreamEvent =
   | { type: "done"; content: string }
   | { type: "error"; message: string };
 
+export type NoteResolutionState = "fixed" | "intentional" | "noise";
+
+/** How/why an AI note was resolved. Mirrors `NoteResolution` in
+ * `dismissed_highlights.rs` — `reason`/`at` are optional there too (empty
+ * string on the wire), kept optional here for the same reason. */
+export interface NoteResolution {
+  state: NoteResolutionState;
+  reason?: string;
+  at?: string;
+}
+
 export type SidebarView = "groups" | "comments" | "category" | "tree";
 
 export type DiffViewMode = "split" | "unified";
@@ -158,6 +169,9 @@ export interface Tab {
   staleViewedFiles: Set<string>;
   /** Keys (see highlightKey) of AI highlights the user has dismissed for this PR. */
   dismissedHighlights: Set<string>;
+  /** Resolution metadata (state + reason) for dismissed highlights, keyed by
+   * highlightKey. A dismissed key may have no entry here (plain/legacy dismiss). */
+  noteResolutions: Map<string, NoteResolution>;
   /** Conversational diff Q&A state for this PR. */
   chat: ChatState;
   commentThreads: CommentThreadsState;

--- a/scripts/resolve-highlights.mjs
+++ b/scripts/resolve-highlights.mjs
@@ -11,6 +11,8 @@
 //   node scripts/resolve-highlights.mjs <pr> --severity=info,warning
 //   node scripts/resolve-highlights.mjs <pr> --file=commands.rs
 //   node scripts/resolve-highlights.mjs <pr> --prune    also drop stale keys (notes that no longer exist)
+//   node scripts/resolve-highlights.mjs <pr> --state=fixed|intentional|noise   (default: noise)
+//   node scripts/resolve-highlights.mjs <pr> --reason="why this was resolved"
 //
 // <pr> may be a bare number (e.g. 126 — matched against the manifests dir), an
 // owner/repo/number or PR URL, or a path to a manifest .json.
@@ -47,6 +49,11 @@ const opts = Object.fromEntries(
 const positional = args.filter((a) => !a.startsWith("--"));
 if (positional.length !== 1) die("expected exactly one <pr> argument. See header for usage.");
 const target = positional[0];
+
+const VALID_STATES = new Set(["fixed", "intentional", "noise"]);
+const state = opts.state || "noise";
+if (!VALID_STATES.has(state)) die(`--state must be one of fixed|intentional|noise, got "${state}"`);
+const reason = opts.reason || "";
 
 // ── Locate the manifest + derive owner/repo/number ──────────────────────────
 function manifestNameToParts(file) {
@@ -93,12 +100,18 @@ for (const f of manifest.files ?? []) {
 }
 
 const dismissedPath = path.join(DISMISSED, `${parts.owner}_${parts.repo}_${parts.number}.json`);
-const existing = new Set(fs.existsSync(dismissedPath) ? JSON.parse(fs.readFileSync(dismissedPath, "utf8")).keys : []);
+const existingRaw = fs.existsSync(dismissedPath) ? JSON.parse(fs.readFileSync(dismissedPath, "utf8")) : {};
+const existing = new Set(existingRaw.keys ?? []);
+const existingResolutions = existingRaw.resolutions ?? {};
 
 const label = `${parts.owner}/${parts.repo}#${parts.number}`;
 console.log(`${label} — ${notes.length} highlight(s)${sevFilter || fileFilter ? " (filtered)" : ""}`);
 for (const n of notes) {
-  const mark = existing.has(n.key) ? "✓ resolved" : "· open";
+  const res = existingResolutions[n.key];
+  let mark = "· open";
+  if (existing.has(n.key)) {
+    mark = res ? `✓ resolved (${res.state}${res.reason ? `: ${res.reason}` : ""})` : "✓ resolved";
+  }
   console.log(`  [${n.severity.padEnd(7)}] ${n.path} L${n.start_line}-${n.end_line}  ${mark}`);
 }
 
@@ -109,25 +122,43 @@ if (flags.has("--list")) {
 
 // ── Apply ───────────────────────────────────────────────────────────────────
 const undo = flags.has("--undo");
-const next = new Set(existing);
+const nextKeys = new Set(existing);
+const nextResolutions = { ...existingResolutions };
 let changed = 0;
 for (const n of notes) {
-  if (undo) { if (next.delete(n.key)) changed++; }
-  else if (!next.has(n.key)) { next.add(n.key); changed++; }
+  if (undo) {
+    if (nextKeys.delete(n.key)) changed++;
+    delete nextResolutions[n.key];
+  } else if (!nextKeys.has(n.key)) {
+    nextKeys.add(n.key);
+    nextResolutions[n.key] = { state, reason, at: new Date().toISOString() };
+    changed++;
+  }
 }
 
 if (flags.has("--prune")) {
   // Drop any stored key that doesn't correspond to a current highlight in this PR.
   const live = new Set((manifest.files ?? []).flatMap((f) => (f.highlights ?? []).map((h) => highlightKey(f.path, h))));
-  for (const k of [...next]) if (!live.has(k)) { next.delete(k); changed++; }
+  for (const k of [...nextKeys]) {
+    if (!live.has(k)) {
+      nextKeys.delete(k);
+      delete nextResolutions[k];
+      changed++;
+    }
+  }
+  for (const k of Object.keys(nextResolutions)) {
+    if (!nextKeys.has(k)) delete nextResolutions[k];
+  }
 }
 
 fs.mkdirSync(DISMISSED, { recursive: true });
-fs.writeFileSync(dismissedPath, JSON.stringify({ keys: [...next].sort() }, null, 2));
+const sortedKeys = [...nextKeys].sort();
+const sortedResolutions = Object.fromEntries(sortedKeys.filter((k) => nextResolutions[k]).map((k) => [k, nextResolutions[k]]));
+fs.writeFileSync(dismissedPath, JSON.stringify({ keys: sortedKeys, resolutions: sortedResolutions }, null, 2));
 fs.chmodSync(dismissedPath, 0o600);
 
 console.log(
-  `\n${undo ? "un-resolved" : "resolved"} ${changed} | file now has ${next.size} key(s)\n` +
+  `\n${undo ? "un-resolved" : `resolved (${state})`} ${changed} | file now has ${nextKeys.size} key(s)\n` +
     `→ ${dismissedPath}\n` +
     `→ switch back to Marrow (it reloads on window focus) to see the change.`,
 );


### PR DESCRIPTION
## Summary
- Closes #148: dismissing an AI note can now record *how* it was resolved — quick `×` stays a plain dismiss, a new **Resolve…** popover captures **Fixed** or **Intentional** with an optional reason.
- The per-PR dismissed store gains a `resolutions` map (`key → {state, reason, at}`), serde-defaulted in both directions: old files load fine, old app versions ignore the new field, and one malformed entry can't resurface every dismissed note.
- The dismissed banner shows state chips + reasons; Restore clears both. `resolve-highlights.mjs` gains `--state=fixed|intentional|noise` and `--reason`.
- The reasons are the substrate for the stacked prompt-quality PR, which feeds prior triage into future analysis runs.

## Changes
- core: `dismissed_highlights.rs` (NoteResolution, invariants, 3 new tests)
- gui: `App.tsx` (resolve/restore + focus-reload compares resolutions too), `DiffViewer.tsx` (Resolve… popover, banner chips), `types.ts`, `styles.css` (token-based)
- scripts: `resolve-highlights.mjs` new flags, `--list`/`--undo`/`--prune` handle both maps

## Test Plan
- [x] `bun run build`, `cargo check --workspace`, `cargo test -p marrow-core` (33, incl. back-compat round-trips) — clean
- [x] Adversarial verifier pass; both findings fixed (defaulted `state` so corrupt entries can't nuke the file; focus-reload now detects metadata-only changes)
- [x] Script smoke-tested against a temp `MARROW_CONFIG_DIR` (resolve → shape on disk → undo)
- [ ] Untested live: the Resolve… popover interaction (statically verified; try it on this PR's own notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)