### PR TITLE
feat(gui): 'N new AI notes' indicator + exhaustive-pass prompt

### DIFF
--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -80,6 +80,8 @@ Severity measures actionability, not category:
 - "warning": a likely defect or genuine risk. Use this test: if the author did not intend this, it is a bug. An intentional-looking behavior change is NOT a warning, even if it's important — that belongs under "info".
 - "info": an accurate, useful observation — an intentional behavior change worth double-checking, a notable addition, a design tradeoff worth knowing about.
 
+Be exhaustive in this pass. Report every notable finding you can defend now — do not hold minor-but-real findings for a later look; a finding you skip may never surface again. Thoroughness in one pass beats a drip of follow-ups across re-analyses.
+
 For each highlight, provide:
 - "path": the file path
 - "start_line": the line number in the NEW (head) version of the file where the notable change starts

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,7 @@ import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution } from "./types";
-import { parsePrUrl, extractPrRef, canonicalPrKey } from "./utils";
+import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey } from "./utils";
 import type { ReviewSession } from "./hooks/useActivityFeed";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
@@ -38,6 +38,15 @@ function isOpenerTab(tab: Tab): boolean {
 /** A fresh, closed chat panel for a new tab. */
 function emptyChatState(): ChatState {
   return { messages: [], status: "idle", streamingText: "", streamingStatus: null, includeWholePr: false, open: false };
+}
+
+/** Every AI highlight key (see highlightKey) across a manifest's files. */
+function collectHighlightKeys(manifest: ReviewManifest): Set<string> {
+  const keys = new Set<string>();
+  for (const f of manifest.files) {
+    for (const h of f.highlights) keys.add(highlightKey(f.path, h));
+  }
+  return keys;
 }
 
 function App() {
@@ -1092,6 +1101,13 @@ function App() {
       const staleCount = newStale.size - tab.staleViewedFiles.size;
       if (staleCount > 0) parts.push(`${staleCount} file${staleCount > 1 ? "s" : ""} changed since reviewed`);
 
+      // Re-analysis may surface highlights the previous pass didn't — diff the
+      // key sets so the overview/diff can call out what's new since last refresh.
+      const oldHighlightKeys = collectHighlightKeys(tab.manifest);
+      const newHighlightKeys = new Set(
+        [...collectHighlightKeys(newManifest)].filter((k) => !oldHighlightKeys.has(k))
+      );
+
       const refreshedTab: Tab = {
         ...tab,
         manifest: newManifest,
@@ -1107,6 +1123,7 @@ function App() {
               ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? null
               : newManifest.files[0] ?? null,
         commentThreads: { status: "idle" },
+        newHighlightKeys,
       };
 
       updateTab(tab.id, () => refreshedTab);
@@ -1119,6 +1136,9 @@ function App() {
         addToast("success", `PR updated: ${parts.join(", ")}`);
       } else {
         addToast("info", "PR refreshed — no changes detected");
+      }
+      if (newHighlightKeys.size > 0) {
+        addToast("info", `${newHighlightKeys.size} new AI ${newHighlightKeys.size === 1 ? "note" : "notes"} from re-analysis`);
       }
     } catch (err) {
       updateTab(tab.id, (t) => ({ ...t, isRefreshing: false }));
@@ -2065,6 +2085,13 @@ function App() {
               startTarget={nextUnviewed(guidedOrder(), -1)}
               onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
               onSelectFile={setSelectedFile}
+              newHighlightKeys={
+                // Dismissing a new note removes it from the chip immediately —
+                // a dead "1 new AI note" pointing at a hidden note is worse
+                // than no chip.
+                activeTab.newHighlightKeys &&
+                new Set([...activeTab.newHighlightKeys].filter((k) => !activeTab.dismissedHighlights.has(k)))
+              }
             />
           ) : (
           <>
@@ -2118,7 +2145,7 @@ function App() {
                 const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
                 return (
                   <>
-                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} newHighlightKeys={activeTab.newHighlightKeys} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
                     <NextFileBar
                       index={idx >= 0 ? idx : 0}
                       total={order.length}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -105,6 +105,9 @@ interface DiffViewerProps {
   dismissedHighlights?: Set<string>;
   /** Resolution metadata (state + reason) for dismissed highlights, keyed by highlightKey. */
   noteResolutions?: Map<string, NoteResolution>;
+  /** Keys (highlightKey) of AI highlights introduced by the most recent
+   * refresh's re-analysis — rendered with a "new" accent treatment. */
+  newHighlightKeys?: Set<string>;
   /** Dismiss a note, optionally recording how/why (null = plain dismiss, no resolution recorded). */
   onResolveHighlight?: (key: string, resolution: NoteResolution | null) => void;
   /** Restore a previously-dismissed note, clearing any recorded resolution. */
@@ -853,7 +856,7 @@ const severityLabel: Record<string, string> = {
 // threading a prop through every hunk-rendering layer.
 const HighlightDismissContext = createContext<{ resolve: (h: Highlight, resolution: NoteResolution | null) => void } | null>(null);
 
-function HighlightMarker({ highlight, onPostAsComment }: { highlight: Highlight; onPostAsComment?: (h: Highlight) => void }) {
+function HighlightMarker({ highlight, isNew, onPostAsComment }: { highlight: Highlight; isNew?: boolean; onPostAsComment?: (h: Highlight) => void }) {
   const ctx = useContext(HighlightDismissContext);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [resolveState, setResolveState] = useState<"fixed" | "intentional">("fixed");
@@ -876,7 +879,8 @@ function HighlightMarker({ highlight, onPostAsComment }: { highlight: Highlight;
   }
 
   return (
-    <div className={`highlight-marker highlight-${highlight.severity}`}>
+    <div className={`highlight-marker highlight-${highlight.severity}${isNew ? " highlight-marker--new" : ""}`}>
+      {isNew && <span className="highlight-new-dot" title="New since your last refresh" />}
       <span className="highlight-icon">
         {severityLabel[highlight.severity] || "Info"}
       </span>
@@ -1025,6 +1029,7 @@ function buildThreadsByLine(threads: ReviewThread[] | undefined): Map<number, Re
 function UnifiedHunkLines({
   lines,
   highlights,
+  newHighlights,
   commentingOn,
   dragging,
   onLineMouseDown,
@@ -1042,6 +1047,8 @@ function UnifiedHunkLines({
 }: {
   lines: DiffLine[];
   highlights: Highlight[];
+  /** Highlights (by reference into `highlights`) new since the last refresh. */
+  newHighlights?: Set<Highlight> | null;
   commentingOn?: CommentingOn | null;
   dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
   onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
@@ -1103,7 +1110,7 @@ function UnifiedHunkLines({
             {hlStart && (
               <tr className="highlight-row">
                 <td colSpan={4}>
-                  <HighlightMarker highlight={hlStart} onPostAsComment={onPostHighlightAsComment} />
+                  <HighlightMarker highlight={hlStart} isNew={newHighlights?.has(hlStart)} onPostAsComment={onPostHighlightAsComment} />
                 </td>
               </tr>
             )}
@@ -1166,6 +1173,7 @@ function UnifiedHunkLines({
 function UnifiedView({
   hunks,
   highlights,
+  newHighlights,
   collapsedHunks,
   onToggleHunk,
   showSignificance,
@@ -1186,6 +1194,7 @@ function UnifiedView({
 }: {
   hunks: Hunk[];
   highlights: Highlight[];
+  newHighlights?: Set<Highlight> | null;
   collapsedHunks: Set<number>;
   onToggleHunk: (index: number) => void;
   showSignificance: boolean;
@@ -1265,13 +1274,13 @@ function UnifiedView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -1286,6 +1295,7 @@ function UnifiedView({
 function SplitHunkLines({
   splitLines,
   highlights,
+  newHighlights,
   commentingOn,
   dragging,
   onLineMouseDown,
@@ -1303,6 +1313,8 @@ function SplitHunkLines({
 }: {
   splitLines: SplitLine[];
   highlights: Highlight[];
+  /** Highlights (by reference into `highlights`) new since the last refresh. */
+  newHighlights?: Set<Highlight> | null;
   commentingOn?: CommentingOn | null;
   dragging?: { anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null;
   onLineMouseDown?: (line: number, side: "LEFT" | "RIGHT") => void;
@@ -1377,7 +1389,7 @@ function SplitHunkLines({
             {hlStart && (
               <tr className="highlight-row">
                 <td colSpan={4}>
-                  <HighlightMarker highlight={hlStart} onPostAsComment={onPostHighlightAsComment} />
+                  <HighlightMarker highlight={hlStart} isNew={newHighlights?.has(hlStart)} onPostAsComment={onPostHighlightAsComment} />
                 </td>
               </tr>
             )}
@@ -1442,6 +1454,7 @@ function SplitHunkLines({
 function SplitView({
   hunks,
   highlights,
+  newHighlights,
   collapsedHunks,
   onToggleHunk,
   showSignificance,
@@ -1462,6 +1475,7 @@ function SplitView({
 }: {
   hunks: Hunk[];
   highlights: Highlight[];
+  newHighlights?: Set<Highlight> | null;
   collapsedHunks: Set<number>;
   onToggleHunk: (index: number) => void;
   showSignificance: boolean;
@@ -1544,13 +1558,13 @@ function SplitView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <SplitHunkLines splitLines={splitLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -1562,7 +1576,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, noteResolutions, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, noteResolutions, newHighlightKeys, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -1743,6 +1757,16 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   const dismissed = dismissedHighlights ?? new Set<string>();
   const highlights = allNotes.filter((h) => !dismissed.has(keyFor(h)));
   const dismissedNotes = allNotes.filter((h) => dismissed.has(keyFor(h)));
+  // Highlight objects (by reference into `highlights`) new since the last
+  // refresh — HighlightMarker renders these with a "new" accent treatment.
+  const newHighlights = useMemo(() => {
+    if (!newHighlightKeys || newHighlightKeys.size === 0) return null;
+    const s = new Set<Highlight>();
+    for (const h of highlights) {
+      if (newHighlightKeys.has(keyFor(h))) s.add(h);
+    }
+    return s;
+  }, [highlights, newHighlightKeys, file.path]);
   const [showDismissed, setShowDismissed] = useState(false);
   const resolutions = noteResolutions ?? new Map<string, NoteResolution>();
   const dismissHighlight = useMemo(
@@ -2342,6 +2366,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
             <UnifiedView
               hunks={fullFile ? fullFileHunks : hunks}
               highlights={highlights}
+              newHighlights={newHighlights}
               collapsedHunks={fullFile ? NO_COLLAPSED : collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
@@ -2364,6 +2389,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
             <SplitView
               hunks={fullFile ? fullFileHunks : hunks}
               highlights={highlights}
+              newHighlights={newHighlights}
               collapsedHunks={fullFile ? NO_COLLAPSED : collapsedHunks}
               onToggleHunk={toggleHunk}
               showSignificance={showHunkSignificance}
@@ -2392,7 +2418,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={diffLines} highlights={highlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
+              <UnifiedHunkLines lines={diffLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
             </tbody>
           </table>
         )}

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { SummaryParagraphs } from "./SummaryParagraphs";
 import { Avatar } from "./ReviewRequestList";
 import { RichText } from "./RichText";
+import { highlightKey } from "../utils";
 import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState } from "../types";
 
 interface PrOverviewProps {
@@ -14,6 +15,19 @@ interface PrOverviewProps {
   startTarget: FileDiff | null;
   onStartReview: () => void;
   onSelectFile: (f: FileDiff) => void;
+  /** Keys (see highlightKey) of AI highlights introduced by the most recent
+   * refresh's re-analysis — surfaced as a "new AI notes" chip when non-empty. */
+  newHighlightKeys?: Set<string>;
+}
+
+/** First file (in manifest order) whose highlights include a new-note key. */
+function firstNewNoteFile(manifest: ReviewManifest, newHighlightKeys: Set<string>): FileDiff | null {
+  for (const f of manifest.files) {
+    for (const h of f.highlights ?? []) {
+      if (newHighlightKeys.has(highlightKey(f.path, h))) return f;
+    }
+  }
+  return null;
 }
 
 function CiChip({ checks }: { checks: PrChecksStatus }) {
@@ -118,7 +132,9 @@ export function PrOverview({
   startTarget,
   onStartReview,
   onSelectFile,
+  newHighlightKeys,
 }: PrOverviewProps) {
+  const newNoteCount = newHighlightKeys?.size ?? 0;
   const relevant = manifest.files.filter((f) => f.classification !== "NOT_RELEVANT");
   const setAside = manifest.files.length - relevant.length;
   const byPath = new Map(manifest.files.map((f) => [f.path, f]));
@@ -154,6 +170,18 @@ export function PrOverview({
           )}
           {draft && <span className="overview-chip overview-chip--draft">Draft</span>}
           {checksStatus && <CiChip checks={checksStatus} />}
+          {newNoteCount > 0 && (
+            <button
+              type="button"
+              className="overview-chip overview-chip--new-notes"
+              onClick={() => {
+                const f = firstNewNoteFile(manifest, newHighlightKeys!);
+                if (f) onSelectFile(f);
+              }}
+            >
+              <span className="overview-new-dot" /> {newNoteCount} new AI {newNoteCount === 1 ? "note" : "notes"}
+            </button>
+          )}
           <span className="overview-chip">
             {relevant.length} relevant of {manifest.files.length}{" "}
             {manifest.files.length === 1 ? "file" : "files"}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1813,6 +1813,20 @@ tr.cursor-selected td {
   border-left-color: var(--accent);
 }
 
+/* New-since-last-refresh treatment: subtle, no layout shift — a small accent
+   dot ahead of the severity label rather than restyling the whole card. */
+.highlight-marker--new {
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-secondary));
+}
+
+.highlight-new-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
 .highlight-icon {
   font-family: var(--font-sans);
   font-weight: 600;
@@ -4761,6 +4775,31 @@ mark.search-highlight-current {
   display: inline-flex;
   align-items: center;
   gap: 5px;
+}
+
+/* Accent-tinted, not filled — mirrors the "Now Reviewing" card's language
+   rather than a severity color, since new notes aren't inherently a warning. */
+.overview-chip--new-notes {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-sans);
+  background: var(--accent-bg);
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.overview-chip--new-notes:hover {
+  border-color: var(--accent);
+}
+
+.overview-chip--new-notes .overview-new-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
 }
 
 /* The one place an arbitrary GitHub label color is allowed — dot only, never

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -179,6 +179,10 @@ export interface Tab {
   /** Resolution metadata (state + reason) for dismissed highlights, keyed by
    * highlightKey. A dismissed key may have no entry here (plain/legacy dismiss). */
   noteResolutions: Map<string, NoteResolution>;
+  /** Keys (see highlightKey) of AI highlights newly introduced by the most
+   * recent refresh's re-analysis, relative to the manifest it replaced.
+   * Transient — not persisted, and undefined outside a just-refreshed tab. */
+  newHighlightKeys?: Set<string>;
   /** Conversational diff Q&A state for this PR. */
   chat: ChatState;
   commentThreads: CommentThreadsState;


### PR DESCRIPTION
## Summary
Follow-up to the re-analysis noise discussion (stacked on #155 — retarget after it merges). Full-PR re-analysis stays as-is per discussion; this adds visibility and front-loading instead:
- **Exhaustiveness instruction** in the highlight prompt: report every defensible finding *now* — "a finding you skip may never surface again." Aims to catch issues in earlier rounds rather than dripping across pushes.
- **"N new AI notes" after refresh**: keys diffed against the previous manifest (only the refresh path — first loads/cached opens/session restore show nothing). Toast + accent chip in the overview meta row (click jumps to the first file with a new note; dismissing a new note removes it from the count immediately) + a subtle accent dot on new note cards inline. Transient state, nothing persisted.

## Test Plan
- [x] `bun run build`, `cargo check --workspace`, `cargo test -p marrow-core` (52) — clean
- [x] Adversarial verifier pass (no correctness findings; two polish observations addressed: dismissed-note interplay, button font)
- [ ] Untested live: needs a real refresh-with-new-notes cycle — next time Marrow re-analyzes a PR and finds something, the chip/dots/toast get their field test

🤖 Generated with [Claude Code](https://claude.com/claude-code)