### PR TITLE
feat(activity): mini-player UI — Now Reviewing, tiers, stories, quick actions

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -568,6 +568,18 @@ function App() {
     if (next) setSelectedFile(next);
   }, [activeTabId, activeTab?.manifest, resumePing]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Bridge for the mini-player's "Open on GitHub" row action: the floating
+  // widget's webview has no shell:open capability (see mini-player.json), so
+  // it can't call the shell plugin directly like the dock (which runs in this
+  // same main window) does. It emits this event instead and the main window —
+  // which does have the capability — opens the URL on its behalf.
+  useEffect(() => {
+    const unlisten = listen<string>("aw-open-external", (event) => {
+      if (event.payload) openUrl(event.payload).catch(() => {});
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []);
+
   async function loadManifest(path: string) {
     try {
       const data = await invoke<ReviewManifest>("load_manifest", { path });

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -28,6 +28,7 @@ import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
+import type { ReviewSession } from "./hooks/useActivityFeed";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
 function isOpenerTab(tab: Tab): boolean {
@@ -1785,7 +1786,9 @@ function App() {
   // move viewedCount/nextFile).
   useEffect(() => {
     const manifest = activeTab?.manifest ?? null;
-    const payload = manifest
+    // Typed as ReviewSession so this inline emit can't drift from the shape
+    // the widget's useReviewSession listener expects.
+    const payload: ReviewSession | null = manifest
       ? {
           prUrl: manifest.pr_url,
           prRef: (() => {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -575,7 +575,12 @@ function App() {
   // which does have the capability — opens the URL on its behalf.
   useEffect(() => {
     const unlisten = listen<string>("aw-open-external", (event) => {
-      if (event.payload) openUrl(event.payload).catch(() => {});
+      // Scope the bridge to what it exists for: activity items carry GitHub
+      // html_urls, so anything else is a bug (or a compromised webview) and
+      // gets dropped rather than handed to the OS opener.
+      if (event.payload?.startsWith("https://github.com/")) {
+        openUrl(event.payload).catch(() => {});
+      }
     });
     return () => { unlisten.then((fn) => fn()); };
   }, []);

--- a/app/src/components/ActivityWidget.tsx
+++ b/app/src/components/ActivityWidget.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { PrActivityItem, Settings, Watch } from "../types";
-import { useActivityFeed, prRefOf } from "../hooks/useActivityFeed";
+import { useActivityFeed, useReviewSession, prRefOf, type ReviewSession } from "../hooks/useActivityFeed";
 import { timeAgo } from "../utils";
 
 interface ActivityWidgetProps {
@@ -14,16 +16,6 @@ interface ActivityWidgetProps {
    */
   variant?: "dock" | "window";
 }
-
-const DELTA_LABELS: Record<string, string> = {
-  new: "new",
-  updated: "updated",
-  "new-commits": "new commits",
-  "new-comments": "new comments",
-  "review-state-changed": "review changed",
-  "new-threads": "new threads",
-  "ci-changed": "CI changed",
-};
 
 /** Strip the `watching:`/`notification:` prefix for a compact chip label. */
 function reasonLabel(reason: string): string {
@@ -58,61 +50,290 @@ function Equalizer() {
   );
 }
 
+type StoryTone = "urgent" | "bad" | "good" | "neutral";
+
+interface Story {
+  text: string;
+  tone: StoryTone;
+}
+
+/**
+ * Compose the row's one-line "story" sentence, priority-ordered. Replaces the
+ * old deltas/reasons chip row with a single sentence built from item fields.
+ *
+ * Note: `is_re_requested` (which the backend uses for `tier`/`urgency`) isn't
+ * part of `PrActivityItem`'s wire shape — the frontend only ever sees its
+ * *effect* (tier === "needs_you", high urgency), not the flag itself. There's
+ * no delta/reason string that distinguishes "re-requested after changes" from
+ * an ordinary review request either, so that branch is intentionally skipped.
+ */
+function storyFor(item: PrActivityItem): Story {
+  const hasDelta = (d: string) => item.deltas.includes(d);
+  const isOwn = item.tier === "yours";
+
+  if (isOwn && (item.ciState === "failure" || item.ciState === "error")) {
+    return {
+      text: hasDelta("new-commits") ? "CI went red after new commits" : "CI went red",
+      tone: "bad",
+    };
+  }
+  if (isOwn && item.reviewState === "approved" && item.ciState === "success") {
+    return { text: "Approved · CI green — ready to merge", tone: "good" };
+  }
+  if (hasDelta("new-comments")) {
+    const n = item.unresolvedThreads;
+    return {
+      text: n && n > 0 ? `New comments · ${n} unresolved thread${n === 1 ? "" : "s"}` : "New comments",
+      tone: "neutral",
+    };
+  }
+  if (item.reasons.includes("review-requested")) {
+    const n = item.unresolvedThreads;
+    return {
+      text:
+        n && n > 0
+          ? `Review requested by ${item.author} · ${n} unresolved thread${n === 1 ? "" : "s"}`
+          : `Review requested by ${item.author}`,
+      tone: "urgent",
+    };
+  }
+  // needs_you via a notification (mention / team review request) — cover the
+  // same reasons core's is_review_ish_reason grants the tier for, so these
+  // rows don't fall through to the generic "Updated Xm" fallback.
+  if (item.tier === "needs_you") {
+    const mention = item.reasons.some((r) => r.startsWith("notification:") && r.includes("mention"));
+    return {
+      text: mention ? `You were mentioned by ${item.author}` : `Your review was requested`,
+      tone: "urgent",
+    };
+  }
+  if (hasDelta("new-commits")) return { text: "New commits", tone: "neutral" };
+  if (hasDelta("ci-changed")) return { text: `CI ${item.ciState ?? "changed"}`, tone: "neutral" };
+  // The watch-label fallback only makes sense in the watching tier — under
+  // YOUR PRS / NEEDS YOU a "watching: X" line reads like a mis-filed row.
+  const watching = item.tier === "watching" ? item.reasons.find((r) => r.startsWith("watching:")) : undefined;
+  if (watching) {
+    return {
+      text: `watching: ${watching.slice("watching:".length)} · updated ${timeAgo(item.updatedAt, true)}`,
+      tone: "neutral",
+    };
+  }
+  return { text: `Updated ${timeAgo(item.updatedAt, true)}`, tone: "neutral" };
+}
+
+/** Fallback glyph for the pill ticker when the item has no CI status to show. */
+function toneGlyph(tone: StoryTone): string {
+  switch (tone) {
+    case "bad":
+      return "✗";
+    case "good":
+      return "✓";
+    default:
+      return "●";
+  }
+}
+
+function tickerTextFor(item: PrActivityItem, needsYouCount: number): string {
+  const story = storyFor(item);
+  const ci = ciGlyph(item.ciState);
+  const glyph = ci?.glyph ?? toneGlyph(story.tone);
+  return `${glyph} ${story.text} on ${item.repo}#${item.number} · ${needsYouCount} need you`;
+}
+
+/**
+ * Open a PR's GitHub URL in the user's browser. The dock renders inside the
+ * main window, which has the `shell:default` capability, so it can call the
+ * shell plugin directly (same pattern as Header.tsx/App.tsx). The floating
+ * window's own webview has no shell capability (see
+ * `app-tauri/capabilities/mini-player.json`) and none can be added here, so it
+ * routes through a plain frontend event instead — App.tsx listens for
+ * `aw-open-external` and opens the URL on the main window's behalf.
+ */
+function openOnGithub(url: string, variant: "dock" | "window") {
+  if (variant === "dock") {
+    openUrl(url).catch(() => {});
+  } else {
+    emit("aw-open-external", url).catch(() => {});
+  }
+}
+
+const TIER_ORDER = ["needs_you", "yours", "watching"] as const;
+const TIER_LABELS: Record<string, string> = {
+  needs_you: "Needs you",
+  yours: "Your PRs",
+  watching: "Watching",
+};
+
+/** Urgency desc, then unread desc, then most-recently-updated first. */
+function sortSection(items: PrActivityItem[]): PrActivityItem[] {
+  return [...items].sort((a, b) => {
+    if (b.urgency !== a.urgency) return b.urgency - a.urgency;
+    if (a.unread !== b.unread) return a.unread ? -1 : 1;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
 function ActivityRow({
   item,
+  variant,
   onActivate,
+  onMarkSeen,
+  onSnooze,
+  onUnsnooze,
+  snoozedMode = false,
 }: {
   item: PrActivityItem;
+  variant: "dock" | "window";
   onActivate: (item: PrActivityItem) => void;
+  onMarkSeen: (item: PrActivityItem) => void;
+  onSnooze: (item: PrActivityItem) => void;
+  onUnsnooze: (item: PrActivityItem) => void;
+  snoozedMode?: boolean;
 }) {
   const ci = ciGlyph(item.ciState);
+  const story = storyFor(item);
   return (
-    <button
-      className={`aw-row ${item.unread ? "aw-row--unread" : ""}`}
-      onClick={() => onActivate(item)}
-      title={`${item.repo}#${item.number} — ${item.title}`}
+    <div
+      className={`aw-row ${item.unread ? "aw-row--unread" : ""} ${snoozedMode ? "aw-row--snoozed" : ""}`}
     >
-      <span className="aw-row__dot" aria-hidden />
-      {item.avatarUrl ? (
-        <img className="aw-row__avatar" src={item.avatarUrl} alt="" loading="lazy" />
-      ) : (
-        <span className="aw-row__avatar aw-row__avatar--blank" aria-hidden />
-      )}
-      <span className="aw-row__main">
-        <span className="aw-row__title">{item.title}</span>
-        <span className="aw-row__meta">
-          <span className="aw-row__repo">
-            {item.repo}#{item.number}
-          </span>
-          {item.deltas.slice(0, 2).map((d) => (
-            <span key={d} className="aw-chip aw-chip--delta">
-              {DELTA_LABELS[d] ?? d}
-            </span>
-          ))}
-          {item.reasons.slice(0, 1).map((r) => (
-            <span key={r} className="aw-chip aw-chip--reason">
-              {reasonLabel(r)}
-            </span>
-          ))}
-        </span>
-      </span>
-      <span className="aw-row__status">
-        {ci && <span className={`aw-ci ${ci.cls}`}>{ci.glyph}</span>}
-        {!!item.unresolvedThreads && item.unresolvedThreads > 0 && (
-          <span className="aw-threads" title="unresolved threads">
-            {item.unresolvedThreads}
-          </span>
+      <button
+        className="aw-row__activate"
+        onClick={() => onActivate(item)}
+        title={`${item.repo}#${item.number} — ${item.title}`}
+      >
+        <span className="aw-row__dot" aria-hidden />
+        {item.avatarUrl ? (
+          <img className="aw-row__avatar" src={item.avatarUrl} alt="" loading="lazy" />
+        ) : (
+          <span className="aw-row__avatar aw-row__avatar--blank" aria-hidden />
         )}
-        <span className="aw-row__time">{timeAgo(item.updatedAt, true)}</span>
+        <span className="aw-row__main">
+          <span className="aw-row__title">{item.title}</span>
+          <span className="aw-row__meta">
+            <span className="aw-row__repo">
+              {item.repo}#{item.number}
+            </span>
+            <span className={`aw-story aw-story--${story.tone}`}>{story.text}</span>
+          </span>
+        </span>
+        <span className="aw-row__status">
+          {ci && <span className={`aw-ci ${ci.cls}`}>{ci.glyph}</span>}
+          {!!item.unresolvedThreads && item.unresolvedThreads > 0 && (
+            <span className="aw-threads" title="unresolved threads">
+              {item.unresolvedThreads}
+            </span>
+          )}
+          <span className="aw-row__time">{timeAgo(item.updatedAt, true)}</span>
+        </span>
+      </button>
+      <span className="aw-row__actions">
+        {snoozedMode ? (
+          <button
+            className="aw-row__action"
+            onClick={(e) => {
+              e.stopPropagation();
+              onUnsnooze(item);
+            }}
+            aria-label="Unsnooze"
+            title="Unsnooze"
+          >
+            zz
+          </button>
+        ) : (
+          <>
+            <button
+              className="aw-row__action"
+              onClick={(e) => {
+                e.stopPropagation();
+                onMarkSeen(item);
+              }}
+              aria-label="Mark seen"
+              title="Mark seen"
+            >
+              ✓
+            </button>
+            <button
+              className="aw-row__action"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSnooze(item);
+              }}
+              aria-label="Snooze"
+              title="Snooze"
+            >
+              zz
+            </button>
+            <button
+              className="aw-row__action"
+              onClick={(e) => {
+                e.stopPropagation();
+                openOnGithub(item.prUrl, variant);
+              }}
+              aria-label="Open on GitHub"
+              title="Open on GitHub"
+            >
+              ↗
+            </button>
+          </>
+        )}
       </span>
-    </button>
+    </div>
+  );
+}
+
+/** The "Now Reviewing" card: reflects the main window's active tab (via the
+ * `review-session` event) so both mini-player variants can jump back in. */
+function NowReviewingCard({
+  session,
+  compact,
+}: {
+  session: ReviewSession;
+  compact: boolean;
+}) {
+  const pct =
+    session.relevantCount > 0
+      ? Math.min(100, Math.round((session.viewedCount / session.relevantCount) * 100))
+      : 0;
+  const nextLabel = session.nextFile ? session.nextFile.split("/").pop() : null;
+
+  function resume() {
+    // Works for both variants: the floating window round-trips through the
+    // main window (as usual), and for the dock — which already IS the main
+    // window — this just re-focuses itself and advances to the next
+    // unviewed file, which App.tsx's `deep-link-resume` listener already
+    // handles regardless of which window emitted the event.
+    invoke("resume_review_in_main", { prRef: session.prRef }).catch(() => {});
+  }
+
+  return (
+    <div className={`aw-now ${compact ? "aw-now--compact" : ""}`}>
+      <div className="aw-now__top">
+        <div className="aw-now__info">
+          <span className="aw-now__eyebrow">Now reviewing</span>
+          <span className="aw-now__title">
+            #{session.number} {session.title}
+          </span>
+          <span className="aw-now__meta">
+            {session.viewedCount} of {session.relevantCount} files
+            {nextLabel ? ` · next: ${nextLabel}` : " · all files viewed"}
+          </span>
+        </div>
+        <button className="aw-now__resume" onClick={resume}>
+          Resume
+        </button>
+      </div>
+      <div className="aw-now__bar">
+        <div className="aw-now__bar-fill" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
   );
 }
 
 const COLLAPSED_KEY = "aw-collapsed";
 
 export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetProps) {
-  const { items, truncatedTotal, unreadCount, markSeen } = useActivityFeed();
+  const { items, truncatedTotal, unreadCount, markSeen, snoozePr, unsnoozePr } = useActivityFeed();
+  const session = useReviewSession();
   // Default to the unobtrusive pill; remember the user's choice across launches.
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
@@ -123,6 +344,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
   });
   const [unreadOnly, setUnreadOnly] = useState(false);
   const [focusIdx, setFocusIdx] = useState(0);
+  const [snoozedExpanded, setSnoozedExpanded] = useState(false);
   // Temporary feed filters (not persisted).
   const [query, setQuery] = useState("");
   const [source, setSource] = useState("all"); // a raw reason string, or "all"
@@ -196,6 +418,7 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     }
   }
 
+  // Existing filters (unread-only, search, source) apply BEFORE tiering.
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase();
     return items.filter((i) => {
@@ -209,9 +432,60 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
     });
   }, [items, unreadOnly, source, query]);
 
-  // The "now playing" item: clamp the cursor into range as the feed changes.
-  const safeIdx = visible.length ? Math.min(focusIdx, visible.length - 1) : 0;
-  const focus = visible[safeIdx];
+  // Group the filtered feed into tier sections (needs_you → yours → watching),
+  // sorted within each section; snoozed items are pulled out into their own
+  // trailing collapsed section instead of their tier.
+  const { sections, snoozed } = useMemo(() => {
+    const nonSnoozed = visible.filter((i) => !i.snoozed);
+    const snoozed = visible.filter((i) => i.snoozed);
+    const byTier: Record<string, PrActivityItem[]> = {};
+    for (const i of nonSnoozed) (byTier[i.tier] ??= []).push(i);
+    const sections = TIER_ORDER.map((tier) => ({ tier, items: sortSection(byTier[tier] ?? []) })).filter(
+      (s) => s.items.length > 0
+    );
+    return { sections, snoozed };
+  }, [visible]);
+
+  const needsYouItems = sections.find((s) => s.tier === "needs_you")?.items ?? [];
+
+  // Compact tier's prev/next transport steps through the needs-you tier only.
+  const safeIdx = needsYouItems.length ? Math.min(focusIdx, needsYouItems.length - 1) : 0;
+  const compactFocus = needsYouItems[safeIdx];
+
+  // Pill ticker: rotates through the top 3 items by urgency (raw feed, not
+  // narrowed by the search/filter controls — the pill is a global glance).
+  const tickerItems = useMemo(
+    () =>
+      [...items]
+        .filter((i) => !i.snoozed)
+        .sort((a, b) => b.urgency - a.urgency)
+        .slice(0, 3),
+    [items]
+  );
+  const needsYouCount = useMemo(
+    () => items.filter((i) => !i.snoozed && i.tier === "needs_you").length,
+    [items]
+  );
+  const prefersReducedMotion = useMemo(
+    () => typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches,
+    []
+  );
+  const [tickerIdx, setTickerIdx] = useState(0);
+  const [tickerVisible, setTickerVisible] = useState(true);
+  const [tickerPaused, setTickerPaused] = useState(false);
+  useEffect(() => {
+    if (prefersReducedMotion || tickerPaused || tickerItems.length <= 1) return;
+    const id = setInterval(() => {
+      setTickerVisible(false);
+      setTimeout(() => {
+        setTickerIdx((i) => (i + 1) % tickerItems.length);
+        setTickerVisible(true);
+      }, 300);
+    }, 6000);
+    return () => clearInterval(id);
+  }, [prefersReducedMotion, tickerPaused, tickerItems.length]);
+  const safeTickerIdx = tickerItems.length ? Math.min(tickerIdx, tickerItems.length - 1) : 0;
+  const tickerItem = tickerItems[safeTickerIdx];
 
   function activate(item: PrActivityItem) {
     markSeen(item);
@@ -225,10 +499,14 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       <button
         className={`activity-widget activity-widget--pill ${unreadCount ? "activity-widget--alert" : ""}`}
         onClick={() => setCollapsedPersist(false)}
+        onMouseEnter={() => setTickerPaused(true)}
+        onMouseLeave={() => setTickerPaused(false)}
         title="PR activity"
       >
         <Equalizer />
-        <span className="aw-pill__count">{unreadCount}</span>
+        <span className={`aw-ticker__text ${tickerVisible ? "" : "aw-ticker__text--hidden"}`}>
+          {tickerItem ? tickerTextFor(tickerItem, needsYouCount) : "All caught up"}
+        </span>
       </button>
     );
   }
@@ -327,10 +605,20 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
       </div>
       )}
 
-      {/* Tier 1 — "now playing". Shown only when too short for a list. */}
-      {compact && focus && (
-        <div className="aw-focus">
-          <div className="aw-focus__transport">
+      {/* "Now Reviewing" — mirrors the main window's active tab. Hidden when
+          there's no active session, or (outside the compact tier) while the
+          search box is open. */}
+      {session && (!showControls || compact) && (
+        <NowReviewingCard session={session} compact={compact} />
+      )}
+
+      {/* Compact tier: no scrolling list — just a prev/next strip through the
+          needs-you tier. Driven by `.aw--compact` (toggled in JS from a
+          measured height) because height-axis container queries don't match
+          in the macOS WKWebView. */}
+      {compact ? (
+        <div className="aw-compact-foot">
+          <div className="aw-compact-foot__transport">
             <button
               className="aw-iconbtn"
               onClick={() => setFocusIdx((i) => Math.max(0, i - 1))}
@@ -341,22 +629,24 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
             </button>
             <button
               className="aw-iconbtn"
-              onClick={() => setFocusIdx((i) => Math.min(visible.length - 1, i + 1))}
-              disabled={safeIdx >= visible.length - 1}
+              onClick={() => setFocusIdx((i) => Math.min(needsYouItems.length - 1, i + 1))}
+              disabled={safeIdx >= needsYouItems.length - 1}
               title="Next"
             >
               ›
             </button>
-            <span className="aw-focus__pos">
-              {safeIdx + 1}/{visible.length}
-            </span>
           </div>
-          <ActivityRow item={focus} onActivate={activate} />
+          {compactFocus ? (
+            <span className="aw-compact-foot__next">
+              next: {compactFocus.repo}#{compactFocus.number} — {storyFor(compactFocus).text}
+            </span>
+          ) : (
+            <span className="aw-compact-foot__next aw-compact-foot__next--empty">
+              Nothing needs you right now
+            </span>
+          )}
         </div>
-      )}
-
-      {/* Tier 2 — the feed. Hidden only when the compact focus bar takes over. */}
-      {(!compact || !focus) && (
+      ) : (
         <div className="aw-feed">
           {visible.length === 0 ? (
             <div className="aw-empty">
@@ -367,9 +657,51 @@ export function ActivityWidget({ onOpenPr, variant = "dock" }: ActivityWidgetPro
                   : "No PR activity yet"}
             </div>
           ) : (
-            visible.map((item) => (
-              <ActivityRow key={item.prUrl} item={item} onActivate={activate} />
-            ))
+            <>
+              {sections.map((s) => (
+                <div className="aw-tier" key={s.tier}>
+                  <div className="aw-tier__head">
+                    <span>{TIER_LABELS[s.tier]}</span>
+                    <span className="aw-tier__count">{s.items.length}</span>
+                  </div>
+                  {s.items.map((item) => (
+                    <ActivityRow
+                      key={item.prUrl}
+                      item={item}
+                      variant={variant}
+                      onActivate={activate}
+                      onMarkSeen={markSeen}
+                      onSnooze={snoozePr}
+                      onUnsnooze={unsnoozePr}
+                    />
+                  ))}
+                </div>
+              ))}
+              {snoozed.length > 0 && (
+                <div className="aw-tier aw-tier--snoozed">
+                  <button
+                    className="aw-tier__head aw-tier__head--clickable"
+                    onClick={() => setSnoozedExpanded((v) => !v)}
+                  >
+                    <span>{snoozedExpanded ? "▾" : "▸"} Snoozed</span>
+                    <span className="aw-tier__count">{snoozed.length}</span>
+                  </button>
+                  {snoozedExpanded &&
+                    snoozed.map((item) => (
+                      <ActivityRow
+                        key={item.prUrl}
+                        item={item}
+                        variant={variant}
+                        snoozedMode
+                        onActivate={activate}
+                        onMarkSeen={markSeen}
+                        onSnooze={snoozePr}
+                        onUnsnooze={unsnoozePr}
+                      />
+                    ))}
+                </div>
+              )}
+            </>
           )}
           {truncatedTotal > 0 && (
             <div className="aw-truncated">+{truncatedTotal} more not shown</div>

--- a/app/src/hooks/useActivityFeed.ts
+++ b/app/src/hooks/useActivityFeed.ts
@@ -29,7 +29,9 @@ export function useActivityFeed() {
   const items = payload?.items ?? EMPTY_ITEMS;
   const truncated = payload?.truncated ?? EMPTY_TRUNCATED;
 
-  const unreadCount = useMemo(() => items.filter((i) => i.unread).length, [items]);
+  // Snoozed items don't count toward the badge/pulse — that's the point of
+  // snoozing; they re-count automatically when a delta wakes them.
+  const unreadCount = useMemo(() => items.filter((i) => i.unread && !i.snoozed).length, [items]);
   const truncatedTotal = useMemo(
     () => Object.values(truncated).reduce((a, b) => a + b, 0),
     [truncated]
@@ -62,10 +64,81 @@ export function useActivityFeed() {
     );
   }, []);
 
-  return { items, truncatedTotal, unreadCount, markSeen };
+  /** Snooze a PR: mute it (backend wakes it on the next delta) and optimistically
+   * flip its local `snoozed` flag so the collapsed section reflects it instantly. */
+  const snoozePr = useCallback((item: PrActivityItem) => {
+    invoke("snooze_pr", {
+      prUrl: item.prUrl,
+      observed: {
+        updated_at: item.updatedAt,
+        review_state: item.reviewState ?? null,
+        unresolved_threads: item.unresolvedThreads ?? null,
+        ci_state: item.ciState ?? null,
+      },
+    }).catch(() => {});
+    setPayload((prev) =>
+      prev
+        ? {
+            ...prev,
+            items: prev.items.map((i) =>
+              i.prUrl === item.prUrl ? { ...i, snoozed: true } : i
+            ),
+          }
+        : prev
+    );
+  }, []);
+
+  /** Clear a manual snooze without waiting for a delta. */
+  const unsnoozePr = useCallback((item: PrActivityItem) => {
+    invoke("unsnooze_pr", { prUrl: item.prUrl }).catch(() => {});
+    setPayload((prev) =>
+      prev
+        ? {
+            ...prev,
+            items: prev.items.map((i) =>
+              i.prUrl === item.prUrl ? { ...i, snoozed: false } : i
+            ),
+          }
+        : prev
+    );
+  }, []);
+
+  return { items, truncatedTotal, unreadCount, markSeen, snoozePr, unsnoozePr };
 }
 
 /** `owner/repo#number` ref used by the deep-link / fetch entry points. */
 export function prRefOf(item: PrActivityItem): string {
   return `${item.owner}/${item.repo}#${item.number}`;
+}
+
+/** Payload of the `review-session` event, broadcast by the main window
+ * whenever the active tab's manifest or viewed-files set changes; null when
+ * no PR is active (e.g. the queue home). Mirrors the inline shape built in
+ * App.tsx — kept local here since it's not part of the Rust-owned wire types. */
+export interface ReviewSession {
+  prUrl: string;
+  prRef: string;
+  number: number;
+  title: string;
+  viewedCount: number;
+  relevantCount: number;
+  nextFile: string | null;
+}
+
+/** Subscribe to the "Now Reviewing" session broadcast for the mini-player's
+ * top card. Frontend-only event (no Rust command involved) — every window
+ * just listens for the main window's emit. */
+export function useReviewSession(): ReviewSession | null {
+  const [session, setSession] = useState<ReviewSession | null>(null);
+
+  useEffect(() => {
+    const unlisten = listen<ReviewSession | null>("review-session", (event) => {
+      setSession(event.payload);
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  return session;
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4266,14 +4266,25 @@ mark.search-highlight-current {
   border-radius: 999px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
 }
+.activity-widget--pill {
+  max-width: 280px;
+  overflow: hidden;
+}
 .activity-widget--pill:hover { border-color: var(--accent); }
 .activity-widget--alert { animation: aw-pulse 2s ease-in-out infinite; }
-.aw-pill__count {
-  font-weight: 600;
-  font-size: 13px;
-  min-width: 16px;
-  text-align: center;
+
+/* Rotating ticker text shown on the pill — top 3 items by urgency, crossfaded
+   every 6s (paused on hover; static under prefers-reduced-motion). */
+.aw-ticker__text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  transition: opacity 0.3s ease;
 }
+.aw-ticker__text--hidden { opacity: 0; }
 
 /* ---- Header ---- */
 .aw-head {
@@ -4352,15 +4363,86 @@ mark.search-highlight-current {
 .aw-eq i:nth-child(2) { height: 12px; animation-delay: -0.4s; }
 .aw-eq i:nth-child(3) { height: 8px; animation-delay: -0.1s; }
 
-/* ---- "Now playing" focus block (Tier 1) ---- */
-.aw-focus {
+/* ---- "Now Reviewing" card ---- */
+.aw-now {
   flex: none;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border);
-  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  margin: 8px 8px 4px;
+  padding: 10px 12px;
+  background: var(--accent-bg);
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  border-radius: var(--radius-md);
 }
-.aw-focus__transport { display: flex; align-items: center; gap: 4px; margin-bottom: 4px; }
-.aw-focus__pos { font-size: 11px; color: var(--text-muted); margin-left: 4px; }
+.aw-now--compact { margin: 6px 8px; padding: 6px 10px; }
+.aw-now__top { display: flex; align-items: center; gap: 10px; }
+.aw-now__info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.aw-now__eyebrow {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.aw-now__title {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aw-now__meta {
+  font-size: 11px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aw-now__resume {
+  flex: none;
+  background: var(--accent-strong);
+  color: var(--white);
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: 5px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.aw-now__resume:hover { background: var(--accent-strong-hover); }
+.aw-now__bar {
+  margin-top: 8px;
+  height: 3px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+.aw-now__bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: var(--radius-pill);
+  transition: width 0.25s ease;
+}
+
+/* ---- Compact tier's footer strip (prev/next through the needs-you tier) ---- */
+.aw-compact-foot {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  min-width: 0;
+}
+.aw-compact-foot__transport { display: flex; align-items: center; gap: 2px; flex: none; }
+.aw-compact-foot__next {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aw-compact-foot__next--empty { color: var(--text-muted); font-style: italic; }
 
 /* ---- Feed (Tier 2) ---- */
 .aw-feed { flex: 1; overflow-y: auto; padding: 4px; }
@@ -4372,8 +4454,48 @@ mark.search-highlight-current {
 }
 .aw-truncated { padding: 8px; font-style: italic; }
 
-/* ---- Row ---- */
-.aw-row {
+/* ---- Tier sections ---- */
+.aw-tier { padding: 2px 4px 6px; }
+.aw-tier__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 6px 4px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+}
+.aw-tier__head--clickable { cursor: pointer; font: inherit; text-align: left; }
+.aw-tier__head--clickable:hover { color: var(--text-secondary); }
+.aw-tier__count {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+  line-height: 1.6;
+}
+.aw-tier--snoozed { margin-top: 4px; border-top: 1px solid var(--border); padding-top: 4px; }
+
+/* ---- Row ----
+   `.aw-row` is a positioning wrapper (not a button — a button can't nest the
+   hover-actions cluster's own buttons); `.aw-row__activate` carries the click
+   target and the row's visual chrome. */
+.aw-row { position: relative; border-radius: 8px; }
+.aw-row:hover { background: var(--bg-tertiary); }
+.aw-row__activate {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -4384,9 +4506,10 @@ mark.search-highlight-current {
   border-radius: 8px;
   background: transparent;
   color: inherit;
+  font: inherit;
   cursor: pointer;
 }
-.aw-row:hover { background: var(--bg-tertiary); }
+.aw-row--snoozed { opacity: 0.6; }
 .aw-row__dot {
   width: 7px; height: 7px; border-radius: 50%;
   background: transparent; flex: none;
@@ -4410,15 +4533,19 @@ mark.search-highlight-current {
   color: var(--text-muted);
   white-space: nowrap;
 }
-.aw-chip {
-  font-size: 10px;
-  padding: 0 6px;
-  border-radius: 999px;
+/* One-line composed "story" sentence, replacing the old deltas/reasons chips. */
+.aw-story {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
   white-space: nowrap;
-  line-height: 1.6;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-.aw-chip--delta { color: var(--diff-add-text); background: var(--diff-add-bg); }
-.aw-chip--reason { color: var(--text-secondary); background: var(--bg-tertiary); }
+.aw-story--neutral { color: var(--text-secondary); }
+.aw-story--urgent { color: var(--risk-medium); }
+.aw-story--bad { color: var(--risk-critical); }
+.aw-story--good { color: var(--diff-add-text); }
 .aw-row__status { display: flex; align-items: center; gap: 6px; flex: none; }
 .aw-row__time { font-size: 11px; color: var(--text-muted); }
 .aw-ci { font-size: 12px; }
@@ -4433,30 +4560,56 @@ mark.search-highlight-current {
   padding: 0 6px;
 }
 
-/* ---- Layout tiers ---- */
-
-/* Compact (short): a single horizontal strip — the "now playing" PR + transport,
-   no scrolling feed. Driven by `.aw--compact` (toggled in JS from a measured
-   height) because height-axis container queries don't match in the macOS
-   WKWebView. The list/focus swap itself is done by conditional render. */
-.activity-widget.aw--compact .aw-controls { display: none; }
-.activity-widget.aw--compact .aw-focus {
-  flex: 1;
-  border-bottom: none;
+/* ---- Row hover quick actions ----
+   Absolutely positioned over the CI/time area (like the mockup); revealed on
+   hover OR keyboard focus so the actions stay reachable via Tab. Always
+   visible (not hover-gated) on snoozed rows, which only ever show Unsnooze. */
+.aw-row__actions {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
-  gap: 10px;
-  min-width: 0;
+  gap: 2px;
+  padding: 3px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
 }
-.activity-widget.aw--compact .aw-focus__transport { margin-bottom: 0; flex: none; }
-/* Let the PR row consume the remaining width so the title isn't truncated
-   while empty space sits to its right. */
-.activity-widget.aw--compact .aw-focus .aw-row { flex: 1; min-width: 0; }
+.aw-row:hover .aw-row__actions,
+.aw-row:focus-within .aw-row__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+.aw-row--snoozed .aw-row__actions { opacity: 1; pointer-events: auto; }
+.aw-row__action {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 7px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+.aw-row__action:hover { background: var(--bg-primary); color: var(--text-primary); }
 
-/* Narrow: shed chips and time to stay tidy. (Width-axis container queries do
+/* ---- Layout tiers ---- */
+
+/* Compact (short): Now Reviewing card + a single prev/next footer strip, no
+   scrolling feed. Driven by `.aw--compact` (toggled in JS from a measured
+   height) because height-axis container queries don't match in the macOS
+   WKWebView. The card/footer swap itself is done by conditional render. */
+.activity-widget.aw--compact .aw-controls { display: none; }
+
+/* Narrow: shed the time column to stay tidy. (Width-axis container queries do
    work in the WKWebView, so this one stays a container query.) */
 @container aw (max-width: 248px) {
-  .aw-chip--reason, .aw-row__time { display: none; }
+  .aw-row__time { display: none; }
 }
 
 /* ---- Watch-list editor (settings) ---- */
@@ -4496,6 +4649,11 @@ mark.search-highlight-current {
 @keyframes aw-pulse {
   0%, 100% { box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45); }
   50% { box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 40%, transparent), 0 8px 24px rgba(0, 0, 0, 0.45); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aw-now__bar-fill { transition: none; }
+  .aw-ticker__text { transition: none; }
 }
 
 /* ─── PR Overview (summary-first landing) ─────────────────────────────── */


### PR DESCRIPTION
## Summary
PR 2 of the mini-player revamp (stacked on #153 — retarget to main after it merges). Mockups: https://claude.ai/code/artifact/810620c8-5962-4539-971b-b5883b9c6bda
- **Now Reviewing card** — fed by the session broadcast; Resume jumps straight to the next unviewed file in the guided flow
- **Attention tiers** — Needs you / Your PRs / Watching, urgency-sorted; snoozed rows in a collapsed trailing section with Unsnooze
- **Story lines** — one composed sentence per row with semantic tone ("CI went red after new commits", "Approved · CI green — ready to merge", "Review requested by mika · 2 unresolved threads")
- **Hover quick actions** — mark seen / snooze / open on GitHub (floating window bridges to the main window's `openUrl`; no new Rust)
- **Compact tier** = now-playing + prev/next transport over the needs-you tier; **collapsed pill** = rotating top-3 urgency ticker (crossfade, hover-pauses, static under `prefers-reduced-motion`)
- Design tokens only; **zero NSPanel changes**; existing filters/truncation footer preserved

## Verifier + live findings (fixed)
- The "urgent" amber tone was unreachable (every branch returned other tones) — review requests and notification-driven needs-you rows now use it
- Notification-tier rows (`notification:mention` etc.) fell through to the generic "Updated Xm" fallback — now get real stories
- Snoozing the only unread PR left the badge/pulse unchanged — snoozed items no longer count
- Live check: a YOUR PRS row with stale deltas read "watching: Marrow" — watch-label fallback now restricted to the watching tier
- Singular/plural thread grammar

## Test Plan
- [x] `bun run build` clean; `cargo check` confirms zero Rust changes
- [x] Adversarial verifier pass (3 findings fixed) + live drive: dock pill ticker rendering, expanded dock with Now Reviewing + YOUR PRS tier + real session data, **Resume verified jumping into activity.rs with the guided flow engaged**, hot-reloaded story fix confirmed on screen
- [ ] Untested live: floating-panel variant of the new content (same component; panel show/hide untouched), snooze round-trip, ticker rotation timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)