### PR TITLE
feat(activity): mini-player data layer — session broadcast, snooze, CI, tiers

### DIFF
--- a/app/src-tauri/crates/core/src/activity.rs
+++ b/app/src-tauri/crates/core/src/activity.rs
@@ -42,6 +42,12 @@ pub struct Observed {
 pub struct SeenState {
     pub last_seen_at: String,
     pub observed: Observed,
+    /// Muted until the next poll's diff against `observed` finds any delta —
+    /// see [`compute_activity`], which clears this the moment the PR "wakes".
+    /// `#[serde(default)]` so existing `activity.json` files (written before
+    /// this field existed) parse as not-snoozed rather than failing to load.
+    #[serde(default)]
+    pub snoozed: bool,
 }
 
 /// `activity.json` on disk: `pr_url -> SeenState`.
@@ -49,6 +55,12 @@ pub struct SeenState {
 pub struct ActivityStore {
     #[serde(default)]
     pub prs: HashMap<String, SeenState>,
+    /// Set by [`compute_activity`] when it mutated the store (a snooze woke).
+    /// Lets the poll loop skip rewriting activity.json on quiet polls — the
+    /// file is unlocked last-write-wins shared with mark_pr_seen/snooze_pr,
+    /// so every avoided write shrinks the lost-update window.
+    #[serde(skip)]
+    pub dirty: bool,
 }
 
 /// A PR observed this poll, with the source-derived metadata the UI renders and
@@ -98,6 +110,19 @@ pub struct PrActivityItem {
     pub unresolved_threads: Option<u32>,
     pub ci_state: Option<String>,
     pub unread: bool,
+    /// "needs_you" | "yours" | "watching" — see [`compute_tier`]. Additive:
+    /// existing consumers that don't read this field are unaffected.
+    #[serde(default)]
+    pub tier: String,
+    /// Sortable relevance score — see [`compute_urgency`]. Additive: not used
+    /// by `compute_activity`'s own sort (unread desc, updated_at desc), which
+    /// stays unchanged; a future queue view can sort by this instead.
+    #[serde(default)]
+    pub urgency: u32,
+    /// Muted by the user until the next delta wakes it. Additive: current UI
+    /// ignores this field, so it has no visible effect yet.
+    #[serde(default)]
+    pub snoozed: bool,
 }
 
 /// The `pr-activity` event payload broadcast to all windows.
@@ -177,7 +202,11 @@ fn diff(seen: &Observed, now: &Observed) -> Vec<String> {
             deltas.push("new-threads".to_string());
         }
     }
-    if now.ci_state.is_some() && now.ci_state != seen.ci_state {
+    // Same first-known-value rule as review_state: enrichment newly populating
+    // ci_state (None→Some) is learning, not change — without the seen guard,
+    // the first poll after CI enrichment ships would fire "ci-changed" for the
+    // entire backlog at once.
+    if now.ci_state.is_some() && seen.ci_state.is_some() && now.ci_state != seen.ci_state {
         deltas.push("ci-changed".to_string());
     }
     deltas
@@ -194,12 +223,95 @@ fn is_self_authored(pr: &ObservedPr, viewer: &str) -> bool {
             .unwrap_or(false)
 }
 
+/// Whether any of `reasons` reads as "someone wants your review specifically"
+/// — a direct request, or a notification whose subject is review-flavored
+/// (as opposed to e.g. a generic "comment"/"subscribed"/"state_change" you're
+/// only following). Used by [`compute_tier`].
+fn is_review_ish_reason(reasons: &[String]) -> bool {
+    reasons.iter().any(|r| {
+        r == "review-requested"
+            || r.strip_prefix("notification:")
+                .map(|subject| matches!(subject, "review_requested" | "mention" | "team_mention"))
+                .unwrap_or(false)
+    })
+}
+
+/// Which of the three mini-player tiers a PR belongs to:
+///  - `"yours"` — you authored it (case-insensitive login match against
+///    `viewer`); takes priority even over a re-request, since it's still your
+///    own PR.
+///  - `"needs_you"` — a fresh re-review request, a direct `"review-requested"`
+///    reason, or a review-flavored notification (`review_requested`/`mention`/
+///    `team_mention`) — someone is explicitly waiting on you.
+///  - `"watching"` — everything else: a saved watch, an "involved" PR you're
+///    only following, or a non-review notification.
+fn compute_tier(author: &str, viewer: &str, reasons: &[String], is_re_requested: bool) -> String {
+    if !viewer.is_empty() && author.eq_ignore_ascii_case(viewer) {
+        return "yours".to_string();
+    }
+    if is_re_requested || is_review_ish_reason(reasons) {
+        return "needs_you".to_string();
+    }
+    "watching".to_string()
+}
+
+/// Sortable relevance score — highest first. This is data for the mini-player
+/// widget and (later) the queue home; it does NOT change `compute_activity`'s
+/// own sort (unread desc, updated_at desc), which stays exactly as before.
+///
+/// The ladder, highest urgency first:
+///  1. A fresh re-review request (`is_re_requested`) — someone explicitly
+///     asked for another look at your own past review.
+///  2. Your own PR whose CI just went red — you're blocked on yourself.
+///  3. An unread PR in the `needs_you` tier — someone is waiting on you and
+///     you haven't acknowledged it yet.
+///  4. New unresolved threads or comments since you last looked.
+///  5. CI state changed (any direction, any tier not already covered above).
+///  6. A plain "updated" delta — the catch-all "something moved".
+///  0. Nothing changed / not urgent.
+///
+/// Exact weights are arbitrary; only the ordering between rungs is the
+/// contract callers can rely on.
+fn compute_urgency(
+    tier: &str,
+    unread: bool,
+    is_re_requested: bool,
+    ci_state: Option<&str>,
+    deltas: &[String],
+) -> u32 {
+    if is_re_requested {
+        return 100;
+    }
+    if tier == "yours" && matches!(ci_state, Some("failure") | Some("error")) {
+        return 90;
+    }
+    if tier == "needs_you" && unread {
+        return 80;
+    }
+    if deltas.iter().any(|d| d == "new-threads" || d == "new-comments") {
+        return 60;
+    }
+    if deltas.iter().any(|d| d == "ci-changed") {
+        return 40;
+    }
+    if deltas.iter().any(|d| d == "updated") {
+        return 20;
+    }
+    0
+}
+
 /// Turn this poll's observations into a feed payload by diffing against the
 /// persisted seen-state. A PR never seen before is `unread` with a `new` delta;
 /// a PR whose observable fields all match its seen-state is read with no deltas.
+///
+/// `store` is mutable: a PR snoozed in a prior poll whose diff now produces
+/// any delta has its persisted `snoozed` flag cleared here (it "wakes") so
+/// later polls — which diff against this same seen-state — don't keep
+/// reporting it as muted. Callers must persist `store` afterward (see
+/// `poll_activity_once` in the desktop crate) for the wake to stick.
 pub fn compute_activity(
     observations: Vec<ObservedPr>,
-    store: &ActivityStore,
+    store: &mut ActivityStore,
     truncated: HashMap<String, u32>,
     fetched_at: String,
     viewer: &str,
@@ -215,7 +327,7 @@ pub fn compute_activity(
                 || pr.observed.review_state.as_deref() != Some("approved")
         })
         .map(|pr| {
-            let (deltas, unread) = match store.prs.get(&pr.pr_url) {
+            let (deltas, unread, was_snoozed) = match store.prs.get(&pr.pr_url) {
                 Some(seen) => {
                     let mut d = diff(&seen.observed, &pr.observed);
                     // Your own comment bumps `updated_at` but isn't news: drop the
@@ -226,10 +338,29 @@ pub fn compute_activity(
                         d.retain(|x| x != "updated");
                     }
                     let unread = !d.is_empty();
-                    (d, unread)
+                    (d, unread, seen.snoozed)
                 }
-                None => (vec!["new".to_string()], true),
+                None => (vec!["new".to_string()], true, false),
             };
+            // A delta landing while snoozed wakes the item: persist the clear
+            // so future polls (diffing against this same seen-state) agree.
+            let snoozed = if was_snoozed && unread {
+                if let Some(seen) = store.prs.get_mut(&pr.pr_url) {
+                    seen.snoozed = false;
+                    store.dirty = true;
+                }
+                false
+            } else {
+                was_snoozed
+            };
+            let tier = compute_tier(&pr.author, viewer, &pr.reasons, pr.is_re_requested);
+            let urgency = compute_urgency(
+                &tier,
+                unread,
+                pr.is_re_requested,
+                pr.observed.ci_state.as_deref(),
+                &deltas,
+            );
             PrActivityItem {
                 pr_url: pr.pr_url,
                 owner: pr.owner,
@@ -246,11 +377,15 @@ pub fn compute_activity(
                 unresolved_threads: pr.observed.unresolved_threads,
                 ci_state: pr.observed.ci_state.clone(),
                 unread,
+                tier,
+                urgency,
+                snoozed,
             }
         })
         .collect();
 
-    // Unread first, then most-recently-updated.
+    // Unread first, then most-recently-updated. Unchanged by tier/urgency —
+    // those are additive data for the widget/queue-home to sort by later.
     items.sort_by(|a, b| {
         b.unread
             .cmp(&a.unread)
@@ -265,15 +400,38 @@ pub fn compute_activity(
 }
 
 /// Record that the user has acknowledged a PR: store its current observable
-/// state so future polls diff against it (clearing the unread state).
+/// state so future polls diff against it (clearing the unread state and any
+/// snooze — an explicit acknowledgement isn't a snooze).
 pub fn mark_seen(store: &mut ActivityStore, pr_url: &str, observed: Observed, now: String) {
     store.prs.insert(
         pr_url.to_string(),
         SeenState {
             last_seen_at: now,
             observed,
+            snoozed: false,
         },
     );
+}
+
+/// Snooze a PR: like [`mark_seen`], but flags it `snoozed` so the UI can mute
+/// it until the next poll's diff against this same seen-state finds any
+/// delta, at which point `compute_activity` clears the flag (the item wakes).
+pub fn snooze(store: &mut ActivityStore, pr_url: &str, observed: Observed, now: String) {
+    store.prs.insert(
+        pr_url.to_string(),
+        SeenState {
+            last_seen_at: now,
+            observed,
+            snoozed: true,
+        },
+    );
+}
+
+/// Clear a manual snooze without waiting for a delta.
+pub fn unsnooze(store: &mut ActivityStore, pr_url: &str) {
+    if let Some(seen) = store.prs.get_mut(pr_url) {
+        seen.snoozed = false;
+    }
 }
 
 #[cfg(test)]
@@ -306,10 +464,10 @@ mod tests {
 
     #[test]
     fn never_seen_pr_is_unread_with_new_delta() {
-        let store = ActivityStore::default();
+        let mut store = ActivityStore::default();
         let payload = compute_activity(
             vec![pr("u1", obs("2026-01-01T00:00:00Z"))],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
@@ -326,7 +484,7 @@ mod tests {
         mark_seen(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "seen".into());
         let payload = compute_activity(
             vec![pr("u1", obs("2026-01-01T00:00:00Z"))],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
@@ -342,7 +500,7 @@ mod tests {
         mark_seen(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "seen".into());
         let payload = compute_activity(
             vec![pr("u1", obs("2026-02-01T00:00:00Z"))],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
@@ -386,7 +544,7 @@ mod tests {
         // updated_at moved, but the latest comment is the viewer's own.
         let mut p = pr("u1", obs("2026-02-01T00:00:00Z"));
         p.last_actor = Some("Me".into());
-        let payload = compute_activity(vec![p], &store, HashMap::new(), "now".into(), "me", true);
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
         assert!(!payload.items[0].unread, "own comment should not be unread");
         assert!(!payload.items[0].deltas.contains(&"updated".to_string()));
     }
@@ -397,7 +555,7 @@ mod tests {
         mark_seen(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "seen".into());
         let mut p = pr("u1", obs("2026-02-01T00:00:00Z"));
         p.last_actor = Some("someone-else".into());
-        let payload = compute_activity(vec![p], &store, HashMap::new(), "now".into(), "me", true);
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
         assert!(payload.items[0].unread);
         assert!(payload.items[0].deltas.contains(&"updated".to_string()));
     }
@@ -419,7 +577,7 @@ mod tests {
         };
         let mut p = pr("u1", now);
         p.last_actor = Some("me".into());
-        let payload = compute_activity(vec![p], &store, HashMap::new(), "now".into(), "me", true);
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
         assert!(payload.items[0].unread, "new commits keep it unread");
         assert!(payload.items[0].deltas.contains(&"new-commits".to_string()));
         assert!(!payload.items[0].deltas.contains(&"updated".to_string()));
@@ -454,12 +612,12 @@ mod tests {
 
     #[test]
     fn approved_prs_are_filtered_unless_opted_in_or_re_requested() {
-        let store = ActivityStore::default();
+        let mut store = ActivityStore::default();
         // Default (show_approved = false): a plain approved PR is dropped, but an
         // approved PR with a re-review requested stays.
         let payload = compute_activity(
             vec![approved("approved-url", false), approved("re-req-url", true)],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
@@ -471,7 +629,7 @@ mod tests {
         // show_approved = true keeps both.
         let payload = compute_activity(
             vec![approved("approved-url", false)],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
@@ -489,12 +647,158 @@ mod tests {
                 pr("seen-url", obs("2026-05-01T00:00:00Z")), // read
                 pr("new-url", obs("2026-01-01T00:00:00Z")),  // unread, older
             ],
-            &store,
+            &mut store,
             HashMap::new(),
             "now".into(),
             "",
             true,
         );
         assert_eq!(payload.items[0].pr_url, "new-url", "unread sorts before read");
+    }
+
+    // ---- Tier ---------------------------------------------------------
+
+    #[test]
+    fn tier_yours_when_author_matches_viewer_case_insensitive() {
+        let mut store = ActivityStore::default();
+        let mut p = pr("u1", obs("t"));
+        p.author = "Me".into();
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
+        assert_eq!(payload.items[0].tier, "yours");
+    }
+
+    #[test]
+    fn tier_needs_you_on_direct_review_request() {
+        let mut store = ActivityStore::default();
+        let mut p = pr("u1", obs("t"));
+        p.reasons = vec!["review-requested".into()];
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
+        assert_eq!(payload.items[0].tier, "needs_you");
+    }
+
+    #[test]
+    fn tier_needs_you_on_review_ish_notification() {
+        let mut store = ActivityStore::default();
+        let mut p = pr("u1", obs("t"));
+        p.reasons = vec!["notification:mention".into()];
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
+        assert_eq!(payload.items[0].tier, "needs_you");
+    }
+
+    #[test]
+    fn tier_needs_you_on_re_requested() {
+        let mut store = ActivityStore::default();
+        let mut p = pr("u1", obs("t"));
+        p.reasons = vec!["watching:x".into()];
+        p.is_re_requested = true;
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
+        assert_eq!(payload.items[0].tier, "needs_you");
+    }
+
+    #[test]
+    fn tier_watching_otherwise() {
+        let mut store = ActivityStore::default();
+        let mut p = pr("u1", obs("t"));
+        p.reasons = vec!["notification:subscribed".into()];
+        let payload = compute_activity(vec![p], &mut store, HashMap::new(), "now".into(), "me", true);
+        assert_eq!(payload.items[0].tier, "watching");
+    }
+
+    // ---- Urgency -------------------------------------------------------
+
+    #[test]
+    fn urgency_ladder_ordering() {
+        let mut store = ActivityStore::default();
+
+        // Re-requested outranks everything.
+        let mut re_req = pr("re-req", obs("t"));
+        re_req.is_re_requested = true;
+
+        // Own PR with red CI outranks a plain review-requested.
+        let mut own_red_ci = pr("own-red-ci", obs("t"));
+        own_red_ci.author = "me".into();
+        own_red_ci.observed.ci_state = Some("failure".into());
+
+        // Unread review-requested (needs_you) outranks a mere delta.
+        let mut review_requested = pr("review-requested", obs("t"));
+        review_requested.reasons = vec!["review-requested".into()];
+
+        let payload = compute_activity(
+            vec![re_req, own_red_ci, review_requested],
+            &mut store,
+            HashMap::new(),
+            "now".into(),
+            "me",
+            true,
+        );
+        let urgency_of = |url: &str| {
+            payload
+                .items
+                .iter()
+                .find(|i| i.pr_url == url)
+                .unwrap()
+                .urgency
+        };
+        assert!(
+            urgency_of("re-req") > urgency_of("own-red-ci"),
+            "re-request outranks own-PR-red-CI"
+        );
+        assert!(
+            urgency_of("own-red-ci") > urgency_of("review-requested"),
+            "own-PR-red-CI outranks review-requested"
+        );
+    }
+
+    // ---- Snooze ---------------------------------------------------------
+
+    #[test]
+    fn snoozed_pr_stays_snoozed_when_nothing_changed() {
+        let mut store = ActivityStore::default();
+        snooze(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "s".into());
+        let payload = compute_activity(
+            vec![pr("u1", obs("2026-01-01T00:00:00Z"))],
+            &mut store,
+            HashMap::new(),
+            "now".into(),
+            "",
+            true,
+        );
+        assert!(payload.items[0].snoozed, "no delta, stays snoozed");
+        assert!(store.prs.get("u1").unwrap().snoozed, "persisted state unchanged");
+    }
+
+    #[test]
+    fn snoozed_pr_wakes_on_any_delta() {
+        let mut store = ActivityStore::default();
+        snooze(&mut store, "u1", obs("2026-01-01T00:00:00Z"), "s".into());
+        let payload = compute_activity(
+            vec![pr("u1", obs("2026-02-01T00:00:00Z"))], // updated_at moved
+            &mut store,
+            HashMap::new(),
+            "now".into(),
+            "",
+            true,
+        );
+        assert!(!payload.items[0].snoozed, "a delta wakes the item");
+        assert!(
+            !store.prs.get("u1").unwrap().snoozed,
+            "the wake is persisted so future polls agree"
+        );
+    }
+
+    #[test]
+    fn unsnooze_clears_without_a_delta() {
+        let mut store = ActivityStore::default();
+        snooze(&mut store, "u1", obs("t"), "s".into());
+        unsnooze(&mut store, "u1");
+        assert!(!store.prs.get("u1").unwrap().snoozed);
+    }
+
+    #[test]
+    fn mark_seen_clears_any_prior_snooze() {
+        let mut store = ActivityStore::default();
+        snooze(&mut store, "u1", obs("t"), "s".into());
+        mark_seen(&mut store, "u1", obs("t2"), "s2".into());
+        assert!(!store.prs.get("u1").unwrap().snoozed);
     }
 }

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -224,6 +224,20 @@ fn resolve_review_state(pr: &serde_json::Value, viewer: &str) -> (String, bool) 
     (status, is_re_requested)
 }
 
+/// Lowercase a `statusCheckRollup.state` GraphQL enum
+/// (`SUCCESS`/`FAILURE`/`ERROR`/`PENDING`/`EXPECTED`) to the activity feed's
+/// `ci_state` convention. `EXPECTED` (checks queued but not yet reported)
+/// reads the same as `PENDING` to callers — both mean "not settled yet".
+fn normalize_ci_state(state: &str) -> String {
+    match state {
+        "SUCCESS" => "success".to_string(),
+        "FAILURE" => "failure".to_string(),
+        "ERROR" => "error".to_string(),
+        "PENDING" | "EXPECTED" => "pending".to_string(),
+        other => other.to_lowercase(),
+    }
+}
+
 impl GithubClient {
     pub fn new(token: Option<String>) -> Self {
         Self {
@@ -1762,6 +1776,7 @@ impl GithubClient {
             reviewRequests(first: 20) { nodes { requestedReviewer { ... on User { login } } } }
             reviews(last: 100) { nodes { author { login } state } }
             comments(last: 1) { nodes { author { login } } }
+            commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
         "#;
 
         // Build one query per chunk from immutable reads, then fire them all at once.
@@ -1813,6 +1828,12 @@ impl GithubClient {
                     .and_then(|v| v.as_str())
                 {
                     o.last_actor = Some(login.to_string());
+                }
+                if let Some(state) = pr
+                    .pointer("/commits/nodes/0/commit/statusCheckRollup/state")
+                    .and_then(|v| v.as_str())
+                {
+                    o.observed.ci_state = Some(normalize_ci_state(state));
                 }
             }
         }

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -186,6 +186,24 @@ pub fn mark_pr_seen(pr_url: String, observed: Observed) -> Result<(), String> {
     activity::save_activity_store(&store)
 }
 
+/// Snooze a PR in the activity feed: like `mark_pr_seen`, but also mutes it
+/// until the next poll's diff finds any delta (see `activity::snooze`), at
+/// which point it wakes back up on its own.
+#[command]
+pub fn snooze_pr(pr_url: String, observed: Observed) -> Result<(), String> {
+    let mut store = activity::load_activity_store();
+    activity::snooze(&mut store, &pr_url, observed, activity::now_rfc3339());
+    activity::save_activity_store(&store)
+}
+
+/// Clear a manual snooze without waiting for a delta.
+#[command]
+pub fn unsnooze_pr(pr_url: String) -> Result<(), String> {
+    let mut store = activity::load_activity_store();
+    activity::unsnooze(&mut store, &pr_url);
+    activity::save_activity_store(&store)
+}
+
 /// Create the floating mini-player window, left HIDDEN. Built eagerly at
 /// startup (and on enable) so that the first show is never a window-creation —
 /// creating a webview window activates the app, which would yank you back to
@@ -334,6 +352,22 @@ pub fn dismiss_mini_player(app: tauri::AppHandle) -> Result<(), String> {
 pub fn open_pr_in_main(app: tauri::AppHandle, pr_ref: String) -> Result<(), String> {
     use tauri::{Emitter, Manager};
     let _ = app.emit("deep-link-open", &pr_ref);
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.set_focus();
+    }
+    Ok(())
+}
+
+/// Resume a PR the user was already reviewing, from the mini-player's "Now
+/// Reviewing" card: like `open_pr_in_main`, but emits `deep-link-resume`
+/// instead of `deep-link-open` so the main window can distinguish "jump back
+/// to my open tab and advance to the next unviewed file" from "open a PR I
+/// haven't started" (which still goes through the ordinary deep-link-open
+/// flow if no matching tab is open).
+#[command]
+pub fn resume_review_in_main(app: tauri::AppHandle, pr_ref: String) -> Result<(), String> {
+    use tauri::{Emitter, Manager};
+    let _ = app.emit("deep-link-resume", &pr_ref);
     if let Some(win) = app.get_webview_window("main") {
         let _ = win.set_focus();
     }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -32,16 +32,23 @@ async fn poll_activity_once(
     let collected = client
         .collect_activity(&watches, cap, notif_since.as_deref())
         .await;
-    let store = marrow_core::activity::load_activity_store();
+    let mut store = marrow_core::activity::load_activity_store();
     let viewer = collected.viewer.unwrap_or_default();
     let payload = marrow_core::activity::compute_activity(
         collected.observations,
-        &store,
+        &mut store,
         collected.truncated,
         marrow_core::activity::now_rfc3339(),
         &viewer,
         settings.show_approved_prs,
     );
+    // Persist only when compute_activity actually mutated the store (a delta
+    // woke a snoozed PR). Skipping quiet polls keeps this loop from being a
+    // periodic writer racing mark_pr_seen/snooze_pr on the unlocked,
+    // last-write-wins activity.json.
+    if store.dirty {
+        let _ = marrow_core::activity::save_activity_store(&store);
+    }
     let _ = handle.emit("pr-activity", payload);
     Some((collected.notif_poll_interval, collected.notif_last_modified))
 }
@@ -256,10 +263,13 @@ pub fn run() {
             commands::get_watches,
             commands::save_watches,
             commands::mark_pr_seen,
+            commands::snooze_pr,
+            commands::unsnooze_pr,
             commands::set_activity_window_visible,
             commands::set_mini_player_enabled,
             commands::dismiss_mini_player,
             commands::open_pr_in_main,
+            commands::resume_review_in_main,
             commands::chat_send,
             commands::chat_cancel,
             commands::load_chat_history,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
+import { listen, emit } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
 import { DiffViewer, detectLanguage, type DiffViewerHandle } from "./components/DiffViewer";
 import { CommentsViewer } from "./components/CommentsViewer";
@@ -519,6 +519,55 @@ function App() {
     return () => { unlisten.then((fn) => fn()); };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  /** Bumped per resume event so the advance effect runs even without a tab-id transition. */
+  const [resumePing, setResumePing] = useState(0);
+
+  // Listen for "resume this PR" from the mini-player's Now Reviewing card. If
+  // a tab for it is already open, jump back in and advance past whatever was
+  // last viewed; otherwise fall back to the ordinary deep-link open flow.
+  useEffect(() => {
+    const unlisten = listen<string>("deep-link-resume", (event) => {
+      if (!event.payload) return;
+      // canonicalPrKey (unlike extractPrRef) also accepts the owner/repo#number
+      // shape this event carries, not just a github.com URL.
+      const incomingKey = canonicalPrKey(event.payload);
+      const existing = incomingKey
+        ? tabsRef.current.find(
+            (t) => t.manifest && canonicalPrKey(t.manifest.pr_url) === incomingKey
+          )
+        : null;
+      if (existing) {
+        pendingResumeTabIdRef.current = existing.id;
+        // Bump a nonce so the advance effect below runs even when the target
+        // tab is ALREADY active — handleSelectTab with the current id causes
+        // no state transition, and without a run the stale ref would fire on
+        // a later unrelated switch back to this tab, yanking the user's file.
+        setResumePing((p) => p + 1);
+        handleSelectTab(existing.id);
+        return;
+      }
+      if (fetchingRef.current) {
+        addToast("info", "Already fetching a PR — try again when it finishes.");
+        return;
+      }
+      handleFetchStart(event.payload);
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Once the tab targeted by `deep-link-resume` above actually becomes active
+  // (a render after handleSelectTab), advance to the next unviewed file —
+  // deferred to here because guidedOrder()/nextUnviewed() close over this
+  // render's `activeTab`, which isn't current yet inside the listener above.
+  useEffect(() => {
+    if (!pendingResumeTabIdRef.current) return;
+    if (activeTabId !== pendingResumeTabIdRef.current) return;
+    if (!activeTab?.manifest) return;
+    pendingResumeTabIdRef.current = null;
+    const next = nextUnviewed(guidedOrder(), -1);
+    if (next) setSelectedFile(next);
+  }, [activeTabId, activeTab?.manifest, resumePing]); // eslint-disable-line react-hooks/exhaustive-deps
+
   async function loadManifest(path: string) {
     try {
       const data = await invoke<ReviewManifest>("load_manifest", { path });
@@ -957,6 +1006,13 @@ function App() {
   tabsRef.current = tabs;
   const activeTabIdRef = useRef(activeTabId);
   activeTabIdRef.current = activeTabId;
+  // Set by the `deep-link-resume` listener when the target tab isn't active
+  // yet; consumed by the effect that advances to the next unviewed file once
+  // it is (see both near the deep-link listeners above).
+  const pendingResumeTabIdRef = useRef<string | null>(null);
+  // Last `review-session` payload emitted (JSON), so the broadcast effect
+  // below doesn't re-emit an unchanged payload on every unrelated render.
+  const lastReviewSessionRef = useRef<string>("");
   // Latest tab handlers in refs so the once-mounted menu listeners never act on stale state.
   const closeTabRef = useRef<(id: string) => void>(() => {});
   const newTabRef = useRef<() => void>(() => {});
@@ -1704,6 +1760,33 @@ function App() {
     }, 500);
     return () => clearTimeout(timer);
   }, [tabs, activeTabId]);
+
+  // Broadcast the active tab's review session to every window (the mini-player
+  // widget's "Now Reviewing" card). Null when the active tab has no manifest
+  // (queue home) — the widget hides the card. Cheap event, so no debounce, but
+  // skip re-emitting an unchanged payload (e.g. re-renders that don't actually
+  // move viewedCount/nextFile).
+  useEffect(() => {
+    const manifest = activeTab?.manifest ?? null;
+    const payload = manifest
+      ? {
+          prUrl: manifest.pr_url,
+          prRef: (() => {
+            const { owner, repo, number } = parsePrUrl(manifest.pr_url);
+            return `${owner}/${repo}#${number}`;
+          })(),
+          number: manifest.pr_number,
+          title: manifest.pr_title,
+          viewedCount: activeTab?.viewedFiles.size ?? 0,
+          relevantCount: manifest.files.filter((f) => f.classification !== "NOT_RELEVANT").length,
+          nextFile: nextUnviewed(guidedOrder(), -1)?.path ?? null,
+        }
+      : null;
+    const serialized = JSON.stringify(payload);
+    if (serialized === lastReviewSessionRef.current) return;
+    lastReviewSessionRef.current = serialized;
+    emit("review-session", payload).catch(() => {});
+  }, [activeTabId, activeTab?.manifest, activeTab?.viewedFiles]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Persist user preferences whenever they change (debounced, with dirty check)
   useEffect(() => {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -333,6 +333,13 @@ export interface PrActivityItem {
   unresolvedThreads?: number | null;
   ciState?: string | null;
   unread: boolean;
+  /** "needs_you" | "yours" | "watching" — see Rust `compute_tier`. */
+  tier: string;
+  /** Sortable relevance score — see Rust `compute_urgency`. Not used by the
+   * current widget; for a future queue view to sort by. */
+  urgency: number;
+  /** Muted until the next delta wakes it. Current widget ignores this. */
+  snoozed: boolean;
 }
 
 /** Payload of the `pr-activity` event (matches Rust `PrActivityPayload`). */


### PR DESCRIPTION
## Summary
PR 1 of 2 for the mini-player revamp (mockups: see #74 thread). Data/plumbing only — the widget UI PR stacks on this.
- **Review-session broadcast**: the main window emits the in-progress review (PR, files progress, next unviewed file) as a deduped `review-session` event; `resume_review_in_main` → `deep-link-resume` activates the tab and advances straight to the next unviewed file.
- **Snooze until-next-delta**: `SeenState.snoozed` + `snooze_pr`/`unsnooze_pr`; any delta wakes the PR. The poll loop persists the store only when a wake dirtied it, to avoid becoming a periodic writer racing `mark_pr_seen` on the unlocked `activity.json`.
- **Real CI state, free**: `statusCheckRollup` added to the already-batched enrichment GraphQL — zero extra requests. Disclosed behavior change: the existing (previously dead) CI glyph column in the current widget now lights up.
- **Tier + urgency in core**: `needs_you`/`yours`/`watching` + a documented urgency ladder, computed core-side so the queue home can share it later. Payload sort unchanged.
- **NSPanel show/hide logic untouched.**

## Verifier catches (fixed)
- `ci_state` None→Some counted as `ci-changed` — the first poll after shipping would have marked **every user's entire backlog unread at once**. Now guarded like `review_state` (learning ≠ change).
- Resuming an already-active tab left a stale pending-resume ref that would silently yank the user's selected file on a later, unrelated tab switch — fixed with a per-event nonce.
- Poll-loop store write narrowed to dirty-only.

## Test Plan
- [x] `cargo check --workspace`, `cargo test -p marrow-core` (52, incl. tier/urgency-ladder/snooze-wake), `bun run build` — clean
- [x] Adversarial verifier pass (all three findings above fixed)
- [ ] Live: CI glyphs appearing in the current widget after first enrichment poll; resume path (needs PR 2's Now Reviewing card to exercise fully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)