### PR TITLE
feat: triage-first review path — top risks, contract-first order, Brief me (#129)

### DIFF
--- a/app/src-tauri/crates/core/src/ai.rs
+++ b/app/src-tauri/crates/core/src/ai.rs
@@ -49,6 +49,42 @@ pub fn extract_json_array(text: &str) -> Result<serde_json::Value, String> {
     ))
 }
 
+/// Extract a JSON object from text that may contain markdown fences or preamble.
+/// Mirror of [`extract_json_array`] for the triage pass, which returns an object.
+pub fn extract_json_object(text: &str) -> Result<serde_json::Value, String> {
+    // Try direct parse.
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(text.trim()) {
+        if val.is_object() {
+            return Ok(val);
+        }
+    }
+
+    // Try to find a JSON object in the text (first '{' to last '}').
+    if let (Some(start), Some(end)) = (text.find('{'), text.rfind('}')) {
+        if end > start {
+            let candidate = &text[start..=end];
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(candidate) {
+                if val.is_object() {
+                    return Ok(val);
+                }
+            }
+        }
+    }
+
+    // Try stripping markdown code fences.
+    let stripped = text.replace("```json", "").replace("```", "");
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(stripped.trim()) {
+        if val.is_object() {
+            return Ok(val);
+        }
+    }
+
+    Err(format!(
+        "Could not extract JSON object from AI response. Raw response:\n{}",
+        &text[..text.len().min(500)]
+    ))
+}
+
 /// The AI provider a config resolves to. A pure decision, separated from
 /// construction so it's testable without hitting AWS/network.
 #[derive(Debug, PartialEq, Eq)]
@@ -944,6 +980,20 @@ mod tests {
             }
         }
         assert_eq!(out, "first.\n\n[[thought:2]]\n\nsecond.");
+    }
+
+    #[test]
+    fn extract_json_object_handles_fences_and_preamble() {
+        // Direct object.
+        assert!(extract_json_object(r#"{"a":1}"#).unwrap().is_object());
+        // Markdown-fenced.
+        let fenced = "```json\n{\"a\": 1}\n```";
+        assert_eq!(extract_json_object(fenced).unwrap()["a"], 1);
+        // Preamble + object.
+        let preamble = "Here is the result:\n{\"a\": 2}\nThanks!";
+        assert_eq!(extract_json_object(preamble).unwrap()["a"], 2);
+        // An array is not an object.
+        assert!(extract_json_object("[1,2,3]").is_err());
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/config.rs
+++ b/app/src-tauri/crates/core/src/config.rs
@@ -106,6 +106,7 @@ fn default_settings() -> Settings {
         show_approved_prs: false,
         show_draft_prs: true,
         setup_done: false,
+        expand_all_hunks: false,
     }
 }
 
@@ -139,6 +140,7 @@ pub fn load_settings() -> Settings {
     let mut show_approved_prs = false;
     let mut show_draft_prs = true;
     let mut setup_done = false;
+    let mut expand_all_hunks = false;
 
     for line in content.lines() {
         if let Some(val) = line.strip_prefix("model=") {
@@ -181,6 +183,8 @@ pub fn load_settings() -> Settings {
             show_draft_prs = val == "true";
         } else if let Some(val) = line.strip_prefix("setup_done=") {
             setup_done = val == "true";
+        } else if let Some(val) = line.strip_prefix("expand_all_hunks=") {
+            expand_all_hunks = val == "true";
         }
     }
 
@@ -204,6 +208,7 @@ pub fn load_settings() -> Settings {
         show_approved_prs,
         show_draft_prs,
         setup_done,
+        expand_all_hunks,
     }
 }
 
@@ -253,6 +258,7 @@ pub fn save_settings_to_disk(settings: &Settings) -> Result<(), String> {
     content.push_str(&format!("show_approved_prs={}\n", settings.show_approved_prs));
     content.push_str(&format!("show_draft_prs={}\n", settings.show_draft_prs));
     content.push_str(&format!("setup_done={}\n", settings.setup_done));
+    content.push_str(&format!("expand_all_hunks={}\n", settings.expand_all_hunks));
 
     fs::write(&path, content).map_err(|e| format!("Failed to save settings: {}", e))?;
 

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -1,14 +1,15 @@
-use crate::ai::{extract_json_array, AiBackend};
+use crate::ai::{extract_json_array, extract_json_object, AiBackend};
 use crate::config::resolve_github_token;
 use crate::dismissed_highlights;
 use crate::github::GithubClient;
 use crate::manifest_cache;
 use crate::pr_parser::parse_pr_ref;
 use crate::prompts::{
-    build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt, PriorNote,
+    build_classification_prompt, build_grouping_prompt, build_highlight_prompt, build_summary_prompt, build_triage_prompt, PriorNote,
 };
 use crate::types::{
-    ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest, Settings,
+    ChangeGroup, FetchProgress, FetchStatus, FileClassification, FileDiff, Highlight, HighlightResult, ReviewManifest,
+    ReviewOrderItem, Settings, TopRisk, TriageReport,
 };
 use futures::stream::{FuturesUnordered, StreamExt};
 use sha2::{Sha256, Digest};
@@ -140,37 +141,56 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let mut highlights_by_path: HashMap<String, Vec<Highlight>> = HashMap::new();
     let mut summary = String::new();
     let mut change_groups: Vec<ChangeGroup> = Vec::new();
+    // Triage guidance (top risks + contract-first order). Only computed for large
+    // PRs (see the gate below); None means the UI falls back to its normal views.
+    let mut triage: Option<TriageReport> = None;
     // Fetched full contents (base, head), keyed by path — only relevant files,
     // so NOT_RELEVANT files show their diff but not a full-file view.
     let mut content_by_path: HashMap<String, (String, String)> = HashMap::new();
 
     if !relevant.is_empty() {
-        // Step 4: AI highlight analysis + summary + grouping (parallel)
-        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, 3)));
+        // Step 4: AI highlight analysis + summary + grouping (+ triage for large
+        // PRs), in parallel. The triage pass (top risks + contract-first order) is
+        // gated on size — small PRs don't need a guided path.
+        let run_triage = relevant.len() >= TRIAGE_MIN_FILES;
+        let ai_total: u32 = if run_triage { 4 } else { 3 };
+        emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((0, ai_total)));
         let per_file_diffs = extract_per_file_diffs(&per_file_diff_map, &relevant);
         let prior_notes = build_prior_notes(&previous_manifest, &parsed.owner, &parsed.repo, parsed.number);
         let highlight_prompt = build_highlight_prompt(&pr_title, &pr_body, &per_file_diffs, &prior_notes);
 
         let summary_prompt = build_summary_prompt(&pr_title, &relevant);
         let grouping_prompt = build_grouping_prompt(&pr_title, &relevant);
+        let triage_prompt = if run_triage {
+            build_triage_prompt(&pr_title, &relevant, &per_file_diffs)
+        } else {
+            String::new()
+        };
 
-        let mut ai_stream: FuturesUnordered<_> = [
+        let mut tasks = vec![
             ("highlights", ai.invoke(&highlight_prompt)),
             ("summary", ai.invoke(&summary_prompt)),
             ("grouping", ai.invoke(&grouping_prompt)),
-        ].into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
+        ];
+        if run_triage {
+            tasks.push(("triage", ai.invoke(&triage_prompt)));
+        }
+        let mut ai_stream: FuturesUnordered<_> =
+            tasks.into_iter().map(|(name, fut)| async move { (name, fut.await) }).collect();
 
         let mut highlights_raw = Err("not started".to_string());
         let mut summary_raw = Err("not started".to_string());
         let mut grouping_raw = Err("not started".to_string());
+        let mut triage_raw = Err("not started".to_string());
         let mut ai_done: u32 = 0;
         while let Some((name, result)) = ai_stream.next().await {
             ai_done += 1;
-            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, 3)));
+            emit_progress(app, 4, "Analyzing highlights, summary, and grouping", FetchStatus::Running, None, Some((ai_done, ai_total)));
             match name {
                 "highlights" => highlights_raw = result,
                 "summary" => summary_raw = result,
                 "grouping" => grouping_raw = result,
+                "triage" => triage_raw = result,
                 _ => {}
             }
         }
@@ -204,6 +224,20 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
                     severity: h.severity,
                     comment: h.comment,
                 });
+        }
+
+        // Assemble triage: parse the AI object, else fall back to a deterministic
+        // risk-ordered report. Either way, finalize so it references only real
+        // files and covers every relevant file.
+        if run_triage {
+            let parsed = triage_raw
+                .ok()
+                .and_then(|raw| extract_json_object(&raw).ok())
+                .and_then(|json| serde_json::from_value::<TriageReport>(json).ok())
+                .filter(|t| !t.review_order.is_empty());
+            let mut report = parsed.unwrap_or_else(|| fallback_triage(&relevant, &highlights_by_path));
+            finalize_triage(&mut report, &relevant);
+            triage = Some(report);
         }
 
         // Step 5: Fetch file contents for all relevant files concurrently
@@ -341,6 +375,7 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
         draft,
         summary,
         change_groups,
+        triage,
         body: truncate_chars(&pr_body, 10000),
         files: file_diffs,
     };
@@ -348,6 +383,68 @@ pub async fn fetch_pr_impl(pr_ref: &str, settings: &Settings, app: ProgressFn<'_
     let _ = manifest_cache::save_cached_manifest(&parsed.owner, &parsed.repo, parsed.number, &manifest);
 
     Ok(manifest)
+}
+
+/// Minimum number of relevant files before the triage pass runs. Small PRs are
+/// fast to review flat and don't need a guided path.
+const TRIAGE_MIN_FILES: usize = 5;
+
+/// Rank a risk level for ordering (lower = riskier, comes first).
+fn risk_rank(level: &str) -> u8 {
+    match level {
+        "critical" => 0,
+        "high" => 1,
+        "medium" => 2,
+        _ => 3,
+    }
+}
+
+/// Deterministic triage for when the AI pass is unavailable: order relevant files
+/// by risk (critical first), and surface the critical/high files as top risks,
+/// using each file's first highlight (or its classification reason) as the detail.
+fn fallback_triage(
+    relevant: &[&FileClassification],
+    highlights_by_path: &HashMap<String, Vec<Highlight>>,
+) -> TriageReport {
+    let mut ordered: Vec<&FileClassification> = relevant.to_vec();
+    ordered.sort_by_key(|f| risk_rank(&f.risk_level));
+    let review_order = ordered
+        .iter()
+        .map(|f| ReviewOrderItem { path: f.path.clone(), rationale: String::new() })
+        .collect();
+
+    let top_risks = relevant
+        .iter()
+        .filter(|f| f.risk_level == "critical" || f.risk_level == "high")
+        .take(3)
+        .map(|f| {
+            let first = highlights_by_path.get(&f.path).and_then(|h| h.first());
+            TopRisk {
+                title: format!("{} ({})", f.path, f.risk_level),
+                detail: first.map(|h| h.comment.clone()).unwrap_or_else(|| f.reason.clone()),
+                path: f.path.clone(),
+                start_line: first.map(|h| h.start_line),
+            }
+        })
+        .collect();
+
+    TriageReport { top_risks, review_order }
+}
+
+/// Keep triage output honest regardless of source: drop top_risks / order entries
+/// that point at files not in this PR (AI hallucinations), and append any relevant
+/// file the AI left out of the order so `[`/`]` navigation still covers everything.
+fn finalize_triage(report: &mut TriageReport, relevant: &[&FileClassification]) {
+    let known: HashSet<&str> = relevant.iter().map(|f| f.path.as_str()).collect();
+    report.top_risks.retain(|r| known.contains(r.path.as_str()));
+    report.review_order.retain(|r| known.contains(r.path.as_str()));
+
+    let ordered: HashSet<String> = report.review_order.iter().map(|r| r.path.clone()).collect();
+    for f in relevant {
+        if !ordered.contains(&f.path) {
+            report.review_order.push(ReviewOrderItem { path: f.path.clone(), rationale: String::new() });
+        }
+    }
 }
 
 /// Build the prior-triage context fed back into the highlight prompt: for
@@ -986,5 +1083,60 @@ mod tests {
         assert_eq!(classify_diff_type(None, true, false), "added");
         assert_eq!(classify_diff_type(None, false, true), "removed");
         assert_eq!(classify_diff_type(None, false, false), "modified");
+    }
+
+    use super::{fallback_triage, finalize_triage};
+    use crate::types::{FileClassification, Highlight, ReviewOrderItem, TopRisk, TriageReport};
+    use std::collections::HashMap;
+
+    fn fc(path: &str, risk: &str) -> FileClassification {
+        FileClassification {
+            path: path.to_string(),
+            classification: "RELEVANT".to_string(),
+            category: "Business Logic".to_string(),
+            risk_level: risk.to_string(),
+            reason: format!("reason for {path}"),
+        }
+    }
+
+    #[test]
+    fn fallback_triage_orders_by_risk_and_surfaces_top_risks() {
+        let files = [fc("a.rs", "low"), fc("b.rs", "critical"), fc("c.rs", "high")];
+        let relevant: Vec<&FileClassification> = files.iter().collect();
+        let mut highlights = HashMap::new();
+        highlights.insert(
+            "b.rs".to_string(),
+            vec![Highlight { start_line: 42, end_line: 50, severity: "critical".into(), comment: "auth check removed".into() }],
+        );
+
+        let report = fallback_triage(&relevant, &highlights);
+        // Risk-first ordering: critical, high, low.
+        let order: Vec<&str> = report.review_order.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(order, vec!["b.rs", "c.rs", "a.rs"]);
+        // Top risks are the critical/high files; the highlight drives detail+line.
+        assert_eq!(report.top_risks.len(), 2);
+        let b = report.top_risks.iter().find(|r| r.path == "b.rs").unwrap();
+        assert_eq!(b.detail, "auth check removed");
+        assert_eq!(b.start_line, Some(42));
+    }
+
+    #[test]
+    fn finalize_triage_drops_unknown_and_appends_missing() {
+        let files = [fc("a.rs", "high"), fc("b.rs", "low")];
+        let relevant: Vec<&FileClassification> = files.iter().collect();
+        // AI returned an order missing b.rs and a hallucinated ghost.rs, plus a
+        // top risk pointing at a file not in the PR.
+        let mut report = TriageReport {
+            top_risks: vec![TopRisk { title: "x".into(), detail: "y".into(), path: "ghost.rs".into(), start_line: None }],
+            review_order: vec![
+                ReviewOrderItem { path: "a.rs".into(), rationale: "defines it".into() },
+                ReviewOrderItem { path: "ghost.rs".into(), rationale: "nope".into() },
+            ],
+        };
+        finalize_triage(&mut report, &relevant);
+        // ghost.rs dropped from both; b.rs appended to the order.
+        assert!(report.top_risks.is_empty());
+        let order: Vec<&str> = report.review_order.iter().map(|r| r.path.as_str()).collect();
+        assert_eq!(order, vec!["a.rs", "b.rs"]);
     }
 }

--- a/app/src-tauri/crates/core/src/fetch.rs
+++ b/app/src-tauri/crates/core/src/fetch.rs
@@ -432,12 +432,15 @@ fn fallback_triage(
 }
 
 /// Keep triage output honest regardless of source: drop top_risks / order entries
-/// that point at files not in this PR (AI hallucinations), and append any relevant
-/// file the AI left out of the order so `[`/`]` navigation still covers everything.
+/// that point at files not in this PR (AI hallucinations), dedupe repeated order
+/// entries (first occurrence wins — the prompt asks for each file exactly once,
+/// but nothing forces the model to comply), and append any relevant file the AI
+/// left out of the order so `[`/`]` navigation still covers everything.
 fn finalize_triage(report: &mut TriageReport, relevant: &[&FileClassification]) {
     let known: HashSet<&str> = relevant.iter().map(|f| f.path.as_str()).collect();
     report.top_risks.retain(|r| known.contains(r.path.as_str()));
-    report.review_order.retain(|r| known.contains(r.path.as_str()));
+    let mut seen: HashSet<String> = HashSet::new();
+    report.review_order.retain(|r| known.contains(r.path.as_str()) && seen.insert(r.path.clone()));
 
     let ordered: HashSet<String> = report.review_order.iter().map(|r| r.path.clone()).collect();
     for f in relevant {
@@ -1124,19 +1127,22 @@ mod tests {
     fn finalize_triage_drops_unknown_and_appends_missing() {
         let files = [fc("a.rs", "high"), fc("b.rs", "low")];
         let relevant: Vec<&FileClassification> = files.iter().collect();
-        // AI returned an order missing b.rs and a hallucinated ghost.rs, plus a
-        // top risk pointing at a file not in the PR.
+        // AI returned an order missing b.rs, listing a.rs twice, and a
+        // hallucinated ghost.rs, plus a top risk pointing at a file not in the PR.
         let mut report = TriageReport {
             top_risks: vec![TopRisk { title: "x".into(), detail: "y".into(), path: "ghost.rs".into(), start_line: None }],
             review_order: vec![
                 ReviewOrderItem { path: "a.rs".into(), rationale: "defines it".into() },
                 ReviewOrderItem { path: "ghost.rs".into(), rationale: "nope".into() },
+                ReviewOrderItem { path: "a.rs".into(), rationale: "again".into() },
             ],
         };
         finalize_triage(&mut report, &relevant);
-        // ghost.rs dropped from both; b.rs appended to the order.
+        // ghost.rs dropped from both; duplicate a.rs collapsed to its first
+        // occurrence; b.rs appended to the order.
         assert!(report.top_risks.is_empty());
         let order: Vec<&str> = report.review_order.iter().map(|r| r.path.as_str()).collect();
         assert_eq!(order, vec!["a.rs", "b.rs"]);
+        assert_eq!(report.review_order[0].rationale, "defines it");
     }
 }

--- a/app/src-tauri/crates/core/src/prompts.rs
+++ b/app/src-tauri/crates/core/src/prompts.rs
@@ -122,6 +122,71 @@ Respond with ONLY a valid JSON array. Each element must be an object with:
 
 Do NOT include any text before or after the JSON array. Just the JSON."#;
 
+pub const TRIAGE_PROMPT: &str = r#"You are a code review assistant helping a reviewer triage a large pull request so they can review the risky parts first, in the order that's easiest to understand.
+
+Produce two things:
+
+1. "top_risks": the 2-3 changes in this PR that carry the most real risk — security/auth changes, removed safety checks, data/permission changes, breaking API/contract changes, concurrency. NOT style, renames, or routine additions. For each: a short "title", a one-sentence "detail" on why it matters, the "path" it lives in, and "start_line" (the line in the NEW version where it starts) when you can tell from the diff. If nothing carries real risk, return an empty array.
+
+2. "review_order": ALL of the relevant files, ordered "contract-first" so the reviewer builds understanding with the fewest jumps back: first the files that DEFINE things (types, schemas, interfaces, API contracts), then the PRODUCERS that implement them, then the CONSUMERS that use them, then tests/config last. Each entry has the "path" and a "rationale" of at most ~12 words explaining why it's here in the order (e.g. "defines the ReviewMode shape the rest consumes"). Every relevant file must appear exactly once.
+
+Respond with ONLY a valid JSON object of this exact shape:
+{
+  "top_risks": [{"title": "...", "detail": "...", "path": "...", "start_line": 123}],
+  "review_order": [{"path": "...", "rationale": "..."}]
+}
+Do NOT include any text before or after the JSON object. Just the JSON."#;
+
+/// Build the triage prompt: structured per-file info (path, category, risk,
+/// reason) plus compact diff snippets so the model can reason about contracts and
+/// dependencies for ordering. Diffs are budgeted tighter than the highlight pass
+/// since ordering needs signatures/imports, not full bodies.
+pub fn build_triage_prompt(
+    pr_title: &str,
+    relevant_files: &[&FileClassification],
+    per_file_diffs: &[(String, String)],
+) -> String {
+    const PER_FILE_BUDGET: usize = 1500;
+    const TOTAL_BUDGET: usize = 20000;
+
+    let mut file_info = String::new();
+    for f in relevant_files {
+        file_info.push_str(&format!(
+            "- {} [{}] [{}] — {}\n",
+            f.path, f.category, f.risk_level, f.reason
+        ));
+    }
+
+    let mut diffs = String::new();
+    let mut remaining = TOTAL_BUDGET;
+    for (path, diff) in per_file_diffs {
+        if remaining == 0 {
+            break;
+        }
+        diffs.push_str(&format!("=== FILE: {} ===\n", path));
+        let cap = PER_FILE_BUDGET.min(remaining);
+        if diff.chars().count() > cap {
+            let snippet: String = diff.chars().take(cap).collect();
+            diffs.push_str(&snippet);
+            diffs.push_str("\n... (truncated)\n");
+            remaining = remaining.saturating_sub(cap);
+        } else {
+            diffs.push_str(diff);
+            remaining = remaining.saturating_sub(diff.chars().count());
+        }
+        diffs.push_str("\n\n");
+    }
+
+    format!(
+        "{}\n\n---\n\nPR Title: {}\n\nRelevant files ({} total):\n\n{}\n\n=== DIFFS ===\n\n{}",
+        TRIAGE_PROMPT,
+        pr_title,
+        relevant_files.len(),
+        file_info,
+        diffs
+    )
+}
+
 pub fn build_summary_prompt(
     pr_title: &str,
     relevant_files: &[&FileClassification],

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -64,6 +64,39 @@ pub struct ChangeGroup {
     pub file_paths: Vec<String>,
 }
 
+/// One of the 2-3 highest-risk changes, surfaced in the top-of-review triage card.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TopRisk {
+    /// Short headline (e.g. "Admin-only check removed on /users").
+    pub title: String,
+    /// One sentence on why it carries risk.
+    pub detail: String,
+    /// File the reviewer should jump to.
+    pub path: String,
+    /// Line (in the head version) to scroll to, when known.
+    #[serde(default)]
+    pub start_line: Option<u64>,
+}
+
+/// One file in the contract-first "fastest path" ordering, with a one-line
+/// rationale ("defines the shape the rest consumes").
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ReviewOrderItem {
+    pub path: String,
+    #[serde(default)]
+    pub rationale: String,
+}
+
+/// Triage guidance for large PRs: what to review first and in what order.
+/// Absent for small PRs (see the gate in `fetch`).
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct TriageReport {
+    #[serde(default)]
+    pub top_risks: Vec<TopRisk>,
+    #[serde(default)]
+    pub review_order: Vec<ReviewOrderItem>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewManifest {
     pub pr_title: String,
@@ -81,6 +114,10 @@ pub struct ReviewManifest {
     pub summary: String,
     #[serde(default)]
     pub change_groups: Vec<ChangeGroup>,
+    /// Triage-first guidance (top risks + contract-first order). `None` for small
+    /// PRs or when the triage AI pass fails without a usable fallback.
+    #[serde(default)]
+    pub triage: Option<TriageReport>,
     /// The PR description, truncated char-safely to bound cache size. Empty
     /// when the PR has no body or on manifests fetched before this field existed.
     #[serde(default)]
@@ -146,6 +183,11 @@ pub struct Settings {
     /// never auto-shows again (config via env vars alone also suppresses it).
     #[serde(default)]
     pub setup_done: bool,
+    /// When true, files open with every hunk expanded instead of auto-collapsing
+    /// low-significance hunks (issue #55). Off by default to keep the
+    /// collapsed-by-default behavior.
+    #[serde(default)]
+    pub expand_all_hunks: bool,
 }
 
 fn default_true() -> bool {

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -35,6 +35,10 @@ function isOpenerTab(tab: Tab): boolean {
   return !tab.manifest && !tab.loading && !tab.error;
 }
 
+/** Prompt sent by the "Brief me" command — a whole-PR guided walkthrough. */
+const BRIEF_ME_PROMPT =
+  "Walk me through this PR change by change, most important first. For each change: what it does, why it matters, and any risks you see. Cite file:line locations (in backticks) so I can jump to each one.";
+
 /** A fresh, closed chat panel for a new tab. */
 function emptyChatState(): ChatState {
   return { messages: [], status: "idle", streamingText: "", streamingStatus: null, includeWholePr: false, open: false };
@@ -57,6 +61,7 @@ function App() {
   const [showHunkSignificance, setShowHunkSignificance] = useState(true);
   const [showAiNotes, setShowAiNotes] = useState(true);
   const [hunkFilter, setHunkFilter] = useState<HunkSignificanceFilter>("all");
+  const [expandAllHunks, setExpandAllHunks] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
@@ -100,7 +105,10 @@ function App() {
 
   const handleSettingsClose = useCallback(() => {
     setSettingsOpen(false);
-    invoke<Settings>("get_settings").then((s) => { settingsRef.current = s; }).catch(() => {});
+    invoke<Settings>("get_settings").then((s) => {
+      settingsRef.current = s;
+      setExpandAllHunks(s.expand_all_hunks ?? false);
+    }).catch(() => {});
   }, []);
 
   const addToast = useCallback((type: ToastData["type"], message: string) => {
@@ -222,11 +230,28 @@ function App() {
     if (!activeTab?.manifest) return [];
     const inManifest = new Set(activeTab.manifest.files.map((f) => f.path));
     const visible = visibleOrderRef.current.filter((p) => inManifest.has(p));
-    return visible.length
+    const candidates = visible.length
       ? visible
       : activeTab.manifest.files
           .filter((f) => f.classification !== "NOT_RELEVANT")
           .map((f) => f.path);
+
+    const reviewOrder = activeTab.manifest.triage?.review_order;
+    if (!reviewOrder?.length) return candidates;
+
+    const candidateSet = new Set(candidates);
+    const triaged = reviewOrder.map((item) => item.path).filter((p) => candidateSet.has(p));
+    const triagedSet = new Set(triaged);
+    const remaining = candidates.filter((p) => !triagedSet.has(p));
+    return [...triaged, ...remaining];
+  }
+
+  // Rationale for a path from the triage review order, if any (null when
+  // triage is absent or the path isn't in it).
+  function triageRationale(path: string): string | null {
+    const reviewOrder = activeTab?.manifest?.triage?.review_order;
+    if (!reviewOrder?.length) return null;
+    return reviewOrder.find((item) => item.path === path)?.rationale ?? null;
   }
 
   // First unviewed file after `fromIdx` in review order (wrapping), treating
@@ -418,6 +443,7 @@ function App() {
         setShowHunkSignificance(settings.show_hunk_significance ?? true);
         setShowAiNotes(settings.show_ai_notes ?? true);
         setHunkFilter(settings.hunk_filter || "all");
+        setExpandAllHunks(settings.expand_all_hunks ?? false);
       } catch {
         // Use defaults on failure
       }
@@ -952,11 +978,12 @@ function App() {
   }
 
   // Chat and Comments are mutually exclusive right-dock panels — opening chat closes comments.
+  function withChatOpen(t: Tab, open: boolean): Tab {
+    return { ...t, chat: { ...t.chat, open }, commentsOpen: open ? false : t.commentsOpen };
+  }
+
   function toggleChatOpen() {
-    updateTab(activeTabId, (t) => {
-      const opening = !t.chat.open;
-      return { ...t, chat: { ...t.chat, open: opening }, commentsOpen: opening ? false : t.commentsOpen };
-    });
+    updateTab(activeTabId, (t) => withChatOpen(t, !t.chat.open));
   }
 
   function setCommentsOpen(open: boolean) {
@@ -980,6 +1007,32 @@ function App() {
     const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
     if (suffixMatches.length === 1) setSelectedFile(suffixMatches[0]);
   }
+
+  // Set by briefMe below; consumed once the chat-open/whole-PR state it just
+  // requested has actually committed (handleChatSend reads tabsRef, which
+  // only reflects this render's tabs after that commit — see the effect).
+  const briefMePendingRef = useRef(false);
+  /** Bumped on every briefMe() call so the send effect runs even when chat was
+   * already open in whole-PR scope (no dependency would otherwise change). */
+  const [briefMePing, setBriefMePing] = useState(0);
+
+  /** AI walkthrough of the whole PR, most-important-first — opens/expands
+   * chat to whole-PR scope and asks it to narrate the changes. */
+  function briefMe() {
+    if (!activeTab?.manifest) return;
+    updateTab(activeTabId, (t) => withChatOpen(t, true));
+    handleChatToggleWholePr(true);
+    if (activeTab.chat.status === "streaming") return;
+    briefMePendingRef.current = true;
+    setBriefMePing((p) => p + 1);
+  }
+
+  useEffect(() => {
+    if (!briefMePendingRef.current) return;
+    if (!activeTab?.manifest) return;
+    briefMePendingRef.current = false;
+    handleChatSend(BRIEF_ME_PROMPT);
+  }, [briefMePing]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const unlistenRef = useRef<(() => void) | null>(null);
 
@@ -1943,6 +1996,7 @@ function App() {
       { id: "refresh", section: "Review", title: "Refresh PR", keys: "⌃R", run: handleRefreshPr },
       { id: "github", section: "Review", title: "Open PR on GitHub", run: () => { openUrl(m.pr_url); } },
       { id: "ask-ai", section: "Review", title: "Ask AI about this change", keys: "⌘J", run: toggleChatOpen },
+      { id: "brief-me", section: "Review", title: "Brief me — AI walkthrough of this PR", run: briefMe },
       { id: "view-split", section: "View", title: "Split diff view", run: () => setViewMode("split") },
       { id: "view-unified", section: "View", title: "Unified diff view", run: () => setViewMode("unified") },
       { id: "toggle-sig", section: "View", title: showHunkSignificance ? "Hide hunk significance" : "Show hunk significance", run: () => setShowHunkSignificance((v) => !v) },
@@ -2153,6 +2207,8 @@ function App() {
               startTarget={nextUnviewed(guidedOrder(), -1)}
               onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
               onSelectFile={setSelectedFile}
+              onOpenAt={handleChatOpenFile}
+              onBriefMe={briefMe}
               newHighlightKeys={
                 // Dismissing a new note removes it from the chip immediately —
                 // a dead "1 new AI note" pointing at a hidden note is worse
@@ -2193,12 +2249,13 @@ function App() {
                 const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
                 return (
                   <>
-                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} newHighlightKeys={activeTab.newHighlightKeys} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} newHighlightKeys={activeTab.newHighlightKeys} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
                     <NextFileBar
                       index={idx >= 0 ? idx : 0}
                       total={order.length}
                       isViewed={activeTab.viewedFiles.has(activeTab.selectedFile.path)}
                       nextName={next ? next.path.split("/").pop() ?? next.path : null}
+                      nextRationale={next ? triageRationale(next.path) : null}
                       allReviewed={allReviewed}
                       onMarkReviewed={markReviewedAndAdvance}
                       onNext={() => { if (next) setSelectedFile(next); }}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -102,6 +102,9 @@ interface DiffViewerProps {
   onViewModeChange?: (mode: DiffViewMode) => void;
   showHunkSignificance: boolean;
   showAiNotes: boolean;
+  /** When true, every hunk starts expanded instead of auto-collapsing
+   * low-significance ones (issue #55). */
+  expandAllHunks?: boolean;
   /** Keys (highlightKey) of AI highlights dismissed for this PR — hidden from the diff. */
   dismissedHighlights?: Set<string>;
   /** Resolution metadata (state + reason) for dismissed highlights, keyed by highlightKey. */
@@ -1581,7 +1584,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, dismissedHighlights, noteResolutions, newHighlightKeys, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, expandAllHunks, dismissedHighlights, noteResolutions, newHighlightKeys, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -1732,7 +1735,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   // Low hunks start collapsed when significance is shown; state resets on file change
   // via the key prop on DiffViewer (see App.tsx)
   const [collapsedHunks, setCollapsedHunks] = useState<Set<number>>(() => {
-    if (!showHunkSignificance || hunks.length <= 1) return new Set<number>();
+    if (expandAllHunks || !showHunkSignificance || hunks.length <= 1) return new Set<number>();
     return new Set(
       hunks.filter((h) => h.significance === "low").map((h) => h.index)
     );

--- a/app/src/components/NextFileBar.tsx
+++ b/app/src/components/NextFileBar.tsx
@@ -3,6 +3,7 @@ interface NextFileBarProps {
   total: number;
   isViewed: boolean;
   nextName: string | null;
+  nextRationale?: string | null;
   allReviewed: boolean;
   onMarkReviewed: () => void;
   onNext: () => void;
@@ -15,6 +16,7 @@ export function NextFileBar({
   total,
   isViewed,
   nextName,
+  nextRationale,
   allReviewed,
   onMarkReviewed,
   onNext,
@@ -46,6 +48,11 @@ export function NextFileBar({
                 Next: <span className="next-bar-file">{nextName}</span>
                 <kbd className="next-bar-key">]</kbd>
               </button>
+            )}
+            {nextName && nextRationale && (
+              <span className="next-bar-rationale" title={nextRationale}>
+                {nextRationale}
+              </span>
             )}
           </>
         )}

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -285,20 +285,20 @@ export function PrOverview({
               <span>No high-risk changes flagged</span>
             )}
           </div>
-          {startTarget ? (
-            <div className="overview-start-row">
+          <div className="overview-start-row">
+            {startTarget ? (
               <button className="overview-start" onClick={onStartReview}>
                 Start review → {fileName(startTarget.path)}
               </button>
-              {onBriefMe && (
-                <button className="overview-start-secondary" onClick={onBriefMe}>
-                  Brief me
-                </button>
-              )}
-            </div>
-          ) : (
-            <div className="overview-state-line">All files reviewed</div>
-          )}
+            ) : (
+              <div className="overview-state-line">All files reviewed</div>
+            )}
+            {onBriefMe && (
+              <button className="overview-start-secondary" onClick={onBriefMe}>
+                Brief me
+              </button>
+            )}
+          </div>
           <div className="overview-start-sub">
             {relevant.length} relevant {relevant.length === 1 ? "file" : "files"},
             in review order

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -3,7 +3,7 @@ import { SummaryParagraphs } from "./SummaryParagraphs";
 import { Avatar } from "./ReviewRequestList";
 import { RichText } from "./RichText";
 import { highlightKey } from "../utils";
-import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState } from "../types";
+import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState, TopRisk } from "../types";
 
 interface PrOverviewProps {
   manifest: ReviewManifest;
@@ -18,6 +18,10 @@ interface PrOverviewProps {
   /** Keys (see highlightKey) of AI highlights introduced by the most recent
    * refresh's re-analysis — surfaced as a "new AI notes" chip when non-empty. */
   newHighlightKeys?: Set<string>;
+  /** Jump to a file, optionally scrolling to a specific line (head version). */
+  onOpenAt?: (path: string, line?: number) => void;
+  /** Start a whole-PR chat walkthrough, most-important-first. */
+  onBriefMe?: () => void;
 }
 
 /** First file (in manifest order) whose highlights include a new-note key. */
@@ -122,6 +126,24 @@ function GroupRow({
   );
 }
 
+function TopRiskRow({ risk, onOpenAt }: { risk: TopRisk; onOpenAt?: (path: string, line?: number) => void }) {
+  return (
+    <button
+      className="overview-risk-row"
+      onClick={() => onOpenAt?.(risk.path, risk.start_line ?? undefined)}
+    >
+      <div className="overview-risk-row-main">
+        <div className="overview-risk-row-title">{risk.title}</div>
+        <div className="overview-risk-row-detail">{risk.detail}</div>
+      </div>
+      <span className="overview-risk-file">
+        {fileName(risk.path)}
+        {risk.start_line ? `:${risk.start_line}` : ""}
+      </span>
+    </button>
+  );
+}
+
 export function PrOverview({
   manifest,
   checksStatus,
@@ -133,6 +155,8 @@ export function PrOverview({
   onStartReview,
   onSelectFile,
   newHighlightKeys,
+  onOpenAt,
+  onBriefMe,
 }: PrOverviewProps) {
   const newNoteCount = newHighlightKeys?.size ?? 0;
   const relevant = manifest.files.filter((f) => f.classification !== "NOT_RELEVANT");
@@ -154,6 +178,7 @@ export function PrOverview({
   const highRisk = relevant.filter(
     (f) => f.risk_level === "critical" || f.risk_level === "high"
   ).length;
+  const topRisks = manifest.triage?.top_risks ?? [];
 
   return (
     <div className="pr-overview">
@@ -233,6 +258,14 @@ export function PrOverview({
         )}
       </div>
       <div className="overview-rail">
+        {topRisks.length > 0 && (
+          <div className="overview-card overview-risks">
+            <h4>What to review first</h4>
+            {topRisks.map((risk, i) => (
+              <TopRiskRow key={i} risk={risk} onOpenAt={onOpenAt} />
+            ))}
+          </div>
+        )}
         <div className="overview-card">
           <h4>Start reviewing</h4>
           <div className="overview-risk-strip">
@@ -253,9 +286,16 @@ export function PrOverview({
             )}
           </div>
           {startTarget ? (
-            <button className="overview-start" onClick={onStartReview}>
-              Start review → {fileName(startTarget.path)}
-            </button>
+            <div className="overview-start-row">
+              <button className="overview-start" onClick={onStartReview}>
+                Start review → {fileName(startTarget.path)}
+              </button>
+              {onBriefMe && (
+                <button className="overview-start-secondary" onClick={onBriefMe}>
+                  Brief me
+                </button>
+              )}
+            </div>
           ) : (
             <div className="overview-state-line">All files reviewed</div>
           )}

--- a/app/src/components/SettingsModal.tsx
+++ b/app/src/components/SettingsModal.tsx
@@ -29,6 +29,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
   const [watches, setWatches] = useState<Watch[]>([]);
   const [perWatchCap, setPerWatchCap] = useState(50);
   const [showApprovedPrs, setShowApprovedPrs] = useState(false);
+  const [expandAllHunks, setExpandAllHunks] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -50,6 +51,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
         setOpenaiBaseUrl(s.openai_base_url || "");
         setPerWatchCap(s.activity_per_watch_cap || 50);
         setShowApprovedPrs(s.show_approved_prs ?? false);
+        setExpandAllHunks(s.expand_all_hunks ?? false);
       });
       invoke<Watch[]>("get_watches").then(setWatches).catch(() => {});
       setSaved(false);
@@ -90,6 +92,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           openai_base_url: openaiBaseUrl.trim(),
           activity_per_watch_cap: perWatchCap,
           show_approved_prs: showApprovedPrs,
+          expand_all_hunks: expandAllHunks,
         },
       });
       // Persist watches alongside settings, dropping blank rows.
@@ -373,6 +376,22 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           <p className="settings-hint">
             By default, approving a PR removes it from the mini-player feed.
             Enable this to keep approved PRs in the list.
+          </p>
+
+          <label className="settings-check">
+            <input
+              type="checkbox"
+              checked={expandAllHunks}
+              onChange={(e) => {
+                setExpandAllHunks(e.target.checked);
+                setSaved(false);
+              }}
+            />
+            Open files with all hunks expanded
+          </label>
+          <p className="settings-hint">
+            By default, low-significance hunks start collapsed. Enable this to
+            open every file with all hunks expanded.
           </p>
 
           <div className="settings-divider" />

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -4668,6 +4668,58 @@ mark.search-highlight-current {
   flex-shrink: 0;
 }
 
+.overview-risk-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 10px 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--chip-border);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.overview-risk-row:first-of-type {
+  border-top: none;
+}
+
+.overview-risk-row:hover .overview-risk-row-title {
+  color: var(--accent);
+}
+
+.overview-risk-row-main {
+  min-width: 0;
+}
+
+.overview-risk-row-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.overview-risk-row-detail {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+}
+
+.overview-risk-file {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 1px 9px;
+  white-space: nowrap;
+}
+
 .overview-chip {
   font-size: 11px;
   color: var(--text-secondary);
@@ -4803,6 +4855,12 @@ mark.search-highlight-current {
   margin-right: 4px;
 }
 
+.overview-start-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .overview-start {
   display: inline-flex;
   align-items: center;
@@ -4819,6 +4877,24 @@ mark.search-highlight-current {
 
 .overview-start:hover {
   background: var(--accent-strong-hover);
+}
+
+.overview-start-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.overview-start-secondary:hover {
+  color: var(--text-primary);
 }
 
 .overview-start-sub {
@@ -4897,6 +4973,15 @@ mark.search-highlight-current {
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-primary);
+}
+
+.next-bar-rationale {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .next-bar-key {

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -32,6 +32,32 @@ export interface ChangeGroup {
   file_paths: string[];
 }
 
+/** One of the 2-3 highest-risk changes, surfaced in the top-of-review triage card. */
+export interface TopRisk {
+  /** Short headline (e.g. "Admin-only check removed on /users"). */
+  title: string;
+  /** One sentence on why it carries risk. */
+  detail: string;
+  /** File the reviewer should jump to. */
+  path: string;
+  /** Line (in the head version) to scroll to, when known. */
+  start_line?: number | null;
+}
+
+/** One file in the contract-first "fastest path" ordering, with a one-line
+ * rationale ("defines the shape the rest consumes"). */
+export interface ReviewOrderItem {
+  path: string;
+  rationale: string;
+}
+
+/** Triage guidance for large PRs: what to review first and in what order.
+ * Absent for small PRs (see the gate in `fetch`). */
+export interface TriageReport {
+  top_risks: TopRisk[];
+  review_order: ReviewOrderItem[];
+}
+
 export interface ReviewManifest {
   pr_title: string;
   pr_url: string;
@@ -44,6 +70,9 @@ export interface ReviewManifest {
   draft: boolean;
   summary: string;
   change_groups: ChangeGroup[];
+  /** Triage-first guidance (top risks + contract-first order). `null` for small
+   * PRs or when the triage AI pass fails without a usable fallback. */
+  triage?: TriageReport | null;
   /** The PR description, truncated char-safely to bound cache size. Empty
    * when the PR has no body or on manifests fetched before this field existed. */
   body: string;
@@ -233,6 +262,10 @@ export interface Settings {
    * behavior); the frontend filters draft rows out when this is off. */
   show_draft_prs: boolean;
   setup_done: boolean;
+  /** When true, files open with every hunk expanded instead of auto-collapsing
+   * low-significance hunks (issue #55). Off by default to keep the
+   * collapsed-by-default behavior. */
+  expand_all_hunks: boolean;
 }
 
 export type ReviewStatus = "approved" | "changes_requested" | "commented" | "dismissed" | "pending";


### PR DESCRIPTION
## Summary
Implements the #129 rescope (closes #129, closes #60, closes #55) — the intelligence layer on top of the shipped guided-review frame:

- **Core triage pass** (adapted cherry-pick from `feat/triage-fastest-path`): on PRs with ≥5 relevant files, a 4th parallel AI call emits 2–3 `top_risks` and a contract-first `review_order` with a one-line rationale per file. Deterministic risk-sorted fallback when the AI output is unusable; `finalize_triage` drops hallucinated paths, dedupes repeats, and appends omitted files. `#[serde(default)]` keeps old cached manifests loading; small PRs are untouched (no 4th call).
- **Risk-driven guided flow**: `guidedOrder()` follows the triage order when present (byte-identical behavior without it); the next-file bar shows the AI's rationale for the upcoming file.
- **"What to review first" card** on the Overview right rail with jump-to-line risk rows (reuses the chat's `file:line` open handler).
- **Brief me** (replaces #134's dropped TourPlayer): button on the Overview + ⌘K entry that opens the chat in whole-PR mode and auto-sends a walkthrough prompt — the streamed answer's `file:line` citations are clickable diff jumps.
- **`expand_all_hunks` setting** (#55): opt-in full expansion; default preserves today's collapse-by-default.

Deliberately NOT included: the salvage branch's `SUMMARY_PROMPT` rewrite (would degrade small PRs where triage never runs) and all TourPlayer/TTS code.

## Test Plan
- [x] `cargo check` clean; `cargo test -p marrow-core` 55 passed (3 new: fallback ordering + top-risk sourcing, finalize dedupe/drop/append, `extract_json_object`)
- [x] `bun run build` clean
- [x] Adversarial verifier pass (2 findings: order dedupe, Brief-me visibility at 100% reviewed — both fixed)
- [x] Live smoke on this PR itself (12 files, 8 relevant — dogfooded): CLI analysis produced a real TriageReport (2 top risks w/ correct file:line, genuinely contract-first 8-file order: types → prompts contract → parser → orchestrator → consumers, each with rationale); GUI Overview shows the "What to review first" card, risk-row click jumps to fetch.rs:141, Start review begins at types.ts (triage order, not display order), next-file bar shows the AI rationale, and Brief me opens the chat in whole-PR scope and streams a walkthrough with clickable file:line citations
- [x] expand_all_hunks live-tested end-to-end both directions: Settings checkbox → Save → `expand_all_hunks=true` in config → fetch.rs remounts fully expanded ("Collapse all" showing, no collapsed bands) → toggled back → config `false` → collapse-by-default returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

