### PR TITLE
feat(core): actionable AI highlights — severity rubric, context, continuity

### DIFF
--- a/app/src-tauri/crates/core/src/dismissed_highlights.rs
+++ b/app/src-tauri/crates/core/src/dismissed_highlights.rs
@@ -36,6 +36,42 @@ pub struct NoteResolution {
     pub at: String,
 }
 
+/// Port of the frontend's `hashString` (app/src/utils.ts) — a djb2-xor
+/// variant operating on UTF-16 code units, matching JS's `charCodeAt`
+/// iteration exactly (surrogate pairs count as two units in both). Must stay
+/// bit-for-bit identical: it's how the Rust side recognizes which cached
+/// highlight a frontend-computed dismissal key refers to.
+fn hash_comment(s: &str) -> String {
+    let mut h: i32 = 5381;
+    for unit in s.encode_utf16() {
+        let shifted = h.wrapping_shl(5);
+        h = shifted.wrapping_add(h).wrapping_add(unit as i32);
+    }
+    to_base36(h as u32)
+}
+
+fn to_base36(mut n: u32) -> String {
+    if n == 0 {
+        return "0".to_string();
+    }
+    const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut buf = Vec::new();
+    while n > 0 {
+        buf.push(DIGITS[(n % 36) as usize]);
+        n /= 36;
+    }
+    buf.reverse();
+    String::from_utf8(buf).unwrap()
+}
+
+/// The same stable identifier the frontend computes for a highlight (see
+/// `highlightKey` in app/src/utils.ts) — path + line range + a hash of the
+/// comment text, so it survives re-fetches but changes if the note's wording
+/// changes.
+pub fn highlight_key(path: &str, start_line: u64, end_line: u64, comment: &str) -> String {
+    format!("{}:{}-{}:{}", path, start_line, end_line, hash_comment(comment))
+}
+
 fn dismissed_dir() -> PathBuf {
     app_config_dir().join("dismissed")
 }
@@ -84,6 +120,39 @@ pub fn save_dismissed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Reference vectors generated from the actual JS `hashString` (app/src/utils.ts):
+    ///
+    /// ```
+    /// node -e '
+    ///   function hashString(s) {
+    ///     let h = 5381;
+    ///     for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+    ///     return (h >>> 0).toString(36);
+    ///   }
+    ///   console.log(hashString(""));
+    ///   console.log(hashString("a"));
+    ///   console.log(hashString("hello world"));
+    ///   console.log(hashString("This removes the null check without a fallback — could NPE if input is empty."));
+    ///   console.log(hashString("emoji test 🚀 unicode"));
+    /// '
+    /// ```
+    #[test]
+    fn hash_comment_matches_js_hashstring() {
+        assert_eq!(hash_comment(""), "45h");
+        assert_eq!(hash_comment("a"), "3t3a");
+        assert_eq!(hash_comment("hello world"), "eslcxt");
+        assert_eq!(
+            hash_comment("This removes the null check without a fallback — could NPE if input is empty."),
+            "1xoypnn"
+        );
+        assert_eq!(hash_comment("emoji test 🚀 unicode"), "1v9mnp9");
+    }
+
+    #[test]
+    fn highlight_key_matches_frontend_format() {
+        assert_eq!(highlight_key("a.rs", 1, 2, "a"), "a.rs:1-2:3t3a");
+    }
 
     #[test]
     fn old_format_json_loads() {

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -1,15 +1,18 @@
 use crate::ai::{extract_json_array, AiBackend};
 use crate::config::resolve_github_token;
+use crate::dismissed_highlights;
 use crate::github::GithubClient;
 use crate::manifest_cache;
 use crate::pr_parser::parse_pr_ref;
-use crate::prompts::{build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt};
+use crate::prompts::{
+    build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt, PriorNote,
+};
 use crate::types::{
     ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, Settings,
 };
 use futures::stream::{FuturesUnordered, StreamExt};
 use sha2::{Sha256, Digest};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Sink for fetch progress updates. The Tauri command passes a closure that
 /// emits a `fetch-progress` event to the webview; the `marrow` CLI passes one that
@@ -61,11 +64,17 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let head_sha = metadata.head.sha;
     let author = metadata.user.as_ref().map(|u| u.login.clone()).unwrap_or_default();
     let draft = metadata.draft.unwrap_or(false);
+    let pr_body = metadata.body.unwrap_or_default();
 
-    if let Some(cached) = manifest_cache::load_cached_manifest(&parsed.owner, &parsed.repo, parsed.number) {
+    // Loaded before this run's manifest overwrites the cache (see the
+    // `save_cached_manifest` call at the end of this function) so it's still
+    // the *previous* analysis — used below to feed prior triage back into the
+    // highlight prompt.
+    let previous_manifest = manifest_cache::load_cached_manifest(&parsed.owner, &parsed.repo, parsed.number);
+    if let Some(cached) = &previous_manifest {
         if cached.head_sha == head_sha {
             emit_progress(app, 6, "Loaded from cache", FetchStatus::Done, Some(&pr_title), None);
-            return Ok(cached);
+            return Ok(cached.clone());
         }
     }
 
@@ -128,7 +137,8 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         // Step 4: AI highlight analysis + summary + grouping (parallel)
         emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
         let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
-        let highlight_prompt = build_highlight_prompt(&pr_title, &per_file_diffs);
+        let prior_notes = build_prior_notes(&previous_manifest, &parsed.owner, &parsed.repo, parsed.number);
+        let highlight_prompt = build_highlight_prompt(&pr_title, &pr_body, &per_file_diffs, &prior_notes);
 
         let summary_prompt = build_summary_prompt(&pr_title, &relevant);
         let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
@@ -326,6 +336,49 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let _ = manifest_cache::save_cached_manifest(&parsed.owner, &parsed.repo, parsed.number, &manifest);
 
     Ok(manifest)
+}
+
+/// Build the prior-triage context fed back into the highlight prompt: for
+/// every highlight in the *previous* cached manifest that the reviewer
+/// dismissed, look up its resolution (if any) and carry it forward so
+/// re-analysis doesn't re-flag an already-triaged concern. Best-effort —
+/// missing previous manifest or dismissed-state file just yields no notes;
+/// this must never fail the fetch.
+fn build_prior_notes(
+    previous_manifest: &Option<ReviewManifest>,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+) -> Vec<PriorNote> {
+    let Some(previous) = previous_manifest else {
+        return Vec::new();
+    };
+    let Some(dismissed) = dismissed_highlights::load_dismissed(owner, repo, pr_number) else {
+        return Vec::new();
+    };
+    let dismissed_keys: HashSet<&str> = dismissed.keys.iter().map(|k| k.as_str()).collect();
+
+    let mut notes = Vec::new();
+    for file in &previous.files {
+        for h in &file.highlights {
+            let key = dismissed_highlights::highlight_key(&file.path, h.start_line, h.end_line, &h.comment);
+            if !dismissed_keys.contains(key.as_str()) {
+                continue;
+            }
+            let (state, reason) = dismissed
+                .resolutions
+                .get(&key)
+                .map(|r| (r.state.clone(), r.reason.clone()))
+                .unwrap_or_default();
+            notes.push(PriorNote {
+                path: file.path.clone(),
+                comment: h.comment.clone(),
+                state,
+                reason,
+            });
+        }
+    }
+    notes
 }
 
 /// Extract per-file diffs for the relevant files from a pre-built diff map.

--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -47,7 +47,7 @@ Respond with ONLY a valid JSON array. Each element must be an object with:
 
 Do NOT include any text before or after the JSON array. Just the JSON."#;
 
-pub const HIGHLIGHT_PROMPT: &str = r#"You are a code review assistant. You are given the diffs of files that have been classified as relevant for review. Your job is to identify specific changes within each file that deserve human attention.
+pub const HIGHLIGHT_PROMPT: &str = r#"You are a code review assistant. You are given a PR's title and description, plus the diffs of files that have been classified as relevant for review. Your job is to surface the specific changes a human reviewer should actually spend attention on — not everything that changed, only what's worth their time.
 
 Focus on:
 - Security implications (auth checks added/removed, input validation changes, permission changes)
@@ -66,16 +66,26 @@ Do NOT flag:
 - Straightforward additions of new independent functionality
 - Log message changes
 - Comment-only changes
+- A change that IS the PR's stated purpose (per its title/description), merely for being a behavior change — the PR exists to change that behavior; only flag it if it's risky beyond what the title/description already tells the reviewer
+- A concern the provided diff itself already answers — if another hunk in this file's diff, or another file's diff, shows the case is handled, don't raise it
+
+Before flagging anything, apply these rules:
+
+1. Resolve before you flag. Never write a note that just asks the reviewer to "verify", "confirm", or "check" something the diff already shows. Read the rest of this file's diff and the other files' diffs first. If the answer is there, either drop the note entirely or turn it into an "info" that states the conclusion — e.g. "Null input is handled by the early return at L42" — never "verify null input is handled".
+2. Respect truncation honestly. If a file's diff ends with a truncation marker ("... (truncated)"), do not speculate about what the unseen remainder contains, and do not flag a "verify X" note whose answer might live in that missing part. If the file still looks risky given what you can see, flag the truncation itself as "info" (e.g. "Diff truncated before the auth check — worth viewing the full file").
+3. Respect prior triage. You may be given a list of notes already reviewed in an earlier pass, with how each was resolved. Do not re-flag a concern one of those already covers unless this diff materially changes the picture. If the continuity is worth a nod, emit at most one "info" note referencing the prior resolution — never repeat the original warning verbatim.
+
+Severity measures actionability, not category:
+- "critical": a likely defect with severe consequences — security hole, data loss, auth bypass, crash. The reviewer must act on this before merging.
+- "warning": a likely defect or genuine risk. Use this test: if the author did not intend this, it is a bug. An intentional-looking behavior change is NOT a warning, even if it's important — that belongs under "info".
+- "info": an accurate, useful observation — an intentional behavior change worth double-checking, a notable addition, a design tradeoff worth knowing about.
 
 For each highlight, provide:
 - "path": the file path
 - "start_line": the line number in the NEW (head) version of the file where the notable change starts
 - "end_line": the line number in the NEW (head) version where it ends
-- "severity": one of "critical", "warning", "info"
-  - "critical": security risk, data loss risk, auth bypass, breaking API change
-  - "warning": behavior change worth verifying, removed safety check, non-obvious side effect
-  - "info": worth noting but likely fine — refactored logic, changed defaults, added dependency
-- "comment": a concise explanation (under 20 words) of what the reviewer should pay attention to
+- "severity": one of "critical", "warning", "info" (see above)
+- "comment": under 30 words. State the risk or the fact, not a request to verify — the reviewer should learn something from it, not receive a homework assignment.
 
 Respond with ONLY a valid JSON array of these highlight objects. If there are no notable changes, return an empty array [].
 Do NOT include any text before or after the JSON array. Just the JSON."#;
@@ -146,6 +156,18 @@ fn build_file_context_prompt(
     )
 }
 
+/// Truncate `s` to at most `max` chars (char-boundary safe — unlike byte
+/// slicing, which can panic mid-character on multibyte input) if it exceeds
+/// the budget. Returns `None` when no truncation is needed. Mirrors the
+/// equivalent helper in chat.rs.
+fn truncate_chars(s: &str, max: usize) -> Option<String> {
+    if s.chars().count() <= max {
+        None
+    } else {
+        Some(s.chars().take(max).collect())
+    }
+}
+
 pub fn build_classification_prompt(
     pr_title: &str,
     file_list: &[String],
@@ -154,13 +176,9 @@ pub fn build_classification_prompt(
     let files_str = file_list.join("\n");
 
     // Truncate diff to ~30000 chars for the AI prompt
-    let truncated_diff = if diff_content.len() > 30000 {
-        format!(
-            "{}\n\n... (diff truncated for brevity)",
-            &diff_content[..30000]
-        )
-    } else {
-        diff_content.to_string()
+    let truncated_diff = match truncate_chars(diff_content, 30000) {
+        Some(t) => format!("{}\n\n... (diff truncated for brevity)", t),
+        None => diff_content.to_string(),
     };
 
     format!(
@@ -169,25 +187,165 @@ pub fn build_classification_prompt(
     )
 }
 
+/// A previously reviewed highlight, fed back into the prompt so re-analysis
+/// doesn't re-flag a concern that was already triaged. `state` is
+/// "fixed" | "intentional" | "noise" | "" (plain dismiss, no resolution recorded).
+pub struct PriorNote {
+    pub path: String,
+    pub comment: String,
+    pub state: String,
+    pub reason: String,
+}
+
 pub fn build_highlight_prompt(
     pr_title: &str,
+    pr_body: &str,
     per_file_diffs: &[(String, String)], // (path, diff)
+    prior_notes: &[PriorNote],
 ) -> String {
     let mut context = String::new();
     for (path, diff) in per_file_diffs {
         context.push_str(&format!("=== FILE: {} ===\n", path));
         // Truncate per-file diff to 5000 chars
-        if diff.len() > 5000 {
-            context.push_str(&diff[..5000]);
-            context.push_str("\n... (truncated)\n");
-        } else {
-            context.push_str(diff);
+        match truncate_chars(diff, 5000) {
+            Some(t) => {
+                context.push_str(&t);
+                context.push_str("\n... (truncated)\n");
+            }
+            None => context.push_str(diff),
         }
         context.push_str("\n\n");
     }
 
+    let body_section = if pr_body.trim().is_empty() {
+        String::new()
+    } else {
+        let truncated_body = match truncate_chars(pr_body, 2000) {
+            Some(t) => format!("{}\n... (truncated)", t),
+            None => pr_body.to_string(),
+        };
+        format!("\nPR Description:\n{}\n", truncated_body)
+    };
+
+    let prior_section = if prior_notes.is_empty() {
+        String::new()
+    } else {
+        let mut s =
+            String::from("\n=== PREVIOUSLY REVIEWED NOTES (do not re-flag; see instructions) ===\n");
+        for note in prior_notes {
+            let label = match note.state.as_str() {
+                "" | "noise" => "dismissed",
+                other => other,
+            };
+            s.push_str(&format!("- [{}] {}: {}", label, note.path, note.comment));
+            if !note.reason.is_empty() {
+                s.push_str(&format!(" — reviewer: {}", note.reason));
+            }
+            s.push('\n');
+        }
+        s
+    };
+
     format!(
-        "{}\n\n---\n\nPR Title: {}\n\n{}",
-        HIGHLIGHT_PROMPT, pr_title, context
+        "{}\n\n---\n\nPR Title: {}\n{}{}\n{}",
+        HIGHLIGHT_PROMPT, pr_title, body_section, prior_section, context
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn highlight_prompt_includes_pr_body_section() {
+        let prompt = build_highlight_prompt(
+            "Add retry logic",
+            "This PR adds exponential backoff to the fetch client.",
+            &[("client.rs".to_string(), "some diff".to_string())],
+            &[],
+        );
+        assert!(prompt.contains("PR Description:"));
+        assert!(prompt.contains("This PR adds exponential backoff to the fetch client."));
+    }
+
+    #[test]
+    fn highlight_prompt_omits_body_section_when_empty() {
+        let prompt = build_highlight_prompt(
+            "Add retry logic",
+            "",
+            &[("client.rs".to_string(), "some diff".to_string())],
+            &[],
+        );
+        assert!(!prompt.contains("PR Description:"));
+    }
+
+    #[test]
+    fn highlight_prompt_includes_prior_notes_section() {
+        let prior_notes = vec![
+            PriorNote {
+                path: "a.rs".to_string(),
+                comment: "Null check removed".to_string(),
+                state: "fixed".to_string(),
+                reason: "restored in follow-up commit".to_string(),
+            },
+            PriorNote {
+                path: "b.rs".to_string(),
+                comment: "Config default changed".to_string(),
+                state: "intentional".to_string(),
+                reason: String::new(),
+            },
+            PriorNote {
+                path: "c.rs".to_string(),
+                comment: "Unused import".to_string(),
+                state: String::new(),
+                reason: String::new(),
+            },
+        ];
+        let prompt = build_highlight_prompt("Title", "", &[], &prior_notes);
+        assert!(prompt.contains("PREVIOUSLY REVIEWED NOTES"));
+        assert!(prompt.contains("- [fixed] a.rs: Null check removed — reviewer: restored in follow-up commit"));
+        assert!(prompt.contains("- [intentional] b.rs: Config default changed"));
+        assert!(prompt.contains("- [dismissed] c.rs: Unused import"));
+    }
+
+    #[test]
+    fn highlight_prompt_omits_prior_section_when_empty() {
+        let prompt = build_highlight_prompt("Title", "", &[], &[]);
+        assert!(!prompt.contains("PREVIOUSLY REVIEWED NOTES"));
+    }
+
+    #[test]
+    fn highlight_prompt_per_file_truncation_is_char_safe_on_multibyte() {
+        // A >5000-char diff made entirely of a 3-byte multibyte char would panic
+        // under `&diff[..5000]` byte slicing (it lands mid-character). Chars,
+        // not bytes, must be counted and sliced.
+        let diff: String = std::iter::repeat('★').take(6000).collect();
+        let prompt = build_highlight_prompt(
+            "Title",
+            "",
+            &[("weird.rs".to_string(), diff)],
+            &[],
+        );
+        assert!(prompt.contains("... (truncated)"));
+    }
+
+    #[test]
+    fn classification_prompt_truncation_is_char_safe_on_multibyte() {
+        let diff: String = std::iter::repeat('★').take(31000).collect();
+        let prompt = build_classification_prompt("Title", &["a.rs".to_string()], &diff);
+        assert!(prompt.contains("diff truncated for brevity"));
+    }
+
+    #[test]
+    fn pr_body_truncation_is_char_safe_on_multibyte() {
+        let body: String = std::iter::repeat('★').take(2500).collect();
+        let prompt = build_highlight_prompt(
+            "Title",
+            &body,
+            &[],
+            &[],
+        );
+        assert!(prompt.contains("PR Description:"));
+        assert!(prompt.contains("... (truncated)"));
+    }
 }

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -194,6 +194,8 @@ pub struct PrMetadata {
     pub user: Option<PrUser>,
     #[serde(default)]
     pub draft: Option<bool>,
+    #[serde(default)]
+    pub body: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary
Stacked on #151 (retarget to main after it merges). Driven by the #148 calibration ledger (22 notes triaged → 3 real fixes, 6/7 Warnings on intentional behavior, chronic "verify X" homework and re-flags):
- **Severity = actionability**: warning now means "if the author didn't intend this, it's a bug"; intentional changes are info; the PR's stated purpose is never a warning.
- **Resolve-before-you-flag**: no "verify/confirm/check X" notes when the diff answers X — state the conclusion or drop it.
- **More context**: the pass finally sees the PR description (`PrMetadata.body`); truncated diffs carry a marker the prompt tells the model to respect instead of speculating past.
- **Continuity**: previously resolved notes (comment + state + reason from the #148 store, joined via a bit-exact Rust port of the frontend `highlightKey` hash — pinned + fuzzed against the JS) feed into the prompt with do-not-re-litigate instructions.
- Fixed latent byte-slice panics in prompt truncation on multibyte diffs.

## Eval (same PR, same head, same claude-CLI backend)
Replayed #133's last analysis round offline:
- **Old prompt**: 7 notes — 2 Warnings (both already-handled), 5 repeats of dismissed notes, 0 actionable
- **New prompt**: 4 notes, 0 Warnings — conclusions instead of questions, the truncation flagged honestly, one genuinely new observation (XSS-sensitive highlight.js consumer not in diff), and exactly one continuity info confirming the prior SSE concern is now fixed

## Test Plan
- [x] `cargo check --workspace`, `cargo test -p marrow-core` (42) + `-p marrow-cli` (37) — clean
- [x] Verifier pass: hash port fuzzed with 205 random strings against the real JS — bit-exact; fetch ordering (previous manifest read before overwrite) traced
- [x] Offline eval above
- [ ] Real-world calibration continues via the #148 ledger on future PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)