### PR TITLE
feat(gui): overview & queue extras — description, avatars, mergeable, labels

### DIFF
--- a/app/src-tauri/crates/cli/src/tui.rs
+++ b/app/src-tauri/crates/cli/src/tui.rs
@@ -2260,6 +2260,7 @@ mod tests {
             draft: false,
             summary: String::new(),
             change_groups: Vec::new(),
+            body: String::new(),
             files: vec![
                 file("pkg/low.go", "low", "@@ -1,1 +1,1 @@\n-a\n+b\n"),
                 file("pkg/high.go", "high", "@@ -1,1 +1,2 @@\n a\n+b\n"),

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -104,6 +104,7 @@ fn default_settings() -> Settings {
         activity_per_watch_cap: 50,
         activity_mini_player: true,
         show_approved_prs: false,
+        show_draft_prs: true,
         setup_done: false,
     }
 }
@@ -136,6 +137,7 @@ pub fn load_settings() -> Settings {
     let mut activity_per_watch_cap = 50u64;
     let mut activity_mini_player = true;
     let mut show_approved_prs = false;
+    let mut show_draft_prs = true;
     let mut setup_done = false;
 
     for line in content.lines() {
@@ -175,6 +177,8 @@ pub fn load_settings() -> Settings {
             activity_mini_player = val == "true";
         } else if let Some(val) = line.strip_prefix("show_approved_prs=") {
             show_approved_prs = val == "true";
+        } else if let Some(val) = line.strip_prefix("show_draft_prs=") {
+            show_draft_prs = val == "true";
         } else if let Some(val) = line.strip_prefix("setup_done=") {
             setup_done = val == "true";
         }
@@ -198,6 +202,7 @@ pub fn load_settings() -> Settings {
         activity_per_watch_cap,
         activity_mini_player,
         show_approved_prs,
+        show_draft_prs,
         setup_done,
     }
 }
@@ -246,6 +251,7 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
         settings.activity_mini_player
     ));
     content.push_str(&format!("show_approved_prs={}\n", settings.show_approved_prs));
+    content.push_str(&format!("show_draft_prs={}\n", settings.show_draft_prs));
     content.push_str(&format!("setup_done={}\n", settings.setup_done));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -20,6 +20,17 @@ use std::collections::{HashMap, HashSet};
 /// reusable by any frontend.
 pub type ProgressFn<'a> = &'a (dyn Fn(FetchProgress) + Send + Sync);
 
+/// Truncate `s` to at most `max` chars on a char boundary (char-safe, unlike
+/// byte slicing). Mirrors the equivalent helpers in prompts.rs/chat.rs —
+/// bounds the cached manifest's stored PR body size.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect()
+    }
+}
+
 fn emit_progress(
     progress: ProgressFn,
     step: u8,
@@ -330,6 +341,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         draft,
         summary,
         change_groups,
+        body: truncate_chars(&pr_body, 10000),
         files: file_diffs,
     };
 

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -1,4 +1,4 @@
-use crate::types::{CheckRunInfo, CommentAuthor, MyReviewState, PrChecksStatus, PrFile, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
+use crate::types::{CheckRunInfo, CommentAuthor, MyReviewState, PrChecksStatus, PrFile, PrLabel, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
 use std::collections::HashMap;
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
@@ -632,6 +632,7 @@ impl GithubClient {
                 direct_request: false,
                 my_review_status: "pending".to_string(),
                 unresolved_thread_count: 0,
+                approval_count: 0,
             });
         }
 
@@ -706,6 +707,7 @@ impl GithubClient {
 
             if let Some(reviews) = pr.pointer("/reviews/nodes").and_then(|v| v.as_array()) {
                 item.my_review_status = resolve_user_review_status(reviews, username);
+                item.approval_count = resolve_approvers(reviews).len() as u32;
             }
 
             // Unresolved thread count
@@ -1451,7 +1453,11 @@ impl GithubClient {
                     pullRequest(number: {}) {{
                         merged
                         isDraft
+                        mergeable
                         author {{ login }}
+                        labels(first: 10) {{
+                            nodes {{ name color }}
+                        }}
                         reviewRequests(first: 20) {{
                             nodes {{
                                 requestedReviewer {{
@@ -1508,6 +1514,31 @@ impl GithubClient {
             .map(|reviews| resolve_approvers(reviews))
             .unwrap_or_default();
 
+        let mergeable = pr
+            .get("mergeable")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_lowercase())
+            .unwrap_or_default();
+
+        let labels = pr
+            .pointer("/labels/nodes")
+            .and_then(|v| v.as_array())
+            .map(|nodes| {
+                nodes
+                    .iter()
+                    .filter_map(|n| {
+                        let name = n.get("name").and_then(|v| v.as_str())?.to_string();
+                        let color = n
+                            .get("color")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        Some(PrLabel { name, color })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Ok(MyReviewState {
             status,
             is_re_requested,
@@ -1515,6 +1546,8 @@ impl GithubClient {
             author,
             draft,
             approved_by,
+            mergeable,
+            labels,
         })
     }
 }

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -81,6 +81,10 @@ pub struct ReviewManifest {
     pub summary: String,
     #[serde(default)]
     pub change_groups: Vec<ChangeGroup>,
+    /// The PR description, truncated char-safely to bound cache size. Empty
+    /// when the PR has no body or on manifests fetched before this field existed.
+    #[serde(default)]
+    pub body: String,
     pub files: Vec<FileDiff>,
 }
 
@@ -134,6 +138,10 @@ pub struct Settings {
     /// once you approve a PR, it drops out of the feed.
     #[serde(default)]
     pub show_approved_prs: bool,
+    /// Whether the review queue shows draft PRs. On by default (current
+    /// behavior); the frontend filters draft rows out when this is off.
+    #[serde(default = "default_true")]
+    pub show_draft_prs: bool,
     /// True once the first-run welcome has been completed or skipped, so it
     /// never auto-shows again (config via env vars alone also suppresses it).
     #[serde(default)]
@@ -280,6 +288,20 @@ pub struct MyReviewState {
     pub draft: bool,
     #[serde(default)]
     pub approved_by: Vec<String>,
+    /// Lowercased GitHub `mergeable` enum: "mergeable" | "conflicting" |
+    /// "unknown". Empty when GitHub hasn't computed it or the field is absent.
+    #[serde(default)]
+    pub mergeable: String,
+    #[serde(default)]
+    pub labels: Vec<PrLabel>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct PrLabel {
+    pub name: String,
+    /// Hex color without the leading '#', as GitHub returns it.
+    #[serde(default)]
+    pub color: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -310,4 +332,6 @@ pub struct ReviewRequestItem {
     pub direct_request: bool,
     pub my_review_status: String,
     pub unresolved_thread_count: u32,
+    #[serde(default)]
+    pub approval_count: u32,
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1486,6 +1486,8 @@ function App() {
           status: statusMap[event] as MyReviewState["status"],
           is_re_requested: false,
           is_merged: t.myReviewState?.is_merged ?? false,
+          mergeable: t.myReviewState?.mergeable ?? "",
+          labels: t.myReviewState?.labels ?? [],
         },
       }));
 
@@ -1645,6 +1647,8 @@ function App() {
                       status: t.myReviewState?.status ?? "pending",
                       is_re_requested: t.myReviewState?.is_re_requested ?? false,
                       is_merged: true,
+                      mergeable: t.myReviewState?.mergeable ?? "",
+                      labels: t.myReviewState?.labels ?? [],
                     },
                   }
             );
@@ -2001,6 +2005,7 @@ function App() {
                 onSelectCachedPr={handleOpenCachedPr}
                 openPrUrls={openPrUrls}
                 filter={queueFilter}
+                onOpenSettings={() => setSettingsOpen(true)}
               />
               {staleConfirm && (
                 <div className="settings-overlay" onMouseDown={() => setStaleConfirm(null)}>

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import hljs from "highlight.js";
+import { useEffect, useRef, useState } from "react";
 import type { ChatState } from "../types";
+import { RichText } from "./RichText";
 
 interface ChatPanelProps {
   chat: ChatState;
@@ -17,91 +17,6 @@ interface ChatPanelProps {
   onOpenFile?: (path: string, line?: number) => void;
 }
 
-/** Render a fenced code block with highlight.js. */
-function CodeBlock({ code, lang }: { code: string; lang?: string }) {
-  const html = useMemo(() => {
-    try {
-      if (lang && hljs.getLanguage(lang)) {
-        return hljs.highlight(code, { language: lang }).value;
-      }
-      return hljs.highlightAuto(code).value;
-    } catch {
-      return escapeHtml(code);
-    }
-  }, [code, lang]);
-  return (
-    <pre className="chat-code">
-      <code dangerouslySetInnerHTML={{ __html: html }} />
-    </pre>
-  );
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-// Matches `path/to/file.ext` or `path/to/file.ext:123` — a bare file mention,
-// optionally with a line number, as the AI tends to write them inline.
-const FILE_REF_RE = /^([\w./-]+\.\w+)(?::(\d+))?$/;
-
-/** Resolve a file mention against the in-scope manifest paths: an exact match,
- * or a unique suffix match (so `foo/bar.rs` matches `crates/foo/bar.rs`). */
-function resolveFileRef(candidate: string, filePaths: string[]): string | null {
-  if (filePaths.includes(candidate)) return candidate;
-  const matches = filePaths.filter((p) => p.endsWith("/" + candidate));
-  return matches.length === 1 ? matches[0] : null;
-}
-
-function parseFileRef(text: string, filePaths: string[]): { path: string; line?: number } | null {
-  const m = text.match(FILE_REF_RE);
-  if (!m) return null;
-  const resolved = resolveFileRef(m[1], filePaths);
-  if (!resolved) return null;
-  return { path: resolved, line: m[2] ? Number(m[2]) : undefined };
-}
-
-/** Render inline `code` spans (recognizing in-scope file:line mentions as
- * clickable links) and **bold** within a single text run. */
-function renderInline(text: string, filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
-  const nodes: React.ReactNode[] = [];
-  // Split on inline code first; bold is handled within non-code runs.
-  const parts = text.split(/(`[^`]+`)/g);
-  parts.forEach((part, i) => {
-    if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
-      const inner = part.slice(1, -1);
-      const ref = filePaths.length > 0 ? parseFileRef(inner, filePaths) : null;
-      if (ref && onOpenFile) {
-        nodes.push(
-          <button
-            key={i}
-            type="button"
-            className="chat-file-link"
-            onClick={() => onOpenFile(ref.path, ref.line)}
-            title={`Open ${ref.path}${ref.line ? `:${ref.line}` : ""}`}
-          >
-            {inner}
-          </button>,
-        );
-      } else {
-        nodes.push(<code key={i} className="chat-inline-code">{inner}</code>);
-      }
-      return;
-    }
-    const boldParts = part.split(/(\*\*[^*]+\*\*)/g);
-    boldParts.forEach((bp, j) => {
-      if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 2) {
-        nodes.push(<strong key={`${i}-${j}`}>{bp.slice(2, -2)}</strong>);
-      } else if (bp) {
-        nodes.push(<span key={`${i}-${j}`}>{bp}</span>);
-      }
-    });
-  });
-  return nodes;
-}
-
 /** A dim divider marking a gap where the AI used tools / thought between
  * answer segments. Backed by a `[[thought:<secs>]]` marker in the content. */
 function ThoughtDivider({ seconds }: { seconds: number }) {
@@ -111,31 +26,6 @@ function ThoughtDivider({ seconds }: { seconds: number }) {
       <span className="chat-thought-label">Thought for {seconds}s</span>
       <span className="chat-thought-rule" />
     </div>
-  );
-}
-
-/** Fenced ```code``` blocks (highlighted with highlight.js) plus paragraphs with
- * inline code and bold. Deliberately small — the project has no Markdown dep. */
-function RichText({ content, filePaths, onOpenFile }: { content: string; filePaths: string[]; onOpenFile?: (path: string, line?: number) => void }) {
-  // Split on fenced code blocks, keeping the fences as delimiters.
-  const segments = content.split(/(```[\s\S]*?```)/g);
-  return (
-    <>
-      {segments.map((seg, i) => {
-        const fence = seg.match(/^```([\w+-]*)\n?([\s\S]*?)```$/);
-        if (fence) {
-          return <CodeBlock key={i} lang={fence[1] || undefined} code={fence[2].replace(/\n$/, "")} />;
-        }
-        return seg
-          .split(/\n\n+/)
-          .filter((p) => p.trim().length > 0)
-          .map((para, j) => (
-            <p key={`${i}-${j}`} className="chat-para">
-              {renderInline(para, filePaths, onOpenFile)}
-            </p>
-          ));
-      })}
-    </>
   );
 }
 

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,7 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
-import { SummaryParagraphs } from "./SummaryParagraphs";
 import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState } from "../types";
 
 function useClickOutside(
@@ -85,8 +84,6 @@ export function Header({
 }: HeaderProps) {
   const totalCount = manifest?.files.length ?? 0;
   const progress = totalCount > 0 ? (viewedCount / totalCount) * 100 : 0;
-  const [summaryExpanded, setSummaryExpanded] = useState(false);
-  const hasSummary = !!manifest?.summary;
 
   return (
     <header className="header">
@@ -172,15 +169,6 @@ export function Header({
                 {isRefreshing ? "Refreshing" : "Refresh"}
               </button>
             )}
-            {hasSummary && (
-              <button
-                className="summary-toggle"
-                onClick={() => setSummaryExpanded((p) => !p)}
-                title={summaryExpanded ? "Hide summary" : "Show summary"}
-              >
-                {summaryExpanded ? "Hide summary" : "Show summary"}
-              </button>
-            )}
           </div>
           <div className="header-right">
             {onToggleChat && (
@@ -204,11 +192,6 @@ export function Header({
               onCheckForUpdates={onCheckForUpdates}
             />
           </div>
-        </div>
-      )}
-      {hasSummary && summaryExpanded && (
-        <div className="header-summary">
-          <SummaryParagraphs text={manifest!.summary} />
         </div>
       )}
     </header>

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef, useState } from "react";
 import { SummaryParagraphs } from "./SummaryParagraphs";
-import { initials } from "./ReviewRequestList";
+import { Avatar } from "./ReviewRequestList";
+import { RichText } from "./RichText";
 import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState } from "../types";
 
 interface PrOverviewProps {
@@ -33,6 +35,35 @@ function CiChip({ checks }: { checks: PrChecksStatus }) {
 
 function fileName(path: string): string {
   return path.split("/").pop() ?? path;
+}
+
+/** Collapsed-by-default PR description card, rendered as minimal markdown. */
+function DescriptionCard({ body }: { body: string }) {
+  const [expanded, setExpanded] = useState(false);
+  // Only offer the toggle when the collapsed body actually overflows — a
+  // short description gets a plain card, not a do-nothing "Show more".
+  const [overflows, setOverflows] = useState(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el) setOverflows(el.scrollHeight > el.clientHeight + 1);
+  }, [body]);
+  return (
+    <div className="overview-card overview-description">
+      <h4>Description</h4>
+      <div
+        ref={bodyRef}
+        className={`overview-description-body${expanded ? "" : " overview-description-body--collapsed"}`}
+      >
+        <RichText content={body} />
+      </div>
+      {(overflows || expanded) && (
+        <button className="overview-description-toggle" onClick={() => setExpanded((v) => !v)}>
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
 }
 
 function GroupRow({
@@ -95,6 +126,11 @@ export function PrOverview({
   const author = reviewState?.author || manifest.author;
   const draft = reviewState ? reviewState.draft : manifest.draft;
   const approvedBy = reviewState?.approved_by ?? [];
+  const labels = reviewState?.labels ?? [];
+  const visibleLabels = labels.slice(0, 5);
+  const hiddenLabelCount = labels.length - visibleLabels.length;
+  const totalAdd = manifest.files.reduce((n, f) => n + f.additions, 0);
+  const totalDel = manifest.files.reduce((n, f) => n + f.deletions, 0);
   const criticalNotes = relevant.reduce(
     (n, f) => n + (f.highlights?.filter((h) => h.severity === "critical").length ?? 0),
     0
@@ -113,7 +149,7 @@ export function PrOverview({
           </span>
           {author && (
             <span className="overview-chip overview-chip--author">
-              <span className="queue-avatar queue-avatar--sm" aria-hidden="true">{initials(author)}</span> {author}
+              <Avatar login={author} size={16} /> {author}
             </span>
           )}
           {draft && <span className="overview-chip overview-chip--draft">Draft</span>}
@@ -122,6 +158,21 @@ export function PrOverview({
             {relevant.length} relevant of {manifest.files.length}{" "}
             {manifest.files.length === 1 ? "file" : "files"}
           </span>
+          <span className="overview-chip overview-chip--branch">
+            {manifest.base_ref} ← {manifest.head_ref} · +{totalAdd} −{totalDel}
+          </span>
+          {reviewState?.mergeable === "conflicting" && (
+            <span className="overview-chip overview-chip--conflict">Has conflicts</span>
+          )}
+          {visibleLabels.map((label) => (
+            <span key={label.name} className="overview-chip overview-chip--label">
+              <span className="overview-label-dot" style={{ background: `#${label.color}` }} />
+              {label.name}
+            </span>
+          ))}
+          {hiddenLabelCount > 0 && (
+            <span className="overview-chip">+{hiddenLabelCount}</span>
+          )}
         </div>
         {manifest.summary && (
           <div className="overview-card">
@@ -129,6 +180,7 @@ export function PrOverview({
             <SummaryParagraphs text={manifest.summary} />
           </div>
         )}
+        {manifest.body && <DescriptionCard body={manifest.body} />}
         {groups.length > 0 && (
           <div className="overview-card">
             <h4>Change groups</h4>
@@ -188,7 +240,14 @@ export function PrOverview({
           <h4>Review state</h4>
           {approvedBy.length > 0 ? (
             <div className="overview-state-line overview-approvals">
-              <span className="risk-dot risk-dot--ok" /> Approved by {approvedBy.join(", ")}
+              <span className="risk-dot risk-dot--ok" /> Approved by
+              <span className="overview-approvers">
+                {approvedBy.map((login) => (
+                  <span key={login} className="overview-approver">
+                    <Avatar login={login} size={16} /> {login}
+                  </span>
+                ))}
+              </span>
             </div>
           ) : (
             reviewState && <div className="overview-state-line">No approvals yet</div>

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -11,10 +11,42 @@ interface ReviewRequestListProps {
   openPrUrls: Set<string>;
   /** Text filter from the omnibox — matches repo, title, and author. */
   filter?: string;
+  /** Opens Settings — offered from the error card when the failure looks
+   * auth-shaped (bad/missing token). */
+  onOpenSettings?: () => void;
 }
+
+/** Matches error strings that look like a bad/missing GitHub token, so the
+ * error card can offer a direct path to Settings instead of just Retry. */
+const AUTH_ERROR_RE = /401|bad credentials|unauthoriz/i;
 
 export function initials(login: string): string {
   return login.slice(0, 2).toUpperCase();
+}
+
+/** A real GitHub avatar, falling back to the existing initials circle if the
+ * image fails to load (private/unreachable avatar, offline, etc). `size` picks
+ * between the two existing queue-avatar footprints (30px default, 16px `--sm`). */
+export function Avatar({ login, size = 30 }: { login: string; size?: 16 | 30 }) {
+  const [failed, setFailed] = useState(false);
+  const sizeClass = size === 16 ? " queue-avatar--sm" : "";
+  if (failed || !login) {
+    return (
+      <span className={`queue-avatar${sizeClass}`} aria-hidden="true">
+        {initials(login)}
+      </span>
+    );
+  }
+  return (
+    <img
+      className={`queue-avatar-img${sizeClass}`}
+      src={`https://github.com/${login}.png?size=64`}
+      alt=""
+      width={size}
+      height={size}
+      onError={() => setFailed(true)}
+    />
+  );
 }
 
 function cutoffDateStr(): string {
@@ -39,7 +71,7 @@ const STATUS_CLASSES: Record<ReviewStatus, string> = {
   pending: "",
 };
 
-export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, filter }: ReviewRequestListProps) {
+export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, filter, onOpenSettings }: ReviewRequestListProps) {
   const [cachedPrs, setCachedPrs] = useState<CachedPrInfo[]>([]);
   const [recentItems, setRecentItems] = useState<ReviewRequestItem[]>([]);
   const [olderItems, setOlderItems] = useState<ReviewRequestItem[]>([]);
@@ -51,6 +83,7 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
 
   const [showOlder, setShowOlder] = useState(true);
   const [showTeam, setShowTeam] = useState(true);
+  const [showDrafts, setShowDrafts] = useState(true);
   const [settingsLoaded, setSettingsLoaded] = useState(false);
 
   const settingsRef = useRef<Settings | null>(null);
@@ -65,6 +98,7 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
       settingsRef.current = s;
       setShowOlder(s.filter_older);
       setShowTeam(s.filter_team);
+      setShowDrafts(s.show_draft_prs);
       setSettingsLoaded(true);
 
       fetchRecent();
@@ -125,9 +159,9 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
   }
 
   const saveFilters = useCallback(
-    (older: boolean, team: boolean) => {
+    (older: boolean, team: boolean, drafts: boolean) => {
       if (settingsRef.current) {
-        const updated = { ...settingsRef.current, filter_older: older, filter_team: team };
+        const updated = { ...settingsRef.current, filter_older: older, filter_team: team, show_draft_prs: drafts };
         settingsRef.current = updated;
         invoke("save_settings", { settings: updated });
       }
@@ -138,14 +172,30 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
   function toggleOlder() {
     setShowOlder((v) => {
       const next = !v;
-      setShowTeam((team) => { saveFilters(next, team); return team; });
+      setShowTeam((team) => {
+        setShowDrafts((drafts) => { saveFilters(next, team, drafts); return drafts; });
+        return team;
+      });
       return next;
     });
   }
   function toggleTeam() {
     setShowTeam((v) => {
       const next = !v;
-      setShowOlder((older) => { saveFilters(older, next); return older; });
+      setShowOlder((older) => {
+        setShowDrafts((drafts) => { saveFilters(older, next, drafts); return drafts; });
+        return older;
+      });
+      return next;
+    });
+  }
+  function toggleDrafts() {
+    setShowDrafts((v) => {
+      const next = !v;
+      setShowOlder((older) => {
+        setShowTeam((team) => { saveFilters(older, team, next); return team; });
+        return older;
+      });
       return next;
     });
   }
@@ -163,17 +213,19 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
   const filteredRecent = useMemo(() => {
     return recentItems.filter((item) => {
       if (!item.direct_request && !showTeam) return false;
+      if (item.draft && !showDrafts) return false;
       return matchesFilter(`${item.owner}/${item.repo}`, item.title, item.author);
     });
-  }, [recentItems, showTeam, matchesFilter]);
+  }, [recentItems, showTeam, showDrafts, matchesFilter]);
 
   const filteredOlder = useMemo(() => {
     if (!showOlder) return [];
     return olderItems.filter((item) => {
       if (!item.direct_request && !showTeam) return false;
+      if (item.draft && !showDrafts) return false;
       return matchesFilter(`${item.owner}/${item.repo}`, item.title, item.author);
     });
-  }, [olderItems, showOlder, showTeam, matchesFilter]);
+  }, [olderItems, showOlder, showTeam, showDrafts, matchesFilter]);
 
   const filteredCached = useMemo(() => {
     return cachedPrs.filter(
@@ -194,6 +246,10 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
       <label className="review-requests-filter">
         <input type="checkbox" checked={showOlder} onChange={toggleOlder} />
         Older
+      </label>
+      <label className="review-requests-filter">
+        <input type="checkbox" checked={showDrafts} onChange={toggleDrafts} />
+        Drafts
       </label>
       {hasTeam && (
         <>
@@ -232,6 +288,11 @@ export function ReviewRequestList({ onSelectPr, onSelectCachedPr, openPrUrls, fi
           <button className="review-requests-retry" onClick={refreshAll}>
             Retry
           </button>
+          {onOpenSettings && AUTH_ERROR_RE.test(error) && (
+            <button className="review-requests-retry" onClick={onOpenSettings}>
+              Open Settings
+            </button>
+          )}
         </div>
       </div>
     );
@@ -366,7 +427,7 @@ function ReviewRequestRow({
 
   return (
     <button className={`queue-row${item.draft ? " queue-row--draft" : ""}`} onClick={() => onSelect(prRef)}>
-      <span className="queue-avatar" aria-hidden="true">{initials(item.author)}</span>
+      <Avatar login={item.author} size={30} />
       <span className="queue-main">
         <span className="queue-title">
           <span className="queue-repo">{item.owner}/{item.repo}#{item.number}</span>
@@ -379,6 +440,11 @@ function ReviewRequestRow({
           {item.draft && <span className="queue-draft-chip">Draft</span>}
           {statusLabel && (
             <span className={`review-status-badge ${statusClass}`}>{statusLabel}</span>
+          )}
+          {item.approval_count > 0 && (
+            <span className="queue-approval-chip">
+              <span className="risk-dot risk-dot--ok" /> {item.approval_count} approval{item.approval_count === 1 ? "" : "s"}
+            </span>
           )}
           {item.unresolved_thread_count > 0 && (
             <span className="review-threads-badge">

--- a/app/src/components/ReviewRequestList.tsx
+++ b/app/src/components/ReviewRequestList.tsx
@@ -28,7 +28,10 @@ export function initials(login: string): string {
  * image fails to load (private/unreachable avatar, offline, etc). `size` picks
  * between the two existing queue-avatar footprints (30px default, 16px `--sm`). */
 export function Avatar({ login, size = 30 }: { login: string; size?: 16 | 30 }) {
-  const [failed, setFailed] = useState(false);
+  // Keyed to the login so a recycled instance (same list slot, new user)
+  // retries the image instead of inheriting the previous user's failure.
+  const [failedLogin, setFailedLogin] = useState<string | null>(null);
+  const failed = failedLogin === login;
   const sizeClass = size === 16 ? " queue-avatar--sm" : "";
   if (failed || !login) {
     return (
@@ -44,7 +47,7 @@ export function Avatar({ login, size = 30 }: { login: string; size?: 16 | 30 }) 
       alt=""
       width={size}
       height={size}
-      onError={() => setFailed(true)}
+      onError={() => setFailedLogin(login)}
     />
   );
 }

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from "react";
+import hljs from "highlight.js";
+
+/** Render a fenced code block with highlight.js. */
+export function CodeBlock({ code, lang }: { code: string; lang?: string }) {
+  const html = useMemo(() => {
+    try {
+      if (lang && hljs.getLanguage(lang)) {
+        return hljs.highlight(code, { language: lang }).value;
+      }
+      return hljs.highlightAuto(code).value;
+    } catch {
+      return escapeHtml(code);
+    }
+  }, [code, lang]);
+  return (
+    <pre className="chat-code">
+      <code dangerouslySetInnerHTML={{ __html: html }} />
+    </pre>
+  );
+}
+
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// Matches `path/to/file.ext` or `path/to/file.ext:123` — a bare file mention,
+// optionally with a line number, as the AI tends to write them inline.
+const FILE_REF_RE = /^([\w./-]+\.\w+)(?::(\d+))?$/;
+
+/** Resolve a file mention against the in-scope manifest paths: an exact match,
+ * or a unique suffix match (so `foo/bar.rs` matches `crates/foo/bar.rs`). */
+function resolveFileRef(candidate: string, filePaths: string[]): string | null {
+  if (filePaths.includes(candidate)) return candidate;
+  const matches = filePaths.filter((p) => p.endsWith("/" + candidate));
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function parseFileRef(text: string, filePaths: string[]): { path: string; line?: number } | null {
+  const m = text.match(FILE_REF_RE);
+  if (!m) return null;
+  const resolved = resolveFileRef(m[1], filePaths);
+  if (!resolved) return null;
+  return { path: resolved, line: m[2] ? Number(m[2]) : undefined };
+}
+
+/** Render inline `code` spans (recognizing in-scope file:line mentions as
+ * clickable links) and **bold** within a single text run. */
+export function renderInline(text: string, filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  // Split on inline code first; bold is handled within non-code runs.
+  const parts = text.split(/(`[^`]+`)/g);
+  parts.forEach((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
+      const inner = part.slice(1, -1);
+      const ref = filePaths.length > 0 ? parseFileRef(inner, filePaths) : null;
+      if (ref && onOpenFile) {
+        nodes.push(
+          <button
+            key={i}
+            type="button"
+            className="chat-file-link"
+            onClick={() => onOpenFile(ref.path, ref.line)}
+            title={`Open ${ref.path}${ref.line ? `:${ref.line}` : ""}`}
+          >
+            {inner}
+          </button>,
+        );
+      } else {
+        nodes.push(<code key={i} className="chat-inline-code">{inner}</code>);
+      }
+      return;
+    }
+    const boldParts = part.split(/(\*\*[^*]+\*\*)/g);
+    boldParts.forEach((bp, j) => {
+      if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 2) {
+        nodes.push(<strong key={`${i}-${j}`}>{bp.slice(2, -2)}</strong>);
+      } else if (bp) {
+        nodes.push(<span key={`${i}-${j}`}>{bp}</span>);
+      }
+    });
+  });
+  return nodes;
+}
+
+/** Fenced ```code``` blocks (highlighted with highlight.js) plus paragraphs with
+ * inline code and bold. Deliberately small — the project has no Markdown dep. */
+export function RichText({ content, filePaths = [], onOpenFile }: { content: string; filePaths?: string[]; onOpenFile?: (path: string, line?: number) => void }) {
+  // Split on fenced code blocks, keeping the fences as delimiters.
+  const segments = content.split(/(```[\s\S]*?```)/g);
+  return (
+    <>
+      {segments.map((seg, i) => {
+        const fence = seg.match(/^```([\w+-]*)\n?([\s\S]*?)```$/);
+        if (fence) {
+          return <CodeBlock key={i} lang={fence[1] || undefined} code={fence[2].replace(/\n$/, "")} />;
+        }
+        return seg
+          .split(/\n\n+/)
+          .filter((p) => p.trim().length > 0)
+          .map((para, j) => (
+            <p key={`${i}-${j}`} className="chat-para">
+              {renderInline(para, filePaths, onOpenFile)}
+            </p>
+          ));
+      })}
+    </>
+  );
+}

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import hljs from "highlight.js";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 
 /** Render a fenced code block with highlight.js. */
 export function CodeBlock({ code, lang }: { code: string; lang?: string }) {
@@ -47,11 +48,33 @@ function parseFileRef(text: string, filePaths: string[]): { path: string; line?:
   return { path: resolved, line: m[2] ? Number(m[2]) : undefined };
 }
 
+/** External link, opened via the shell plugin (main-window contexts only —
+ * everything that renders RichText lives in the main window). http(s) only. */
+function ExternalLink({ label, url }: { label: string; url: string }) {
+  const safe = /^https?:\/\//i.test(url);
+  if (!safe) return <span>{label}</span>;
+  return (
+    <button type="button" className="rt-link" title={url} onClick={() => openUrl(url).catch(() => {})}>
+      {label}
+    </button>
+  );
+}
+
+/** Bold runs within a plain-text span. */
+function renderBold(text: string, keyPrefix: string): React.ReactNode[] {
+  return text.split(/(\*\*[^*]+\*\*)/g).flatMap((bp, j) => {
+    if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 4) {
+      return [<strong key={`${keyPrefix}-${j}`}>{bp.slice(2, -2)}</strong>];
+    }
+    return bp ? [<span key={`${keyPrefix}-${j}`}>{bp}</span>] : [];
+  });
+}
+
 /** Render inline `code` spans (recognizing in-scope file:line mentions as
- * clickable links) and **bold** within a single text run. */
+ * clickable links), [text](url) / ![alt](url) links, and **bold**. */
 export function renderInline(text: string, filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
-  // Split on inline code first; bold is handled within non-code runs.
+  // Code spans first — nothing inside them is markdown.
   const parts = text.split(/(`[^`]+`)/g);
   parts.forEach((part, i) => {
     if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
@@ -74,23 +97,104 @@ export function renderInline(text: string, filePaths: string[], onOpenFile?: (pa
       }
       return;
     }
-    const boldParts = part.split(/(\*\*[^*]+\*\*)/g);
-    boldParts.forEach((bp, j) => {
-      if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 2) {
-        nodes.push(<strong key={`${i}-${j}`}>{bp.slice(2, -2)}</strong>);
-      } else if (bp) {
-        nodes.push(<span key={`${i}-${j}`}>{bp}</span>);
+    // Then links (and image syntax, rendered as a labeled link — no remote
+    // image loading), then bold in the remaining plain runs.
+    const linkParts = part.split(/(!?\[[^\]]*\]\([^\s)]+\))/g);
+    linkParts.forEach((lp, k) => {
+      const m = lp.match(/^(!?)\[([^\]]*)\]\(([^\s)]+)\)$/);
+      if (m) {
+        const label = m[1] ? `🖼 ${m[2] || "image"}` : m[2] || m[3];
+        nodes.push(<ExternalLink key={`${i}-${k}`} label={label} url={m[3]} />);
+        return;
       }
+      nodes.push(...renderBold(lp, `${i}-${k}`));
     });
   });
   return nodes;
 }
 
-/** Fenced ```code``` blocks (highlighted with highlight.js) plus paragraphs with
- * inline code and bold. Deliberately small — the project has no Markdown dep. */
+type Block =
+  | { kind: "heading"; level: number; text: string }
+  | { kind: "quote"; lines: string[] }
+  | { kind: "list"; ordered: boolean; items: { text: string; task?: "done" | "todo" }[] }
+  | { kind: "hr" }
+  | { kind: "para"; lines: string[] };
+
+const HEADING_RE = /^(#{1,4})\s+(.*)$/;
+const LIST_RE = /^\s*(?:([-*])|(\d+)[.)])\s+(.*)$/;
+const TASK_RE = /^\[([ xX])\]\s+(.*)$/;
+
+/** Line-oriented block parser for GitHub-flavored PR bodies / chat answers.
+ * Deliberately small — headings, lists (incl. task items), quotes, rules,
+ * paragraphs. Nested lists flatten; unknown constructs degrade to text. */
+function parseBlocks(segment: string): Block[] {
+  const lines = segment.split("\n");
+  const blocks: Block[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "") { i++; continue; }
+    const h = line.match(HEADING_RE);
+    if (h) { blocks.push({ kind: "heading", level: h[1].length, text: h[2] }); i++; continue; }
+    if (/^\s*(-{3,}|\*{3,})\s*$/.test(line)) { blocks.push({ kind: "hr" }); i++; continue; }
+    if (line.startsWith(">")) {
+      const q: string[] = [];
+      while (i < lines.length && lines[i].startsWith(">")) {
+        q.push(lines[i].replace(/^>\s?/, ""));
+        i++;
+      }
+      blocks.push({ kind: "quote", lines: q });
+      continue;
+    }
+    const l = line.match(LIST_RE);
+    if (l) {
+      const ordered = !!l[2];
+      const items: { text: string; task?: "done" | "todo" }[] = [];
+      while (i < lines.length) {
+        const im = lines[i].match(LIST_RE);
+        if (!im || !!im[2] !== ordered) break;
+        let text = im[3];
+        let task: "done" | "todo" | undefined;
+        const t = text.match(TASK_RE);
+        if (t) { task = t[1].trim() ? "done" : "todo"; text = t[2]; }
+        items.push({ text, task });
+        i++;
+        // Continuation lines (indented, not a new item) fold into the item.
+        while (i < lines.length && lines[i].trim() !== "" && !LIST_RE.test(lines[i]) && /^\s{2,}/.test(lines[i])) {
+          items[items.length - 1].text += " " + lines[i].trim();
+          i++;
+        }
+      }
+      blocks.push({ kind: "list", ordered, items });
+      continue;
+    }
+    const p: string[] = [];
+    while (i < lines.length && lines[i].trim() !== "" && !HEADING_RE.test(lines[i]) && !LIST_RE.test(lines[i]) && !lines[i].startsWith(">")) {
+      p.push(lines[i]);
+      i++;
+    }
+    blocks.push({ kind: "para", lines: p });
+  }
+  return blocks;
+}
+
+/** Inline nodes for multiple source lines, preserving single newlines as
+ * breaks (GitHub renders PR-body newlines hard, like comments). */
+function renderLines(lines: string[], filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
+  return lines.flatMap((ln, i) => {
+    const nodes = renderInline(ln, filePaths, onOpenFile);
+    return i < lines.length - 1 ? [...nodes, <br key={`br-${i}`} />] : nodes;
+  });
+}
+
+/** Minimal GitHub-flavored markdown: fenced code (highlighted), headings,
+ * lists with task boxes, quotes, rules, links, inline code/bold. Deliberately
+ * small — the project has no Markdown dep; unknown syntax degrades to text. */
 export function RichText({ content, filePaths = [], onOpenFile }: { content: string; filePaths?: string[]; onOpenFile?: (path: string, line?: number) => void }) {
+  // PR templates are full of HTML comments — never render them.
+  const cleaned = content.replace(/<!--[\s\S]*?-->/g, "");
   // Split on fenced code blocks, keeping the fences as delimiters.
-  const segments = content.split(/(```[\s\S]*?```)/g);
+  const segments = cleaned.split(/(```[\s\S]*?```)/g);
   return (
     <>
       {segments.map((seg, i) => {
@@ -98,14 +202,40 @@ export function RichText({ content, filePaths = [], onOpenFile }: { content: str
         if (fence) {
           return <CodeBlock key={i} lang={fence[1] || undefined} code={fence[2].replace(/\n$/, "")} />;
         }
-        return seg
-          .split(/\n\n+/)
-          .filter((p) => p.trim().length > 0)
-          .map((para, j) => (
-            <p key={`${i}-${j}`} className="chat-para">
-              {renderInline(para, filePaths, onOpenFile)}
-            </p>
-          ));
+        return parseBlocks(seg).map((b, j) => {
+          const key = `${i}-${j}`;
+          switch (b.kind) {
+            case "heading":
+              return <div key={key} className={`rt-h rt-h--${b.level}`}>{renderInline(b.text, filePaths, onOpenFile)}</div>;
+            case "hr":
+              return <hr key={key} className="rt-hr" />;
+            case "quote":
+              return <blockquote key={key} className="rt-quote">{renderLines(b.lines, filePaths, onOpenFile)}</blockquote>;
+            case "list": {
+              const Tag = b.ordered ? "ol" : "ul";
+              return (
+                <Tag key={key} className="rt-list">
+                  {b.items.map((it, k) => (
+                    <li key={k} className={it.task ? "rt-task" : undefined}>
+                      {it.task && (
+                        <span className={`rt-check rt-check--${it.task}`} aria-hidden>
+                          {it.task === "done" ? "☑" : "☐"}
+                        </span>
+                      )}
+                      {renderInline(it.text, filePaths, onOpenFile)}
+                    </li>
+                  ))}
+                </Tag>
+              );
+            }
+            case "para":
+              return (
+                <p key={key} className="chat-para">
+                  {renderLines(b.lines, filePaths, onOpenFile)}
+                </p>
+              );
+          }
+        });
       })}
     </>
   );

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -2,7 +2,12 @@ import { useMemo } from "react";
 import hljs from "highlight.js";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 
-/** Render a fenced code block with highlight.js. */
+/** Render a fenced code block with highlight.js.
+ *
+ * SECURITY: the only innerHTML sink in the shared renderer, fed untrusted
+ * input (PR bodies, AI answers). Safe today because hljs entity-escapes code
+ * and the catch path runs escapeHtml — any change to this function must
+ * preserve that; never interpolate unescaped input into the HTML. */
 export function CodeBlock({ code, lang }: { code: string; lang?: string }) {
   const html = useMemo(() => {
     try {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -2530,42 +2530,6 @@ tr.cursor-selected td {
   border-color: var(--text-muted);
 }
 
-/* ─── PR Summary (header bar) ──────────────────────────────────────────── */
-.header-summary {
-  padding: 8px 16px;
-  background: rgba(88, 166, 255, 0.06);
-  border-bottom: 1px solid var(--border);
-  font-size: 13px;
-  line-height: 1.5;
-  color: var(--text-secondary);
-}
-
-.header-summary p {
-  margin: 0 0 6px 0;
-}
-
-.header-summary p:last-child {
-  margin-bottom: 0;
-}
-
-.summary-toggle {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  color: var(--text-secondary);
-  font-size: 12px;
-  cursor: pointer;
-  font-family: var(--font-sans);
-  padding: 3px 10px;
-  flex-shrink: 0;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.summary-toggle:hover {
-  color: var(--text-primary);
-  border-color: var(--text-muted);
-}
-
 /* ─── PR Summary (diff pane placeholder) ──────────────────────────────── */
 .pr-summary {
   display: flex;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5880,3 +5880,28 @@ mark.search-highlight-current {
   color: var(--text-muted);
   white-space: nowrap;
 }
+
+/* ─── RichText block-level markdown (PR descriptions, chat answers) ─────── */
+.rt-h { font-weight: 600; color: var(--text-primary); margin: var(--space-3) 0 var(--space-1); line-height: 1.3; }
+.rt-h:first-child { margin-top: 0; }
+.rt-h--1 { font-size: 16px; }
+.rt-h--2 { font-size: 14.5px; }
+.rt-h--3 { font-size: 13.5px; }
+.rt-h--4 { font-size: 13px; color: var(--text-secondary); text-transform: none; }
+.rt-hr { border: 0; border-top: 1px solid var(--border); margin: var(--space-3) 0; }
+.rt-quote {
+  margin: var(--space-2) 0;
+  padding: var(--space-1) var(--space-3);
+  border-left: 3px solid var(--border);
+  color: var(--text-secondary);
+}
+.rt-list { margin: var(--space-2) 0; padding-left: var(--space-5); }
+.rt-list li { margin: 3px 0; }
+.rt-list li.rt-task { list-style: none; margin-left: calc(-1 * var(--space-4)); }
+.rt-check { margin-right: var(--space-2); color: var(--text-secondary); }
+.rt-check--done { color: var(--diff-add-text); }
+.rt-link {
+  background: none; border: 0; padding: 0; font: inherit; cursor: pointer;
+  color: var(--accent); text-decoration: none;
+}
+.rt-link:hover { text-decoration: underline; }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4781,6 +4781,76 @@ mark.search-highlight-current {
   color: var(--text-muted);
 }
 
+.overview-chip--branch {
+  font-family: var(--font-mono);
+}
+
+/* Outlined amber, mirroring .risk-high's badge treatment — filled red stays
+   reserved for critical severity only. */
+.overview-chip--conflict {
+  background: transparent;
+  border-color: rgba(219, 109, 40, 0.55);
+  color: var(--risk-high);
+}
+
+.overview-chip--label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+/* The one place an arbitrary GitHub label color is allowed — dot only, never
+   the chip background. */
+.overview-label-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.overview-description-body {
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--text-primary);
+  position: relative;
+}
+
+.overview-description-body--collapsed {
+  max-height: 9.6em;
+  overflow: hidden;
+  mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, black 70%, transparent 100%);
+}
+
+.overview-description-toggle {
+  margin-top: var(--space-2);
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 12px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  padding: 0;
+}
+
+.overview-description-toggle:hover {
+  text-decoration: underline;
+}
+
+.overview-approvers {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  margin-left: 4px;
+}
+
+.overview-approver {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
 .overview-noise {
   font-size: 12.5px;
   color: var(--text-secondary);
@@ -5089,9 +5159,31 @@ mark.search-highlight-current {
   display: inline-flex;
 }
 
+/* Real GitHub avatar image — same circular footprint as .queue-avatar, which
+   the Avatar component falls back to on image load failure. */
+.queue-avatar-img {
+  flex-shrink: 0;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--bg-tertiary);
+}
+
 .queue-draft-chip {
   font-size: 10.5px;
   color: var(--text-muted);
+  background: transparent;
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 0px 7px;
+  white-space: nowrap;
+}
+
+.queue-approval-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10.5px;
+  color: var(--text-secondary);
   background: transparent;
   border: 1px solid var(--chip-border);
   border-radius: var(--radius-pill);
@@ -5476,8 +5568,11 @@ mark.search-highlight-current {
 
 .overview-meta {
   display: flex;
+  /* The chip set (author, CI, files, branch, conflicts, labels) can outgrow
+     one line on a busy PR — wrap instead of overflowing horizontally. */
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-2);
+  gap: var(--space-1) var(--space-2);
   padding: 2px 2px 6px;
   min-width: 0;
 }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -44,6 +44,9 @@ export interface ReviewManifest {
   draft: boolean;
   summary: string;
   change_groups: ChangeGroup[];
+  /** The PR description, truncated char-safely to bound cache size. Empty
+   * when the PR has no body or on manifests fetched before this field existed. */
+  body: string;
   files: FileDiff[];
 }
 
@@ -221,6 +224,9 @@ export interface Settings {
   activity_per_watch_cap: number;
   activity_mini_player: boolean;
   show_approved_prs: boolean;
+  /** Whether the review queue shows draft PRs. On by default (current
+   * behavior); the frontend filters draft rows out when this is off. */
+  show_draft_prs: boolean;
   setup_done: boolean;
 }
 
@@ -233,6 +239,16 @@ export interface MyReviewState {
   author: string;
   draft: boolean;
   approved_by: string[];
+  /** Lowercased GitHub `mergeable` enum: "mergeable" | "conflicting" |
+   * "unknown". Empty when GitHub hasn't computed it or the field is absent. */
+  mergeable: string;
+  labels: PrLabel[];
+}
+
+export interface PrLabel {
+  name: string;
+  /** Hex color without the leading '#', as GitHub returns it. */
+  color: string;
 }
 
 export interface CheckRunInfo {
@@ -275,6 +291,7 @@ export interface ReviewRequestItem {
   direct_request: boolean;
   my_review_status: ReviewStatus;
   unresolved_thread_count: number;
+  approval_count: number;
 }
 
 export type UpdateStatus =


### PR DESCRIPTION
## Summary
Closes #146 (issue body + both comment additions):
- **PR description on the overview** — collapsible card under the AI summary, rendered with a shared minimal-markdown `RichText` extracted from the chat panel (toggle only appears when the text actually overflows). Old cached manifests simply hide the card.
- **Real avatars** (github.com/{login}.png with initials fallback on error): queue rows, overview author chip, approvers line. Comment threads already had them.
- **Live mergeable state** — outlined-amber "Has conflicts" chip in the meta row, only when actually conflicting; **labels as chips** (color dot only, capped at 5+n). Both ride the existing `get_my_review_state` GraphQL — no new API calls.
- **Branch + size chip** — `base ← head · +A −D` from data already in the manifest.
- **Approval counts on queue rows** — reuses review data `enrich_review_requests` already fetches.
- **Drafts queue toggle** (`show_draft_prs`, default on — current behavior) next to Older, filtering frontend-side like the existing toggles.
- **Auth-shaped queue errors** (401 / bad credentials) now offer **Open Settings** beside Try again.

## Verifier + fixes
- Overview meta row now wraps (`flex-wrap`) — the grown chip set overflowed horizontally on busy PRs
- "Show more" only renders when the description overflows the collapsed height

## Test Plan
- [x] `cargo check --workspace`; `cargo test -p marrow-core` (52) + `-p marrow-cli` (37); `bun run build` — all clean
- [x] Adversarial verifier pass (2 findings, both fixed); config parser tolerates old files without the new key; both settings-writing modals spread fresh Settings (no clobber)
- [x] Live-verified: Drafts toggle + real avatar on queue rows; overview showing branch/size chip, a *genuinely true* "Has conflicts" chip, author avatar; old-cache manifests correctly hide the Description card
- [ ] Untested live: Description card with a fresh manifest (needs re-analysis), label chips (no labeled PRs in my queue), approval-count chip (no approved queue items right now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)