### PR TITLE
ci(homebrew): sync a desktop cask to the tap on release publish

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -1,13 +1,15 @@
 name: Update Homebrew Tap
 
-# When a CLI (`cli-v*`) release is *published*, copy its generated `marrow.rb`
-# into `Formula/marrow.rb` in the umbrella tap (Besendorfer/homebrew-tap) so
-# `brew install marrow` tracks the new version automatically.
+# When a release is *published*, sync the umbrella tap (Besendorfer/homebrew-tap):
+#   - CLI releases (`cli-v*`): copy the generated `marrow.rb` into `Formula/`
+#     so `brew install besendorfer/tap/marrow` tracks the new version.
+#   - Desktop releases (`v*`): regenerate `Casks/marrow.rb` against the release's
+#     `Marrow_aarch64.dmg` so `brew install --cask besendorfer/tap/marrow` works.
 #
-# Why `release: published` and not the tag push: cli-release.yml creates a
-# *draft* release, and a draft's asset download URLs aren't publicly reachable —
-# the formula points at those URLs, so it must only land in the tap once the
-# release is live. Publishing the draft fires this workflow.
+# Why `release: published` and not the tag push: both release workflows create
+# *draft* releases, and a draft's asset download URLs aren't publicly reachable —
+# the formula/cask point at those URLs, so they must only land in the tap once
+# the release is live. Publishing the draft fires this workflow.
 #
 # Requires a repo secret HOMEBREW_TAP_TOKEN: a PAT with contents:write on
 # Besendorfer/homebrew-tap (the default GITHUB_TOKEN can't push to another repo).
@@ -18,15 +20,14 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "CLI release tag to sync to the tap (e.g. cli-v0.1.0-alpha.3)"
+        description: "Release tag to sync to the tap (cli-v* → formula, v* → cask)"
         required: true
 
 jobs:
   update-tap:
-    # Only CLI releases carry a Homebrew formula; skip desktop (`v*`) releases.
-    # (workflow_dispatch has no release object, so allow it through and validate
-    # the tag below.)
-    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'cli-v') }}
+    # Only CLI releases carry a Homebrew formula; desktop (`v*`) releases are
+    # handled by update-cask below.
+    if: ${{ startsWith(github.event.release.tag_name, 'cli-v') || (github.event_name == 'workflow_dispatch' && startsWith(inputs.tag, 'cli-v')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Resolve release tag
@@ -70,5 +71,84 @@ jobs:
             echo "Formula already up to date — nothing to commit."
           else
             git commit -m "marrow $VERSION"
+            git push
+          fi
+
+  update-cask:
+    # Desktop releases (`v*`, not `cli-v*`) ship the signed+notarized DMG; the
+    # cask pins its sha256, so it is generated from the published asset. The
+    # `cli-v` prefix starts with "c", so startsWith(tag, 'v') alone excludes it.
+    if: ${{ (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) || (github.event_name == 'workflow_dispatch' && startsWith(inputs.tag, 'v')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: rel
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          case "$TAG" in
+            cli-v*) echo "::error::got a CLI tag ('$TAG') — the cask tracks desktop v* releases"; exit 1 ;;
+            v*) ;;
+            *) echo "::error::tag must start with v (got: '$TAG')"; exit 1 ;;
+          esac
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download the DMG and compute its checksum
+        id: dmg
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.rel.outputs.tag }}
+        run: |
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern Marrow_aarch64.dmg \
+            --dir .
+          SHA=$(sha256sum Marrow_aarch64.dmg | cut -d' ' -f1)
+          echo "sha256=$SHA" >> "$GITHUB_OUTPUT"
+          echo "Marrow_aarch64.dmg sha256: $SHA"
+
+      - name: Generate the cask and commit to the tap
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ steps.rel.outputs.tag }}
+          SHA256: ${{ steps.dmg.outputs.sha256 }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::HOMEBREW_TAP_TOKEN is not set — create a PAT with contents:write on Besendorfer/homebrew-tap and add it as a repo secret."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/Besendorfer/homebrew-tap.git" tap
+          mkdir -p tap/Casks
+          cat > tap/Casks/marrow.rb <<EOF
+          cask "marrow" do
+            version "$VERSION"
+            sha256 "$SHA256"
+
+            url "https://github.com/Besendorfer/marrow/releases/download/v#{version}/Marrow_aarch64.dmg"
+            name "Marrow"
+            desc "AI-powered GitHub PR review app - surfaces only the diffs that matter"
+            homepage "https://github.com/Besendorfer/marrow"
+
+            livecheck do
+              url "https://github.com/Besendorfer/marrow"
+              strategy :github_latest
+            end
+
+            # The app self-updates via the Tauri updater; brew upgrade skips it
+            # unless --greedy.
+            auto_updates true
+            depends_on arch: :arm64
+
+            app "Marrow.app"
+          end
+          EOF
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/marrow.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date — nothing to commit."
+          else
+            git commit -m "marrow cask $VERSION"
             git push
           fi

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -123,6 +123,29 @@ brew install marrow
 > The formula is also attached to every CLI release, so the manual copy above
 > always works if the automation is unavailable (e.g. the secret is missing).
 
+### Desktop app cask (`brew install --cask`)
+
+The same tap also carries a **cask** for the desktop app in `Casks/marrow.rb`
+(same `marrow` token as the CLI formula — `brew install besendorfer/tap/marrow`
+resolves the formula, `--cask` the app):
+
+```bash
+brew install --cask besendorfer/tap/marrow
+```
+
+Updating it is automated by the same `homebrew-tap.yml` workflow: when a
+desktop `v*` release is *published*, the `update-cask` job downloads that
+release's `Marrow_aarch64.dmg`, computes its sha256, regenerates
+`Casks/marrow.rb`, and pushes to the tap (same `HOMEBREW_TAP_TOKEN` secret,
+same publish-not-tag reasoning as the formula). Backfill or re-sync with a
+manual run: Actions → "Update Homebrew Tap" → `workflow_dispatch` with the
+desktop tag (e.g. `v0.24.0`).
+
+The cask declares `auto_updates true` — the app updates itself via the Tauri
+updater, so `brew upgrade` leaves it alone unless `--greedy`. Never rebuild a
+release's DMG after publishing: the cask pins its sha256 (same rule as
+`latest.json`/`marrow.rb`).
+
 ### Bare `brew install marrow` (homebrew-core, later)
 
 To drop the tap entirely and get `brew install marrow`, submit the formula to


### PR DESCRIPTION
## Summary
The tap workflow (`homebrew-tap.yml`) only synced the CLI formula on `cli-v*` publishes. This adds an `update-cask` job for desktop `v*` releases: on publish it downloads the release's `Marrow_aarch64.dmg`, computes its sha256, regenerates `Casks/marrow.rb` in `Besendorfer/homebrew-tap`, and pushes — so:

```bash
brew install --cask besendorfer/tap/marrow
```

tracks desktop releases automatically, the same way the formula tracks the CLI.

Details:
- Same `marrow` token as the formula (Homebrew disambiguates via `--cask`), same `HOMEBREW_TAP_TOKEN` secret, same publish-not-tag-push reasoning (draft asset URLs aren't reachable).
- `auto_updates true` since the app self-updates via the Tauri updater — `brew upgrade` skips it unless `--greedy`.
- `workflow_dispatch` backfill accepts either tag flavor and routes by prefix (`cli-v*` → formula job, `v*` → cask job); the formula job's dispatch guard tightened to match.
- PUBLISHING.md documents the cask flow + the never-rebuild-assets sha256 rule.

## Test Plan
- [x] YAML parses; heredoc dedents so the generated cask starts at column 0 (verified with pyyaml against GitHub's block-scalar semantics)
- [ ] First real run: publish the v0.24.0 draft → `update-cask` fires → `Casks/marrow.rb` lands in the tap → `brew install --cask besendorfer/tap/marrow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)