### PR TITLE
fix(gui): resolve/unresolve failures now show an error toast

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1585,12 +1585,13 @@ function App() {
 
     try {
       await invoke<boolean>("toggle_thread_resolved", { threadId, resolve });
-    } catch {
-      // Revert on error
+    } catch (err) {
+      // Revert on error — and say so, or the button just looks dead (#72)
       updateTab(activeTabId,(t) => ({
         ...t,
         commentThreads: { status: "loaded", threads: prevThreads },
       }));
+      addToast("error", `Couldn't ${resolve ? "resolve" : "unresolve"} the thread: ${String(err)}`);
     }
   }
 


### PR DESCRIPTION
Closes #72. The `handleToggleResolved` catch silently reverted the optimistic update, making a failed `resolveReviewThread` mutation indistinguishable from a dead button. The revert now pairs with an error toast naming the action and the underlying error, matching the app's existing toast patterns.

`bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)