### PR TITLE
feat(gui): comments become a panel — the diff never leaves the screen

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2016,7 +2016,7 @@ function App() {
   }
 
   return (
-    <div className="app">
+    <div className={`app${activeTab?.chat.open || activeTab?.commentsOpen ? " app--right-panel" : ""}`}>
       <ActivityWidget onOpenPr={(ref) => handleFetchStart(ref, activeTabId ?? undefined)} />
       <Header
         tabs={tabs}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { invoke, Channel } from "@tauri-apps/api/core";
 import { listen, emit } from "@tauri-apps/api/event";
 import { FileSidebar } from "./components/FileSidebar";
-import { DiffViewer, detectLanguage, type DiffViewerHandle } from "./components/DiffViewer";
-import { CommentsViewer } from "./components/CommentsViewer";
+import { DiffViewer, type DiffViewerHandle } from "./components/DiffViewer";
+import { CommentsPanel } from "./components/CommentsPanel";
 import { Header } from "./components/Header";
 import { PrOpener } from "./components/PrOpener";
 import { ReviewRequestList } from "./components/ReviewRequestList";
@@ -70,6 +70,11 @@ function App() {
   const [viewerLogin, setViewerLogin] = useState<string | null>(null);
   const searchRef = useRef<SearchBarHandle>(null);
   const diffViewerRef = useRef<DiffViewerHandle>(null);
+  // Jump-to-thread from the comments panel: the target thread id, and a ping
+  // bumped on every jump so the retry effect below reruns even when the
+  // selected file doesn't change (thread already on the open file).
+  const pendingThreadIdRef = useRef<string | null>(null);
+  const [threadScrollPing, setThreadScrollPing] = useState(0);
   // Visible file order from the sidebar, used by the [ / ] navigation shortcuts.
   const visibleOrderRef = useRef<string[]>([]);
   const handleVisibleFilesChange = useCallback((paths: string[]) => {
@@ -273,15 +278,27 @@ function App() {
     handleSelectTab(tabs[(i + delta + tabs.length) % tabs.length].id);
   }
 
+  // Chat and Comments are mutually exclusive right-dock panels — opening one closes the other.
   function toggleThreadsView() {
     if (!activeTab?.manifest) return;
-    if (activeTab.sidebarView === "comments") {
-      const hasGroups = (activeTab.manifest.change_groups ?? []).length > 0;
-      handleViewChange(hasGroups ? "groups" : "category");
-    } else {
-      handleViewChange("comments");
-    }
+    const opening = !activeTab.commentsOpen;
+    updateTab(activeTabId, (t) => ({
+      ...t,
+      commentsOpen: opening,
+      chat: opening ? { ...t.chat, open: false } : t.chat,
+    }));
+    // Fetch is driven by the commentsOpen+idle effect below, so every path
+    // that opens the panel (toggle, palette, legacy session restore) fetches.
   }
+
+  // Whenever the panel is open on a tab whose threads were never fetched,
+  // fetch them. Single trigger for all open paths — including a restored
+  // pre-panel session that had the old comments *mode* persisted.
+  useEffect(() => {
+    if (activeTab?.commentsOpen && activeTab.manifest && activeTab.commentThreads.status === "idle") {
+      handleRequestComments();
+    }
+  }, [activeTabId, activeTab?.commentsOpen, activeTab?.commentThreads.status]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useKeyboardShortcuts(
     {
@@ -346,7 +363,7 @@ function App() {
       noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
-      selectedCommentFile: null,
+      commentsOpen: false,
       sidebarView: hasGroups ? "groups" : "category",
       isRefreshing: false,
       lastCommentCount: 0,
@@ -372,7 +389,7 @@ function App() {
       noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
-      selectedCommentFile: null,
+      commentsOpen: false,
       sidebarView: "category",
       isRefreshing: false,
       lastCommentCount: 0,
@@ -436,10 +453,15 @@ function App() {
                   if (file) tab.selectedFile = file;
                 }
                 if (entry.sidebar_view) {
-                  tab.sidebarView = entry.sidebar_view as SidebarView;
-                }
-                if (entry.selected_comment_file) {
-                  tab.selectedCommentFile = entry.selected_comment_file;
+                  // Pre-#144 sessions may have persisted the now-removed "comments"
+                  // mode — map it onto the panel instead of a dead sidebar view.
+                  if ((entry.sidebar_view as string) === "comments") {
+                    const hasGroups = (manifest.change_groups ?? []).length > 0;
+                    tab.sidebarView = hasGroups ? "groups" : "category";
+                    tab.commentsOpen = true;
+                  } else {
+                    tab.sidebarView = entry.sidebar_view as SidebarView;
+                  }
                 }
                 return tab;
               } catch {
@@ -577,6 +599,35 @@ function App() {
     const next = nextUnviewed(guidedOrder(), -1);
     if (next) setSelectedFile(next);
   }, [activeTabId, activeTab?.manifest, resumePing]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Once a jump-to-thread target's file is selected, the DiffViewer for it may
+  // not have mounted (or rendered the thread row) yet on this same tick — retry
+  // via rAF for up to ~1s rather than a single synchronous call.
+  useEffect(() => {
+    if (!pendingThreadIdRef.current) return;
+    const id = pendingThreadIdRef.current;
+    let attempts = 0;
+    let raf = 0;
+    const tryScroll = () => {
+      attempts++;
+      // First attempt may expand collapsed low-significance hunks — a thread
+      // inside one has no DOM row until its hunk renders.
+      if (diffViewerRef.current?.scrollToThread(id, attempts === 1)) {
+        pendingThreadIdRef.current = null;
+        return;
+      }
+      if (attempts > 60) {
+        pendingThreadIdRef.current = null;
+        // Outdated threads (line: null, position gone from the current diff)
+        // have no row to land on — say so instead of silently doing nothing.
+        addToast("info", "Couldn't locate this thread in the current diff — it may be outdated.");
+        return;
+      }
+      raf = requestAnimationFrame(tryScroll);
+    };
+    raf = requestAnimationFrame(tryScroll);
+    return () => cancelAnimationFrame(raf);
+  }, [activeTabId, activeTab?.selectedFile?.path, threadScrollPing]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Bridge for the mini-player's "Open on GitHub" row action: the floating
   // widget's webview has no shell:open capability (see mini-player.json), so
@@ -900,8 +951,16 @@ function App() {
     updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open } }));
   }
 
+  // Chat and Comments are mutually exclusive right-dock panels — opening chat closes comments.
   function toggleChatOpen() {
-    updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, open: !t.chat.open } }));
+    updateTab(activeTabId, (t) => {
+      const opening = !t.chat.open;
+      return { ...t, chat: { ...t.chat, open: opening }, commentsOpen: opening ? false : t.commentsOpen };
+    });
+  }
+
+  function setCommentsOpen(open: boolean) {
+    updateTab(activeTabId, (t) => ({ ...t, commentsOpen: open }));
   }
 
   function handleChatToggleWholePr(value: boolean) {
@@ -1254,9 +1313,6 @@ function App() {
 
   function handleViewChange(view: SidebarView) {
     updateTab(activeTabId,(t) => ({ ...t, sidebarView: view }));
-    if (view === "comments") {
-      handleRequestComments();
-    }
   }
 
   async function handleRequestComments() {
@@ -1268,19 +1324,7 @@ function App() {
       const threads = await invoke<ReviewThread[]>("fetch_review_comments", {
         prUrl: tab.manifest.pr_url,
       });
-      // Set first file with comments as selected if none selected
-      const firstFile = threads.length > 0 ? threads[0].path : null;
-      setTabs((prev) =>
-        prev.map((t) =>
-          t.id === activeTabId
-            ? {
-                ...t,
-                commentThreads: { status: "loaded", threads },
-                selectedCommentFile: t.selectedCommentFile ?? firstFile,
-              }
-            : t
-        )
-      );
+      updateTab(activeTabId,(t) => ({ ...t, commentThreads: { status: "loaded", threads } }));
     } catch (err) {
       updateTab(activeTabId,(t) => ({
         ...t,
@@ -1289,8 +1333,30 @@ function App() {
     }
   }
 
-  function handleSelectCommentFile(path: string) {
-    updateTab(activeTabId,(t) => ({ ...t, selectedCommentFile: path }));
+  /** File-group header click in the comments panel — jump to the file, no thread scroll. */
+  function handleOpenCommentFile(path: string) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab?.manifest) return;
+    const file = tab.manifest.files.find((f) => f.path === path);
+    if (file) setSelectedFile(file);
+    else addToast("info", "File not in this diff");
+  }
+
+  /** Thread-card location click in the comments panel — select the file (if
+   * needed) then scroll/flash the thread into view once the diff has mounted it. */
+  function handleJumpToThread(thread: ReviewThread) {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab?.manifest) return;
+    if (tab.selectedFile?.path !== thread.path) {
+      const file = tab.manifest.files.find((f) => f.path === thread.path);
+      if (!file) {
+        addToast("info", "File not in this diff");
+        return;
+      }
+      setSelectedFile(file);
+    }
+    pendingThreadIdRef.current = thread.id;
+    setThreadScrollPing((p) => p + 1);
   }
 
   async function handleReply(threadId: string, commentId: string, body: string) {
@@ -1794,7 +1860,9 @@ function App() {
             pr_url: t.manifest!.pr_url,
             selected_file: t.selectedFile?.path ?? null,
             sidebar_view: t.sidebarView,
-            selected_comment_file: t.selectedCommentFile,
+            // Retired with the comments panel (#144) — kept on the wire type
+            // for schema stability, always written null now.
+            selected_comment_file: null,
           })),
         active_pr: tabs.find((t) => t.id === activeTabId)?.manifest?.pr_url ?? null,
       };
@@ -1871,7 +1939,7 @@ function App() {
       { id: "mark-next", section: "Review", title: "Mark reviewed and go to next", run: markReviewedAndAdvance },
       { id: "finish", section: "Review", title: "Finish review…", keys: "R", run: () => setReviewPickerOpen(true) },
       { id: "search", section: "Review", title: "Search in diffs", keys: "/", run: () => searchRef.current?.open("local") },
-      { id: "threads", section: "Review", title: "Toggle threads view", keys: "T", run: toggleThreadsView },
+      { id: "threads", section: "Review", title: "Toggle comments panel", keys: "T", run: toggleThreadsView },
       { id: "refresh", section: "Review", title: "Refresh PR", keys: "⌃R", run: handleRefreshPr },
       { id: "github", section: "Review", title: "Open PR on GitHub", run: () => { openUrl(m.pr_url); } },
       { id: "ask-ai", section: "Review", title: "Ask AI about this change", keys: "⌘J", run: toggleChatOpen },
@@ -2074,7 +2142,7 @@ function App() {
           onOpenChange={setSearchOpen}
         />
         <div className="main-content">
-          {activeTab.sidebarView !== "comments" && !activeTab.selectedFile ? (
+          {!activeTab.selectedFile ? (
             <PrOverview
               manifest={activeTab.manifest}
               checksStatus={activeChecks ?? null}
@@ -2109,33 +2177,13 @@ function App() {
             sidebarView={activeTab.sidebarView}
             onViewChange={handleViewChange}
             commentThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : []}
-            selectedCommentFile={activeTab.selectedCommentFile}
-            onSelectCommentFile={handleSelectCommentFile}
+            commentsOpen={activeTab.commentsOpen ?? false}
+            onToggleComments={toggleThreadsView}
             onVisibleFilesChange={handleVisibleFilesChange}
             onShowOverview={() => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, selectedFile: null })); }}
           />
           <div className="diff-pane">
-            {activeTab.sidebarView === "comments" ? (
-              activeTab.commentThreads.status === "loading" ? (
-                <div className="no-file-selected">Loading review threads...</div>
-              ) : activeTab.commentThreads.status === "error" ? (
-                <div className="no-file-selected" style={{ color: "var(--diff-remove-text)" }}>
-                  {activeTab.commentThreads.message}
-                </div>
-              ) : activeTab.commentThreads.status === "loaded" ? (
-                <CommentsViewer
-                  threads={activeTab.commentThreads.threads}
-                  selectedFile={activeTab.selectedCommentFile}
-                  onReply={handleReply}
-                  onToggleResolved={handleToggleResolved}
-                  onEditComment={handleEditComment}
-                  onToggleReaction={handleToggleReaction}
-                  lang={activeTab.selectedCommentFile ? detectLanguage(activeTab.selectedCommentFile) : undefined}
-                />
-              ) : (
-                <div className="no-file-selected">Switch to Comments tab to load threads</div>
-              )
-            ) : activeTab.selectedFile ? (
+            {activeTab.selectedFile ? (
               (() => {
                 const order = guidedOrder();
                 const idx = order.indexOf(activeTab.selectedFile.path);
@@ -2177,6 +2225,19 @@ function App() {
               onClear={handleChatClear}
               onToggleWholePr={handleChatToggleWholePr}
               onOpenFile={handleChatOpenFile}
+            />
+          )}
+          {activeTab.commentsOpen && (
+            <CommentsPanel
+              commentThreads={activeTab.commentThreads}
+              onRetry={handleRequestComments}
+              onReply={handleReply}
+              onToggleResolved={handleToggleResolved}
+              onEditComment={handleEditComment}
+              onToggleReaction={handleToggleReaction}
+              onClose={() => setCommentsOpen(false)}
+              onOpenFile={handleOpenCommentFile}
+              onJumpToThread={handleJumpToThread}
             />
           )}
         </div>

--- a/app/src/components/CommentsPanel.tsx
+++ b/app/src/components/CommentsPanel.tsx
@@ -1,16 +1,22 @@
-import { useState, useMemo } from "react";
-import type { ReviewThread, ReviewComment } from "../types";
-import { timeAgo } from "../utils";
-import { CommentBodyRendered, ReactionBar } from "./DiffViewer";
+import { useEffect, useMemo, useState } from "react";
+import type { CommentThreadsState, ReviewComment, ReviewThread } from "../types";
+import { getFileName, timeAgo } from "../utils";
+import { CommentBodyRendered, ReactionBar, detectLanguage } from "./DiffViewer";
 
-interface CommentsViewerProps {
-  threads: ReviewThread[];
-  selectedFile: string | null;
+type CommentsFilter = "unresolved" | "all";
+
+interface CommentsPanelProps {
+  commentThreads: CommentThreadsState;
+  onRetry: () => void;
   onReply: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved: (threadId: string, resolve: boolean) => void;
   onEditComment?: (commentId: string, body: string) => void;
   onToggleReaction?: (commentId: string, content: string) => void;
-  lang?: string;
+  onClose: () => void;
+  /** Jump straight to a file (from a file-group header) — no thread scroll. */
+  onOpenFile: (path: string) => void;
+  /** Select the thread's file (if needed) and scroll/flash it into view. */
+  onJumpToThread: (thread: ReviewThread) => void;
 }
 
 function CommentCard({
@@ -85,6 +91,7 @@ function ThreadCard({
   onToggleResolved,
   onEdit,
   onToggleReaction,
+  onJumpToThread,
   lang,
 }: {
   thread: ReviewThread;
@@ -92,15 +99,20 @@ function ThreadCard({
   onToggleResolved: (threadId: string, resolve: boolean) => void;
   onEdit?: (commentId: string, body: string) => void;
   onToggleReaction?: (commentId: string, content: string) => void;
+  onJumpToThread: (thread: ReviewThread) => void;
   lang?: string;
 }) {
+  const [threadCollapsed, setThreadCollapsed] = useState(thread.is_resolved);
   const [hunkExpanded, setHunkExpanded] = useState(!thread.is_resolved);
+  const [commentsExpanded, setCommentsExpanded] = useState(thread.comments.length <= 2);
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyText, setReplyText] = useState("");
   const [submitting, setSubmitting] = useState(false);
-  const [threadCollapsed, setThreadCollapsed] = useState(thread.is_resolved);
 
+  const first = thread.comments[0];
   const lastComment = thread.comments[thread.comments.length - 1];
+  const extraCount = thread.comments.length - 1;
+  const visibleComments = commentsExpanded ? thread.comments : thread.comments.slice(0, 1);
 
   function handleSubmitReply() {
     if (!replyText.trim() || submitting) return;
@@ -121,12 +133,18 @@ function ThreadCard({
     <div className={`thread-card ${thread.is_resolved ? "thread-card-resolved" : ""}`}>
       <div className="thread-card-header" onClick={() => setThreadCollapsed((v) => !v)}>
         <span className={`collapse-chevron ${threadCollapsed ? "collapsed" : ""}`}>&#9662;</span>
-        <span className="thread-card-location">
+        {first?.author.avatar_url && (
+          <img className="comment-avatar" src={first.author.avatar_url} alt={first.author.login} width={18} height={18} />
+        )}
+        <span className="thread-card-author">@{first?.author.login}</span>
+        <span className="comment-time">{timeAgo(first?.created_at)}</span>
+        <span
+          className="thread-card-location"
+          onClick={(e) => { e.stopPropagation(); onJumpToThread(thread); }}
+          title="Jump to this comment in the diff"
+        >
           {lineLabel}
           {thread.is_outdated && <span className="thread-outdated-badge">outdated</span>}
-        </span>
-        <span className="thread-card-comment-count">
-          {thread.comments.length} comment{thread.comments.length !== 1 ? "s" : ""}
         </span>
         {thread.is_resolved && <span className="thread-resolved-badge">Resolved</span>}
       </div>
@@ -149,10 +167,16 @@ function ThreadCard({
           )}
 
           <div className="thread-comments">
-            {thread.comments.map((comment) => (
+            {visibleComments.map((comment) => (
               <CommentCard key={comment.id} comment={comment} onEdit={onEdit} onToggleReaction={onToggleReaction} lang={lang} />
             ))}
           </div>
+
+          {!commentsExpanded && extraCount > 1 && (
+            <button className="thread-comments-more" onClick={() => setCommentsExpanded(true)}>
+              {extraCount} more comment{extraCount === 1 ? "" : "s"}
+            </button>
+          )}
 
           <div className="thread-actions">
             {replyOpen ? (
@@ -207,72 +231,120 @@ function ThreadCard({
   );
 }
 
-export function CommentsViewer({
-  threads,
-  selectedFile,
+/** Sort key: unresolved threads first, then by line number. */
+function threadSortKey(t: ReviewThread): number {
+  return (t.is_resolved ? 1_000_000 : 0) + (t.line ?? t.original_line ?? 0);
+}
+
+export function CommentsPanel({
+  commentThreads,
+  onRetry,
   onReply,
   onToggleResolved,
   onEditComment,
   onToggleReaction,
-  lang,
-}: CommentsViewerProps) {
-  if (!selectedFile) {
-    return (
-      <div className="comments-viewer-empty">
-        Select a file from the Comments sidebar to view review threads
-      </div>
-    );
-  }
+  onClose,
+  onOpenFile,
+  onJumpToThread,
+}: CommentsPanelProps) {
+  // null until the first load resolves, so the default (Unresolved, unless
+  // there are none) is applied exactly once — after that, the user's choice sticks.
+  const [filter, setFilter] = useState<CommentsFilter | null>(null);
 
-  const { fileThreads, unresolvedThreads, resolvedThreads } = useMemo(() => {
-    const fileThreads = threads.filter((t) => t.path === selectedFile);
-    return {
-      fileThreads,
-      unresolvedThreads: fileThreads.filter((t) => !t.is_resolved),
-      resolvedThreads: fileThreads.filter((t) => t.is_resolved),
-    };
-  }, [threads, selectedFile]);
+  const allThreads = commentThreads.status === "loaded" ? commentThreads.threads : [];
+  const unresolvedCount = useMemo(() => allThreads.filter((t) => !t.is_resolved).length, [allThreads]);
+  const totalCount = allThreads.length;
 
-  if (fileThreads.length === 0) {
-    return (
-      <div className="comments-viewer-empty">
-        No review threads for this file
-      </div>
-    );
-  }
+  useEffect(() => {
+    if (filter !== null) return;
+    if (commentThreads.status !== "loaded") return;
+    setFilter(unresolvedCount > 0 ? "unresolved" : "all");
+  }, [commentThreads.status, unresolvedCount, filter]);
+
+  const effectiveFilter = filter ?? "unresolved";
+
+  const groups = useMemo(() => {
+    const filtered = allThreads.filter((t) => effectiveFilter === "all" || !t.is_resolved);
+    const byPath = new Map<string, ReviewThread[]>();
+    for (const t of filtered) {
+      const arr = byPath.get(t.path) ?? [];
+      arr.push(t);
+      byPath.set(t.path, arr);
+    }
+    return [...byPath.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([path, threads]) => ({
+        path,
+        threads: threads.slice().sort((a, b) => threadSortKey(a) - threadSortKey(b)),
+      }));
+  }, [allThreads, effectiveFilter]);
 
   return (
-    <div className="comments-viewer">
-      <div className="comments-viewer-header">
-        <span className="comments-viewer-path">{selectedFile}</span>
-        <span className="comments-viewer-summary">
-          {unresolvedThreads.length} unresolved
-          {resolvedThreads.length > 0 && `, ${resolvedThreads.length} resolved`}
-        </span>
+    <div className="comments-panel">
+      <div className="comments-panel-header">
+        <span className="comments-panel-title">Comments</span>
+        <button className="chat-icon-btn" onClick={onClose} title="Close comments panel">
+          ✕
+        </button>
       </div>
-      <div className="comments-viewer-threads">
-        {unresolvedThreads.map((thread) => (
-          <ThreadCard
-            key={thread.id}
-            thread={thread}
-            onReply={onReply}
-            onToggleResolved={onToggleResolved}
-            onEdit={onEditComment}
-            onToggleReaction={onToggleReaction}
-            lang={lang}
-          />
-        ))}
-        {resolvedThreads.map((thread) => (
-          <ThreadCard
-            key={thread.id}
-            thread={thread}
-            onReply={onReply}
-            onToggleResolved={onToggleResolved}
-            onEdit={onEditComment}
-            onToggleReaction={onToggleReaction}
-            lang={lang}
-          />
-        ))}
+
+      <div className="comments-panel-meta">
+        <span className="comments-panel-count">
+          {unresolvedCount} unresolved · {totalCount} total
+        </span>
+        <div className="comments-panel-filter">
+          <button
+            className={effectiveFilter === "unresolved" ? "active" : ""}
+            onClick={() => setFilter("unresolved")}
+          >
+            Unresolved
+          </button>
+          <button
+            className={effectiveFilter === "all" ? "active" : ""}
+            onClick={() => setFilter("all")}
+          >
+            All
+          </button>
+        </div>
+      </div>
+
+      <div className="comments-panel-body">
+        {commentThreads.status === "error" ? (
+          <div className="comments-panel-error" role="alert">
+            {commentThreads.message}
+            <button className="comments-panel-retry" onClick={onRetry}>Retry</button>
+          </div>
+        ) : commentThreads.status === "loading" || commentThreads.status === "idle" ? (
+          <div className="comments-panel-empty">Loading comments…</div>
+        ) : totalCount === 0 ? (
+          <div className="comments-panel-empty">No review threads on this PR</div>
+        ) : groups.length === 0 ? (
+          <div className="comments-panel-empty">No unresolved threads — nice work</div>
+        ) : (
+          groups.map(({ path, threads }) => (
+            <div key={path} className="comments-panel-file-group">
+              <button
+                className="comments-panel-file-header"
+                onClick={() => onOpenFile(path)}
+                title={path}
+              >
+                {getFileName(path)}
+              </button>
+              {threads.map((thread) => (
+                <ThreadCard
+                  key={thread.id}
+                  thread={thread}
+                  onReply={onReply}
+                  onToggleResolved={onToggleResolved}
+                  onEdit={onEditComment}
+                  onToggleReaction={onToggleReaction}
+                  onJumpToThread={onJumpToThread}
+                  lang={detectLanguage(path)}
+                />
+              ))}
+            </div>
+          ))
+        )}
       </div>
     </div>
   );

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -3,6 +3,7 @@ import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
 import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch, NoteResolution } from "../types";
 import { timeAgo, highlightKey } from "../utils";
+import { RichText } from "./RichText";
 
 const extToLang: Record<string, string> = {
   ts: "typescript", tsx: "typescript", js: "javascript", jsx: "javascript",
@@ -149,6 +150,10 @@ export interface DiffViewerHandle {
   replyAtCursor: () => void;
   /** Resolve/reopen the review thread on the cursor line, if any. */
   resolveAtCursor: () => void;
+  /** Scroll the given review thread into view and flash it. Returns false
+   * when the thread isn't rendered in this file (e.g. the diff hasn't
+   * mounted it yet) so the caller can retry. */
+  scrollToThread: (threadId: string, expandIfHidden?: boolean) => boolean;
 }
 
 /** Small keyboard-driven reply box, shown when `r` is pressed on a thread line. */
@@ -181,8 +186,8 @@ export const CommentBodyRendered = memo(function CommentBodyRendered({ body, lan
   const parts = body.split(/(```suggestion\n[\s\S]*?\n```)/g);
 
   if (parts.length === 1) {
-    // No suggestion blocks — render as plain pre-wrapped text
-    return <div className="comment-body">{body}</div>;
+    // No suggestion blocks — render as Markdown
+    return <div className="comment-body"><RichText content={body} /></div>;
   }
 
   return (
@@ -202,7 +207,7 @@ export const CommentBodyRendered = memo(function CommentBodyRendered({ body, lan
           );
         }
         if (!part.trim()) return null;
-        return <span key={i}>{part}</span>;
+        return <RichText key={i} content={part} />;
       })}
     </div>
   );
@@ -504,7 +509,7 @@ function InlineThreadMarker({
   const showActions = onReply || onToggleResolved;
 
   return (
-    <tr className={`inline-thread-row ${thread.is_resolved ? "inline-thread-resolved" : ""}`}>
+    <tr className={`inline-thread-row ${thread.is_resolved ? "inline-thread-resolved" : ""}`} data-thread-id={thread.id}>
       <td colSpan={colSpan}>
         <div className="inline-thread">
           {isSingle ? (
@@ -2219,6 +2224,23 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   const nextFinding = () => stepFinding(1);
   const prevFinding = () => stepFinding(-1);
 
+  const scrollToThread = (threadId: string, expandIfHidden = false): boolean => {
+    const c = diffContentRef.current;
+    if (!c) return false;
+    const el = c.querySelector<HTMLElement>(`[data-thread-id="${threadId}"]`);
+    if (!el) {
+      // The thread may live inside a default-collapsed low-significance hunk,
+      // which renders no rows at all. Expand and let the caller's retry loop
+      // find it on a later frame.
+      if (expandIfHidden) expandAll();
+      return false;
+    }
+    el.scrollIntoView({ block: "center", behavior: "smooth" });
+    el.classList.add("finding-flash");
+    setTimeout(() => el.classList.remove("finding-flash"), 1200);
+    return true;
+  };
+
   // Scroll to + paint the cursor on the pending row once it has (re-)rendered.
   useEffect(() => {
     if (pendingScroll == null) return;
@@ -2242,7 +2264,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   useImperativeHandle(ref, () => ({
     nextHunk, prevHunk, foldAll,
     cursorMove, cursorEdge, cursorPage, nextFinding, prevFinding, foldAtCursor,
-    commentAtCursor, toggleAnchor, replyAtCursor, resolveAtCursor,
+    commentAtCursor, toggleAnchor, replyAtCursor, resolveAtCursor, scrollToThread,
   }));
 
   return (

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -15,9 +15,10 @@ interface FileSidebarProps {
   onHunkFilterChange: (filter: HunkSignificanceFilter) => void;
   sidebarView: SidebarView;
   onViewChange: (view: SidebarView) => void;
+  /** Review threads for the whole PR, used only to size the "Comments (N)" toggle. */
   commentThreads: ReviewThread[];
-  selectedCommentFile: string | null;
-  onSelectCommentFile: (path: string) => void;
+  commentsOpen: boolean;
+  onToggleComments: () => void;
   /** Emits the visible file paths in manifest order, for keyboard file navigation. */
   onVisibleFilesChange?: (paths: string[]) => void;
   onShowOverview?: () => void;
@@ -328,72 +329,6 @@ function TreeFolder({
   );
 }
 
-/* ─── Comment file list ──────────────────────────────────────────────────── */
-
-function CommentFileList({
-  threads,
-  selectedFile,
-  onSelectFile,
-}: {
-  threads: ReviewThread[];
-  selectedFile: string | null;
-  onSelectFile: (path: string) => void;
-}) {
-  const fileMap = useMemo(() => {
-    const map = new Map<string, { total: number; unresolved: number }>();
-    for (const t of threads) {
-      const entry = map.get(t.path) ?? { total: 0, unresolved: 0 };
-      entry.total++;
-      if (!t.is_resolved) entry.unresolved++;
-      map.set(t.path, entry);
-    }
-    // Sort: files with unresolved threads first, then alphabetical
-    const sorted = [...map.entries()].sort((a, b) => {
-      if (a[1].unresolved > 0 && b[1].unresolved === 0) return -1;
-      if (a[1].unresolved === 0 && b[1].unresolved > 0) return 1;
-      return a[0].localeCompare(b[0]);
-    });
-    return sorted;
-  }, [threads]);
-
-  if (threads.length === 0) {
-    return (
-      <div className="comment-file-list-empty">
-        No review threads on this PR
-      </div>
-    );
-  }
-
-  return (
-    <div className="comment-file-list">
-      {fileMap.map(([path, counts]) => {
-        const fileName = getFileName(path);
-        const dirHint = path.split("/").slice(-2, -1)[0] || "";
-        return (
-          <button
-            key={path}
-            className={`comment-file-item ${selectedFile === path ? "selected" : ""}`}
-            onClick={() => onSelectFile(path)}
-            title={path}
-          >
-            <span className="file-name">{fileName}</span>
-            <span className="file-path-hint">{dirHint}</span>
-            {counts.unresolved > 0 ? (
-              <span className="unresolved-badge">
-                {counts.unresolved}
-              </span>
-            ) : (
-              <span className="comment-count-badge">
-                {counts.total}
-              </span>
-            )}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
 /* ─── Main component ────────────────────────────────────────────────────── */
 
 export function FileSidebar({
@@ -410,8 +345,8 @@ export function FileSidebar({
   sidebarView: view,
   onViewChange: setView,
   commentThreads,
-  selectedCommentFile,
-  onSelectCommentFile,
+  commentsOpen,
+  onToggleComments,
   onVisibleFilesChange,
   onShowOverview,
 }: FileSidebarProps) {
@@ -563,7 +498,6 @@ export function FileSidebar({
     } else if (view === "tree") {
       flattenTreePaths(visibleFileTree, 0, collapsed, out);
     }
-    // "comments" view drives a separate selection model — emit nothing.
     return out;
   }, [view, changeGroups, collapsed, filesByPath, visiblePaths, ungroupedFiles, visibleCriticalFiles, visibleCategories, visibleGrouped, visibleFileTree]);
 
@@ -574,10 +508,14 @@ export function FileSidebar({
   const viewedCount = viewedFiles.size;
   const staleCount = staleViewedFiles.size;
   const totalCount = files.length;
+  const unresolvedCommentCount = useMemo(
+    () => commentThreads.filter((t) => !t.is_resolved).length,
+    [commentThreads],
+  );
 
   return (
     <aside className="file-sidebar">
-      {onShowOverview && view !== "comments" && (
+      {onShowOverview && (
         <button
           className={`sidebar-overview-link${selectedFile === null ? " active" : ""}`}
           onClick={onShowOverview}
@@ -599,13 +537,6 @@ export function FileSidebar({
                 Groups
               </button>
             )}
-            <button
-              className={view === "comments" ? "active" : ""}
-              onClick={() => setView("comments")}
-              title="Review comments"
-            >
-              Comments
-            </button>
             <button
               className={view === "category" ? "active" : ""}
               onClick={() => setView("category")}
@@ -673,13 +604,7 @@ export function FileSidebar({
         </div>
       )}
       <nav className="file-list">
-        {view === "comments" ? (
-          <CommentFileList
-            threads={commentThreads}
-            selectedFile={selectedCommentFile}
-            onSelectFile={onSelectCommentFile}
-          />
-        ) : view === "groups" ? (
+        {view === "groups" ? (
           <>
             {changeGroups.map((group, idx) => {
               const groupKey = `group:${idx}`;
@@ -813,6 +738,15 @@ export function FileSidebar({
           </div>
         )}
       </nav>
+      <div className="sidebar-footer">
+        <button
+          className={`sidebar-comments-toggle ${commentsOpen ? "active" : ""}`}
+          onClick={onToggleComments}
+          title="Review comments (T)"
+        >
+          Comments{unresolvedCommentCount > 0 && ` (${unresolvedCommentCount})`}
+        </button>
+      </div>
     </aside>
   );
 }

--- a/app/src/components/KeyboardHelp.tsx
+++ b/app/src/components/KeyboardHelp.tsx
@@ -56,7 +56,7 @@ const SECTIONS: Section[] = [
       { keys: ["z"], label: "Fold / unfold hunk at cursor" },
       { keys: ["Z"], label: "Fold / unfold all hunks" },
       { keys: ["V"], label: "Toggle file viewed" },
-      { keys: ["T"], label: "Toggle threads / diff" },
+      { keys: ["T"], label: "Toggle comments panel" },
       { keys: ["⌃r", "F5"], label: "Refresh PR" },
       { keys: ["/"], label: "Search" },
       { keys: ["?"], label: "Toggle this help" },

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -65,13 +65,23 @@ function ExternalLink({ label, url }: { label: string; url: string }) {
   );
 }
 
-/** Bold runs within a plain-text span. */
+/** Italic runs (single *asterisk*, non-space-adjacent) within a plain span. */
+function renderItalic(text: string, keyPrefix: string): React.ReactElement[] {
+  return text.split(/(\*[^\s*][^*]*\*)/g).flatMap((ip, j) => {
+    if (ip.length > 2 && ip.startsWith("*") && ip.endsWith("*") && !/\s$/.test(ip.slice(1, -1))) {
+      return [<em key={`${keyPrefix}-i${j}`}>{ip.slice(1, -1)}</em>];
+    }
+    return ip ? [<span key={`${keyPrefix}-i${j}`}>{ip}</span>] : [];
+  });
+}
+
+/** Bold (then italic) runs within a plain-text span. */
 function renderBold(text: string, keyPrefix: string): React.ReactNode[] {
   return text.split(/(\*\*[^*]+\*\*)/g).flatMap((bp, j) => {
     if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 4) {
       return [<strong key={`${keyPrefix}-${j}`}>{bp.slice(2, -2)}</strong>];
     }
-    return bp ? [<span key={`${keyPrefix}-${j}`}>{bp}</span>] : [];
+    return bp ? renderItalic(bp, `${keyPrefix}-${j}`) : [];
   });
 }
 
@@ -123,6 +133,7 @@ type Block =
   | { kind: "quote"; lines: string[] }
   | { kind: "list"; ordered: boolean; items: { text: string; task?: "done" | "todo" }[] }
   | { kind: "hr" }
+  | { kind: "fence"; lang?: string; code: string }
   | { kind: "para"; lines: string[] };
 
 const HEADING_RE = /^(#{1,4})\s+(.*)$/;
@@ -139,6 +150,21 @@ function parseBlocks(segment: string): Block[] {
   while (i < lines.length) {
     const line = lines[i];
     if (line.trim() === "") { i++; continue; }
+    // Fenced code: only a line STARTING with ``` opens a fence (GitHub
+    // semantics) — inline ``` inside a sentence stays literal text.
+    const f = line.match(/^```([\w+-]*)\s*$/);
+    if (f) {
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+        code.push(lines[i]);
+        i++;
+      }
+      i++; // consume the closing fence (or run off the end — unterminated
+      // fences render as code anyway, which also suits streaming chat text).
+      blocks.push({ kind: "fence", lang: f[1] || undefined, code: code.join("\n") });
+      continue;
+    }
     const h = line.match(HEADING_RE);
     if (h) { blocks.push({ kind: "heading", level: h[1].length, text: h[2] }); i++; continue; }
     if (/^\s*(-{3,}|\*{3,})\s*$/.test(line)) { blocks.push({ kind: "hr" }); i++; continue; }
@@ -174,7 +200,7 @@ function parseBlocks(segment: string): Block[] {
       continue;
     }
     const p: string[] = [];
-    while (i < lines.length && lines[i].trim() !== "" && !HEADING_RE.test(lines[i]) && !LIST_RE.test(lines[i]) && !lines[i].startsWith(">")) {
+    while (i < lines.length && lines[i].trim() !== "" && !HEADING_RE.test(lines[i]) && !LIST_RE.test(lines[i]) && !lines[i].startsWith(">") && !/^```/.test(lines[i])) {
       p.push(lines[i]);
       i++;
     }
@@ -199,17 +225,14 @@ export function RichText({ content, filePaths = [], onOpenFile }: { content: str
   // PR templates are full of HTML comments — never render them.
   const cleaned = content.replace(/<!--[\s\S]*?-->/g, "");
   // Split on fenced code blocks, keeping the fences as delimiters.
-  const segments = cleaned.split(/(```[\s\S]*?```)/g);
   return (
     <>
-      {segments.map((seg, i) => {
-        const fence = seg.match(/^```([\w+-]*)\n?([\s\S]*?)```$/);
-        if (fence) {
-          return <CodeBlock key={i} lang={fence[1] || undefined} code={fence[2].replace(/\n$/, "")} />;
-        }
-        return parseBlocks(seg).map((b, j) => {
-          const key = `${i}-${j}`;
+      {(() => {
+        return parseBlocks(cleaned).map((b, j) => {
+          const key = `b-${j}`;
           switch (b.kind) {
+            case "fence":
+              return <CodeBlock key={key} lang={b.lang} code={b.code} />;
             case "heading":
               return <div key={key} className={`rt-h rt-h--${b.level}`}>{renderInline(b.text, filePaths, onOpenFile)}</div>;
             case "hr":
@@ -241,7 +264,7 @@ export function RichText({ content, filePaths = [], onOpenFile }: { content: str
               );
           }
         });
-      })}
+      })()}
     </>
   );
 }

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -75,15 +75,32 @@ function renderItalic(text: string, keyPrefix: string): React.ReactElement[] {
   });
 }
 
-/** GFM backslash escapes: \` \* \_ etc. render the punctuation literally.
- * Applied only at plain-text leaves — never inside code spans. */
-function unescapeMd(s: string): string {
-  return s.replace(/\\([\\`*_{}[\]()#+\-.!<>~|])/g, "$1");
+/** Escaped `\\` and `\*` must be invisible to the emphasis delimiter regexes
+ * (an escaped asterisk never opens emphasis), so they're sentinel-encoded
+ * before splitting and decoded back at the text leaves in unescapeMd. `\\`
+ * goes first so the backslash in `\\*` isn't misread as escaping the star. */
+const ESC_BS = "\u0000";
+const ESC_STAR = "\u0001";
+function encodeEscapes(s: string): string {
+  return s.replace(/\\\\/g, ESC_BS).replace(/\\\*/g, ESC_STAR);
 }
 
-/** Bold (then italic) runs within a plain-text span. */
+/** GFM backslash escapes: \` \* \_ etc. render the punctuation literally.
+ * Applied only at plain-text leaves — never inside code spans. `\\` and `\*`
+ * arrive sentinel-encoded (see encodeEscapes). */
+function unescapeMd(s: string): string {
+  return s
+    .replace(/\\([`_{}[\]()#+\-.!<>~|])/g, "$1")
+    .replace(/\u0000/g, "\\")
+    .replace(/\u0001/g, "*");
+}
+
+/** Bold and ***bold-italic*** (then italic) runs within a plain-text span. */
 function renderBold(text: string, keyPrefix: string): React.ReactNode[] {
-  return text.split(/(\*\*[^*]+\*\*)/g).flatMap((bp, j) => {
+  return encodeEscapes(text).split(/(\*\*\*[^*]+\*\*\*|\*\*[^*]+\*\*)/g).flatMap((bp, j) => {
+    if (bp.startsWith("***") && bp.endsWith("***") && bp.length > 6) {
+      return [<strong key={`${keyPrefix}-${j}`}><em>{unescapeMd(bp.slice(3, -3))}</em></strong>];
+    }
     if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 4) {
       return [<strong key={`${keyPrefix}-${j}`}>{unescapeMd(bp.slice(2, -2))}</strong>];
     }

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -69,17 +69,23 @@ function ExternalLink({ label, url }: { label: string; url: string }) {
 function renderItalic(text: string, keyPrefix: string): React.ReactElement[] {
   return text.split(/(\*[^\s*][^*]*\*)/g).flatMap((ip, j) => {
     if (ip.length > 2 && ip.startsWith("*") && ip.endsWith("*") && !/\s$/.test(ip.slice(1, -1))) {
-      return [<em key={`${keyPrefix}-i${j}`}>{ip.slice(1, -1)}</em>];
+      return [<em key={`${keyPrefix}-i${j}`}>{unescapeMd(ip.slice(1, -1))}</em>];
     }
-    return ip ? [<span key={`${keyPrefix}-i${j}`}>{ip}</span>] : [];
+    return ip ? [<span key={`${keyPrefix}-i${j}`}>{unescapeMd(ip)}</span>] : [];
   });
+}
+
+/** GFM backslash escapes: \` \* \_ etc. render the punctuation literally.
+ * Applied only at plain-text leaves — never inside code spans. */
+function unescapeMd(s: string): string {
+  return s.replace(/\\([\\`*_{}[\]()#+\-.!<>~|])/g, "$1");
 }
 
 /** Bold (then italic) runs within a plain-text span. */
 function renderBold(text: string, keyPrefix: string): React.ReactNode[] {
   return text.split(/(\*\*[^*]+\*\*)/g).flatMap((bp, j) => {
     if (bp.startsWith("**") && bp.endsWith("**") && bp.length > 4) {
-      return [<strong key={`${keyPrefix}-${j}`}>{bp.slice(2, -2)}</strong>];
+      return [<strong key={`${keyPrefix}-${j}`}>{unescapeMd(bp.slice(2, -2))}</strong>];
     }
     return bp ? renderItalic(bp, `${keyPrefix}-${j}`) : [];
   });

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -85,15 +85,55 @@ function renderBold(text: string, keyPrefix: string): React.ReactNode[] {
   });
 }
 
+/** CommonMark-style inline code-span scan: a run of N backticks opens a span
+ * closed only by the next run of exactly N backticks (so `` a`b `` works and
+ * multi-backtick runs don't pair off with random singles). Unclosed runs stay
+ * literal text. */
+function splitCodeSpans(text: string): Array<{ code: string } | { text: string }> {
+  const out: Array<{ code: string } | { text: string }> = [];
+  let plain = "";
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== "`") { plain += text[i]; i++; continue; }
+    let n = 0;
+    while (text[i + n] === "`") n++;
+    // Find a closing run of exactly n backticks.
+    let close = -1;
+    for (let j = i + n; j < text.length; j++) {
+      if (text[j] !== "`") continue;
+      let m = 0;
+      while (text[j + m] === "`") m++;
+      if (m === n) { close = j; break; }
+      j += m - 1;
+    }
+    if (close === -1) {
+      plain += "`".repeat(n);
+      i += n;
+      continue;
+    }
+    if (plain) { out.push({ text: plain }); plain = ""; }
+    let code = text.slice(i + n, close);
+    // CommonMark: strip one leading+trailing space when both present and the
+    // content isn't all spaces (lets you write code that starts with `).
+    if (code.length >= 2 && code.startsWith(" ") && code.endsWith(" ") && code.trim() !== "") {
+      code = code.slice(1, -1);
+    }
+    out.push({ code });
+    i = close + n;
+  }
+  if (plain) out.push({ text: plain });
+  return out;
+}
+
 /** Render inline `code` spans (recognizing in-scope file:line mentions as
  * clickable links), [text](url) / ![alt](url) links, and **bold**. */
 export function renderInline(text: string, filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
   // Code spans first — nothing inside them is markdown.
-  const parts = text.split(/(`[^`]+`)/g);
-  parts.forEach((part, i) => {
-    if (part.startsWith("`") && part.endsWith("`") && part.length > 1) {
-      const inner = part.slice(1, -1);
+  const parts = splitCodeSpans(text);
+  parts.forEach((tok, i) => {
+    if ("code" in tok) {
+      const inner = tok.code;
       const ref = filePaths.length > 0 ? parseFileRef(inner, filePaths) : null;
       if (ref && onOpenFile) {
         nodes.push(
@@ -114,7 +154,7 @@ export function renderInline(text: string, filePaths: string[], onOpenFile?: (pa
     }
     // Then links (and image syntax, rendered as a labeled link — no remote
     // image loading), then bold in the remaining plain runs.
-    const linkParts = part.split(/(!?\[[^\]]*\]\([^\s)]+\))/g);
+    const linkParts = tok.text.split(/(!?\[[^\]]*\]\([^\s)]+\))/g);
     linkParts.forEach((lp, k) => {
       const m = lp.match(/^(!?)\[([^\]]*)\]\(([^\s)]+)\)$/);
       if (m) {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4105,6 +4105,7 @@ mark.search-highlight-current {
   right: 16px;
   /* Clears the next-file bar at the bottom of the diff pane. */
   bottom: 64px;
+  transition: right 0.2s ease;
   width: 340px;
   height: 440px;
   min-width: 210px;
@@ -5974,3 +5975,13 @@ mark.search-highlight-current {
   color: var(--accent); text-decoration: none;
 }
 .rt-link:hover { text-decoration: underline; }
+
+/* When a right panel (chat/comments, 380px, in-flow at the window's right
+   edge) is open, the fixed-position activity dock/pill steps left of it so
+   it never covers the panel's content. */
+.app--right-panel .activity-widget--dock {
+  right: calc(380px + 24px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .activity-widget--dock { transition: none; }
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -5978,10 +5978,16 @@ mark.search-highlight-current {
 
 /* When a right panel (chat/comments, 380px, in-flow at the window's right
    edge) is open, the fixed-position activity dock/pill steps left of it so
-   it never covers the panel's content. */
-.app--right-panel .activity-widget--dock {
+   it never covers the panel's content. The expanded dock and collapsed pill
+   are separate classes — both need the offset. */
+.app--right-panel .activity-widget--dock,
+.app--right-panel .activity-widget--pill {
   right: calc(380px + 24px);
 }
+.activity-widget--pill {
+  transition: right 0.2s ease;
+}
 @media (prefers-reduced-motion: reduce) {
-  .activity-widget--dock { transition: none; }
+  .activity-widget--dock,
+  .activity-widget--pill { transition: none; }
 }

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -588,6 +588,36 @@ body {
   flex: 1;
 }
 
+/* ─── Sidebar Footer (Comments toggle) ─────────────────────────────────── */
+.sidebar-footer {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border);
+}
+
+.sidebar-comments-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: var(--space-2) var(--space-4);
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.sidebar-comments-toggle:hover {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+.sidebar-comments-toggle.active {
+  color: var(--accent-strong);
+  background: var(--accent-bg);
+}
+
 .file-group {
   margin-bottom: 4px;
 }
@@ -2774,54 +2804,6 @@ tr.cursor-selected td {
   background: var(--border);
 }
 
-/* ─── Comments Viewer ──────────────────────────────────────────────────── */
-.comments-viewer {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  overflow: hidden;
-}
-
-.comments-viewer-header {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 16px;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border);
-  flex-shrink: 0;
-}
-
-.comments-viewer-path {
-  font-family: var(--font-mono);
-  font-size: 13px;
-  color: var(--text-primary);
-}
-
-.comments-viewer-summary {
-  font-size: 12px;
-  color: var(--text-secondary);
-  margin-left: auto;
-}
-
-.comments-viewer-threads {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.comments-viewer-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  color: var(--text-muted);
-  font-size: 14px;
-}
-
 /* ─── Thread Card ──────────────────────────────────────────────────────── */
 .thread-card {
   border: 1px solid var(--border);
@@ -2850,16 +2832,22 @@ tr.cursor-selected td {
   background: var(--border);
 }
 
+.thread-card-author {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
 .thread-card-location {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--text-primary);
+  cursor: pointer;
 }
 
-.thread-card-comment-count {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--text-muted);
+.thread-card-location:hover {
+  color: var(--accent);
+  text-decoration: underline;
 }
 
 .thread-outdated-badge {
@@ -2933,6 +2921,25 @@ tr.cursor-selected td {
 
 .thread-comment:last-child {
   border-bottom: none;
+}
+
+.thread-comments-more {
+  display: block;
+  width: 100%;
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.thread-comments-more:hover {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
 }
 
 .comment-header {
@@ -3103,69 +3110,6 @@ tr.cursor-selected td {
 .reply-submit:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-}
-
-/* ─── Comment File List (sidebar) ──────────────────────────────────────── */
-.comment-file-list {
-  display: flex;
-  flex-direction: column;
-}
-
-.comment-file-list-empty {
-  padding: 16px;
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 13px;
-}
-
-.comment-file-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 16px;
-  border: none;
-  background: none;
-  color: var(--text-primary);
-  font-family: var(--font-sans);
-  font-size: 13px;
-  cursor: pointer;
-  text-align: left;
-}
-
-.comment-file-item .file-name {
-  flex: 1;
-  min-width: 0;
-}
-
-.comment-file-item .file-path-hint {
-  margin-left: 0;
-  width: 48px;
-  text-align: right;
-}
-
-.comment-file-item:hover {
-  background: var(--bg-tertiary);
-}
-
-.comment-file-item.selected {
-  background: rgba(88, 166, 255, 0.15);
-}
-
-.comment-count-badge {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  background: var(--bg-tertiary);
-  color: var(--text-muted);
-  margin-left: auto;
-  flex-shrink: 0;
 }
 
 /* ─── Inline Review Threads (Diff View) ────────────────────────────────── */
@@ -3687,21 +3631,6 @@ tr.cursor-selected td {
   position: relative;
   cursor: pointer;
   user-select: none;
-}
-
-.unresolved-badge {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  background: var(--risk-high-bg);
-  color: var(--risk-high);
-  flex-shrink: 0;
 }
 
 /* ─── Search Bar ────────────────────────────────────────────────────────── */
@@ -5663,6 +5592,143 @@ mark.search-highlight-current {
   border-left: 1px solid var(--chip-border);
   background: var(--bg-secondary);
   overflow: hidden;
+}
+
+/* ─── Comments Panel (right dock) ───────────────────────────────────────── */
+.comments-panel {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--chip-border);
+  background: var(--bg-secondary);
+  overflow: hidden;
+}
+
+.comments-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--chip-border);
+}
+
+.comments-panel-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.comments-panel-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--chip-border);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.comments-panel-count {
+  white-space: nowrap;
+}
+
+.comments-panel-filter {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.comments-panel-filter button {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 2px var(--space-2);
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.comments-panel-filter button:first-child {
+  border-right: 1px solid var(--border);
+}
+
+.comments-panel-filter button.active {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.comments-panel-filter button:hover:not(.active) {
+  color: var(--text-secondary);
+}
+
+.comments-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.comments-panel-empty {
+  color: var(--text-muted);
+  font-size: 12px;
+  text-align: center;
+  padding: var(--space-4) 0;
+}
+
+.comments-panel-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--diff-remove-text);
+  font-size: 12px;
+  border: 1px solid var(--diff-remove-text);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+
+.comments-panel-retry {
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--diff-remove-text);
+  border-radius: var(--radius-sm);
+  color: var(--diff-remove-text);
+  padding: 2px var(--space-2);
+  font-size: 11px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.comments-panel-retry:hover {
+  background: var(--diff-remove-bg);
+}
+
+.comments-panel-file-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.comments-panel-file-header {
+  align-self: flex-start;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+}
+
+.comments-panel-file-header:hover {
+  color: var(--accent);
+  text-decoration: underline;
 }
 
 .chat-header {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -146,7 +146,7 @@ export interface NoteResolution {
   at?: string;
 }
 
-export type SidebarView = "groups" | "comments" | "category" | "tree";
+export type SidebarView = "groups" | "category" | "tree";
 
 export type DiffViewMode = "split" | "unified";
 
@@ -186,7 +186,8 @@ export interface Tab {
   /** Conversational diff Q&A state for this PR. */
   chat: ChatState;
   commentThreads: CommentThreadsState;
-  selectedCommentFile: string | null;
+  /** Whether the right-dock comments panel is open (mutually exclusive with `chat.open`). */
+  commentsOpen?: boolean;
   sidebarView: SidebarView;
   isRefreshing?: boolean;
   lastCommentCount?: number;


### PR DESCRIPTION
## Summary
Closes #144. The comments sidebar *mode* — which swapped the entire diff pane away — is gone. Comments are now a right-dock slide-in panel (same dock pattern as the chat), so you never lose the code you're discussing:
- Threads grouped by file, **Unresolved/All** filter (defaults Unresolved; falls back to All when everything's resolved), reply / resolve / react / edit all preserved
- **Jump-to-thread**: click a thread's line reference → the diff scrolls to the inline thread and flashes it, expanding collapsed low-significance hunks when the target hides inside one, and toasting honestly when an outdated thread's position no longer exists in the diff
- **Markdown in comment bodies** via the shared RichText (`suggestion` blocks keep their dedicated rendering)
- `T` toggles the panel; chat and comments panels are mutually exclusive; the sidebar gets a footer Comments toggle (the Comments view-tab is gone)
- Legacy sessions that persisted the old comments mode restore with the panel open; a single open+idle effect drives the fetch for every entry path

## Verifier findings (all fixed)
- Legacy-session restore opened the panel but never fetched (centralized into the open+idle effect)
- Jump silently no-oped on outdated threads (now toasts) and on threads inside default-collapsed hunks (now expands first)
- Retry loop now invalidates on tab switch

## Second verifier pass (post-polish commits, all fixed)
- Escaped asterisks (`\*`) still opened emphasis, with the backslash bleeding through
- `***bold italic***` left stray literal asterisks around the bold

## Test Plan
- [x] `bun run build` clean; `cargo check` confirms zero Rust changes
- [x] Adversarial verifier pass (3 findings, all fixed)
- [x] Second adversarial verifier pass over the polish commits (2 findings, fixed; emphasis logic re-tested against 10 CommonMark edge cases)
- [x] Live: panel opens beside the diff, fetch fires on open, filter defaults correctly, empty state, sidebar toggle active-state — verified on a threadless PR
- [x] Live on this PR's own review threads (dogfooded): thread cards w/ markdown + suggestion blocks, resolved/unresolved states, jump-to-thread scroll+flash, reply and resolve/unresolve round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)


