### PR TITLE
test: CI-annotation fixture for #61 (do not merge)

### DIFF
--- a/.github/workflows/annotation-fixture.yml
+++ b/.github/workflows/annotation-fixture.yml
@@ -1,0 +1,16 @@
+# Throwaway fixture for live-testing issue #61 (inline CI failure annotations).
+# Lives only on a draft PR that is closed unmerged — never on main.
+name: Annotation fixture
+on: pull_request
+jobs:
+  emit-annotations:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "::error file=README.md,line=214,title=Fixture assertion failed::Deliberate failing annotation on a diff line — expected 'marrow' to equal 'bone broth' (fixture for #61; stack trace excerpt line 1
+          fixture frame 2 at review.rs:42
+          fixture frame 3 at soup.rs:7)"
+          echo "::error file=README.md,line=215,title=Second fixture failure::Two annotations on nearby lines to exercise stacking and per-file counts"
+          echo "::error file=PUBLISHING.md,line=159,title=Cross-file fixture failure::Annotation in a second changed file for the sidebar badge"
+          echo "::warning file=README.md,line=3,title=Fixture warning::Warning-level annotation on an unchanged line (should appear in the card but not inline)"
+          exit 1

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -155,3 +155,5 @@ core rejects brand-new projects), the bare name `marrow` being free in core, and
 a **build-from-source** formula (`depends_on "rust"`; core doesn't ship our
 prebuilt binaries). Worth doing post-`0.1.0` once Marrow has some traction;
 until then the tap is the path.
+
+<!-- annotation fixture line C (#61 live test) -->

--- a/README.md
+++ b/README.md
@@ -210,3 +210,6 @@ Marrow began as [`rr`](rr), a standalone Bash script driving the same fetch/clas
 ## License
 
 MIT
+
+<!-- annotation fixture line A (#61 live test) -->
+<!-- annotation fixture line B -->


### PR DESCRIPTION
Throwaway fixture: emits file-anchored ::error/::warning check-run annotations against its own diff so the #61 feature branch can be live-tested against real Checks-API data. Will be closed unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)