### PR TITLE
fix(gui): make Brief me concise — scannable briefing instead of an essay

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -35,9 +35,16 @@ function isOpenerTab(tab: Tab): boolean {
   return !tab.manifest && !tab.loading && !tab.error;
 }
 
-/** Prompt sent by the "Brief me" command — a whole-PR guided walkthrough. */
+/** Prompt sent by the "Brief me" command — a whole-PR guided walkthrough.
+ * Deliberately strict about brevity: without hard limits the model produces an
+ * exhausting per-change essay instead of a scannable briefing. */
 const BRIEF_ME_PROMPT =
-  "Walk me through this PR change by change, most important first. For each change: what it does, why it matters, and any risks you see. Cite file:line locations (in backticks) so I can jump to each one.";
+  "Brief me on this PR — a briefing I can scan in under a minute, not an essay. " +
+  "Start with a one-sentence TL;DR. Then one line per change, most important first: " +
+  "a `file:line` citation (in backticks, so I can jump there), what it does, and its sharpest risk if it has one. " +
+  "Hard limits: at most 7 lines, roughly 25 words each, no sub-bullets, no headings, no code snippets, no restating the diff. " +
+  "Merge related changes into one line. Skip filler like 'low risk' or 'mechanical change' — silence means fine. " +
+  "End with one line: where to spend my review time. If I want depth on a stop, I'll ask.";
 
 /** A fresh, closed chat panel for a new tab. */
 function emptyChatState(): ChatState {


### PR DESCRIPTION
User feedback on Brief me (tried on marrow#161): the output was accurate but *'A LOT of text… I feel exhausted just thinking about reading through all of that.'*

The old prompt asked for what/why/risks per change with no length discipline, which reliably yields a per-change essay. The new prompt keeps the value (ranked stops, clickable `file:line` citations, sharpest risk, where-to-spend-time) but enforces the shape:

- one-sentence TL;DR up top
- **one line per change**, most important first, ~25 words, **max 7 lines**
- no sub-bullets, headings, code snippets, or diff restating
- no 'low risk' filler — silence means fine
- ends with a single where-to-spend-review-time line; depth is a follow-up question away

One string change in `App.tsx`; `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)