### PR TITLE
feat: inline CI failure annotations on the diff (#61)

### DIFF
--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -293,6 +293,16 @@ fn parse_commit_diff_file(f: &serde_json::Value) -> CommitDiffFile {
     }
 }
 
+/// Conclusions whose runs are worth scanning for annotations: outright
+/// failures plus the attention states a step can reach after emitting
+/// annotations (`timed_out`, `action_required`). `cancelled` is deliberately
+/// excluded — a user-initiated stop's partial annotations are noise.
+fn failing_conclusion(conclusion: &str) -> bool {
+    conclusion.eq_ignore_ascii_case("failure")
+        || conclusion.eq_ignore_ascii_case("timed_out")
+        || conclusion.eq_ignore_ascii_case("action_required")
+}
+
 /// Parse one annotation from a check run's `GET
 /// .../check-runs/{id}/annotations` REST response. Only "failure" and
 /// "warning" levels are surfaced; "notice" is dropped. Missing or malformed
@@ -688,7 +698,7 @@ impl GithubClient {
     ) -> Result<CheckFailures, String> {
         const MAX_ANNOTATIONS: usize = 200;
 
-        let mut failed_runs: Vec<(u64, String)> = Vec::new();
+        let mut failed_runs: Vec<(u64, String, u64)> = Vec::new();
         let mut run_list_truncated = false;
         let mut page = 1u32;
 
@@ -717,7 +727,7 @@ impl GithubClient {
 
             for r in &runs {
                 let conclusion = r.get("conclusion").and_then(|v| v.as_str()).unwrap_or("");
-                if !conclusion.eq_ignore_ascii_case("failure") {
+                if !failing_conclusion(conclusion) {
                     continue;
                 }
 
@@ -734,7 +744,7 @@ impl GithubClient {
                     None => continue,
                 };
                 let name = r.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                failed_runs.push((id, name));
+                failed_runs.push((id, name, annotations_count));
             }
 
             page += 1;
@@ -750,10 +760,15 @@ impl GithubClient {
         let mut annotations: Vec<CheckAnnotation> = Vec::new();
         let mut truncated = run_list_truncated;
 
-        for (id, name) in &failed_runs {
+        for (id, name, annotations_count) in &failed_runs {
             if annotations.len() >= MAX_ANNOTATIONS {
                 truncated = true;
                 break;
+            }
+            // One page of 50 per run is a deliberate cap — but a run reporting
+            // more must not let the result claim completeness.
+            if *annotations_count > 50 {
+                truncated = true;
             }
 
             let url = format!(
@@ -2328,7 +2343,7 @@ pub struct CollectedActivity {
 
 #[cfg(test)]
 mod tests {
-    use super::{first_line, latest_viewer_review, parse_check_annotation, parse_pr_commit};
+    use super::{failing_conclusion, first_line, latest_viewer_review, parse_check_annotation, parse_pr_commit};
 
     #[test]
     fn first_line_extracts_headline_from_multi_line_message() {
@@ -2391,6 +2406,18 @@ mod tests {
         .unwrap();
 
         assert_eq!(parse_pr_commit(&c).committed_at, "2026-02-02T00:00:00Z");
+    }
+
+    #[test]
+    fn failing_conclusion_covers_attention_states_but_not_cancelled() {
+        assert!(failing_conclusion("failure"));
+        assert!(failing_conclusion("FAILURE"));
+        assert!(failing_conclusion("timed_out"));
+        assert!(failing_conclusion("action_required"));
+        assert!(!failing_conclusion("cancelled"));
+        assert!(!failing_conclusion("success"));
+        assert!(!failing_conclusion("neutral"));
+        assert!(!failing_conclusion(""));
     }
 
     #[test]

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -1,4 +1,4 @@
-use crate::types::{CheckRunInfo, CommentAuthor, CommitDiff, CommitDiffFile, MyReviewState, PrChecksStatus, PrCommit, PrFile, PrLabel, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
+use crate::types::{CheckAnnotation, CheckFailures, CheckRunInfo, CommentAuthor, CommitDiff, CommitDiffFile, MyReviewState, PrChecksStatus, PrCommit, PrFile, PrLabel, PrMetadata, ReactionGroup, ReviewComment, ReviewRequestItem, ReviewThread};
 use std::collections::HashMap;
 use base64::Engine;
 use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
@@ -291,6 +291,32 @@ fn parse_commit_diff_file(f: &serde_json::Value) -> CommitDiffFile {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string()),
     }
+}
+
+/// Parse one annotation from a check run's `GET
+/// .../check-runs/{id}/annotations` REST response. Only "failure" and
+/// "warning" levels are surfaced; "notice" is dropped. Missing or malformed
+/// required fields skip the annotation rather than erroring.
+fn parse_check_annotation(v: &serde_json::Value, check_name: &str) -> Option<CheckAnnotation> {
+    let path = v.get("path").and_then(|v| v.as_str())?.to_string();
+    let start_line = v.get("start_line").and_then(|v| v.as_u64())?;
+    let end_line = v.get("end_line").and_then(|v| v.as_u64())?;
+    let annotation_level = v.get("annotation_level").and_then(|v| v.as_str())?.to_string();
+    if annotation_level != "failure" && annotation_level != "warning" {
+        return None;
+    }
+    let message = v.get("message").and_then(|v| v.as_str())?.to_string();
+    let title = v.get("title").and_then(|v| v.as_str()).map(|s| s.to_string());
+
+    Some(CheckAnnotation {
+        path,
+        start_line,
+        end_line,
+        annotation_level,
+        message,
+        title,
+        check_name: check_name.to_string(),
+    })
 }
 
 /// Find the viewer's most recent submitted review (by `submittedAt`) from a
@@ -644,6 +670,118 @@ impl GithubClient {
             sha: sha.to_string(),
             message_headline,
             files: all_files,
+            truncated,
+        })
+    }
+
+    /// Inline annotations from the head commit's failed check runs. Only
+    /// runs with `conclusion == "failure"` and at least one reported
+    /// annotation are fetched. Each qualifying run's annotations are capped
+    /// at 50 (one page); total accumulation is capped at 200, with
+    /// `truncated` set when that cap is hit or a qualifying run couldn't be
+    /// fetched because the cap was already reached.
+    pub async fn get_check_annotations(
+        &self,
+        owner: &str,
+        repo: &str,
+        head_sha: &str,
+    ) -> Result<CheckFailures, String> {
+        const MAX_ANNOTATIONS: usize = 200;
+
+        let mut failed_runs: Vec<(u64, String)> = Vec::new();
+        let mut run_list_truncated = false;
+        let mut page = 1u32;
+
+        loop {
+            let url = format!(
+                "https://api.github.com/repos/{}/{}/commits/{}/check-runs?per_page=100&page={}",
+                owner, repo, head_sha, page
+            );
+
+            let resp = self.send_checked(&url, "application/vnd.github.v3+json").await?;
+
+            let body: serde_json::Value = resp
+                .json()
+                .await
+                .map_err(|e| format!("Failed to parse check runs: {}", e))?;
+
+            let runs = body
+                .get("check_runs")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+
+            if runs.is_empty() {
+                break;
+            }
+
+            for r in &runs {
+                let conclusion = r.get("conclusion").and_then(|v| v.as_str()).unwrap_or("");
+                if !conclusion.eq_ignore_ascii_case("failure") {
+                    continue;
+                }
+
+                let annotations_count = r
+                    .pointer("/output/annotations_count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+                if annotations_count == 0 {
+                    continue;
+                }
+
+                let id = match r.get("id").and_then(|v| v.as_u64()) {
+                    Some(id) => id,
+                    None => continue,
+                };
+                let name = r.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                failed_runs.push((id, name));
+            }
+
+            page += 1;
+
+            // Safety: don't paginate forever. Runs past this point are
+            // dropped, so the result must say so.
+            if page > 30 {
+                run_list_truncated = true;
+                break;
+            }
+        }
+
+        let mut annotations: Vec<CheckAnnotation> = Vec::new();
+        let mut truncated = run_list_truncated;
+
+        for (id, name) in &failed_runs {
+            if annotations.len() >= MAX_ANNOTATIONS {
+                truncated = true;
+                break;
+            }
+
+            let url = format!(
+                "https://api.github.com/repos/{}/{}/check-runs/{}/annotations?per_page=50",
+                owner, repo, id
+            );
+
+            let resp = self.send_checked(&url, "application/vnd.github.v3+json").await?;
+
+            let items: Vec<serde_json::Value> = resp
+                .json()
+                .await
+                .map_err(|e| format!("Failed to parse check annotations: {}", e))?;
+
+            for item in &items {
+                if annotations.len() >= MAX_ANNOTATIONS {
+                    truncated = true;
+                    break;
+                }
+                if let Some(a) = parse_check_annotation(item, name) {
+                    annotations.push(a);
+                }
+            }
+        }
+
+        Ok(CheckFailures {
+            head_sha: head_sha.to_string(),
+            annotations,
             truncated,
         })
     }
@@ -2190,7 +2328,7 @@ pub struct CollectedActivity {
 
 #[cfg(test)]
 mod tests {
-    use super::{first_line, latest_viewer_review, parse_pr_commit};
+    use super::{first_line, latest_viewer_review, parse_check_annotation, parse_pr_commit};
 
     #[test]
     fn first_line_extracts_headline_from_multi_line_message() {
@@ -2263,5 +2401,67 @@ mod tests {
         .unwrap();
 
         assert_eq!(parse_pr_commit(&c).committed_at, "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn parse_check_annotation_parses_all_fields() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"path": "src/main.rs", "start_line": 10, "end_line": 12, "annotation_level": "failure", "message": "unused variable", "title": "clippy"}"#,
+        )
+        .unwrap();
+
+        let parsed = parse_check_annotation(&a, "clippy-check").unwrap();
+        assert_eq!(parsed.path, "src/main.rs");
+        assert_eq!(parsed.start_line, 10);
+        assert_eq!(parsed.end_line, 12);
+        assert_eq!(parsed.annotation_level, "failure");
+        assert_eq!(parsed.message, "unused variable");
+        assert_eq!(parsed.title, Some("clippy".to_string()));
+        assert_eq!(parsed.check_name, "clippy-check");
+    }
+
+    #[test]
+    fn parse_check_annotation_null_title_becomes_none() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"path": "src/main.rs", "start_line": 10, "end_line": 12, "annotation_level": "warning", "message": "msg", "title": null}"#,
+        )
+        .unwrap();
+
+        assert_eq!(parse_check_annotation(&a, "check").unwrap().title, None);
+    }
+
+    #[test]
+    fn parse_check_annotation_missing_start_line_is_skipped() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"path": "src/main.rs", "end_line": 12, "annotation_level": "failure", "message": "msg"}"#,
+        )
+        .unwrap();
+
+        assert!(parse_check_annotation(&a, "check").is_none());
+    }
+
+    #[test]
+    fn parse_check_annotation_drops_notice_level() {
+        let a: serde_json::Value = serde_json::from_str(
+            r#"{"path": "src/main.rs", "start_line": 1, "end_line": 1, "annotation_level": "notice", "message": "msg"}"#,
+        )
+        .unwrap();
+
+        assert!(parse_check_annotation(&a, "check").is_none());
+    }
+
+    #[test]
+    fn parse_check_annotation_keeps_failure_and_warning_levels() {
+        let failure: serde_json::Value = serde_json::from_str(
+            r#"{"path": "a.rs", "start_line": 1, "end_line": 1, "annotation_level": "failure", "message": "msg"}"#,
+        )
+        .unwrap();
+        let warning: serde_json::Value = serde_json::from_str(
+            r#"{"path": "a.rs", "start_line": 1, "end_line": 1, "annotation_level": "warning", "message": "msg"}"#,
+        )
+        .unwrap();
+
+        assert!(parse_check_annotation(&failure, "check").is_some());
+        assert!(parse_check_annotation(&warning, "check").is_some());
     }
 }

--- a/app/src-tauri/crates/core/src/github.rs
+++ b/app/src-tauri/crates/core/src/github.rs
@@ -684,8 +684,9 @@ impl GithubClient {
         })
     }
 
-    /// Inline annotations from the head commit's failed check runs. Only
-    /// runs with `conclusion == "failure"` and at least one reported
+    /// Inline annotations from the head commit's failed check runs. Runs with
+    /// an attention conclusion (see `failing_conclusion`: failure, timed_out,
+    /// action_required) and at least one reported
     /// annotation are fetched. Each qualifying run's annotations are capped
     /// at 50 (one page); total accumulation is capped at 200, with
     /// `truncated` set when that cap is hit or a qualifying run couldn't be

--- a/app/src-tauri/crates/core/src/types.rs
+++ b/app/src-tauri/crates/core/src/types.rs
@@ -409,6 +409,25 @@ pub struct PrChecksStatus {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CheckAnnotation {
+    pub path: String,
+    pub start_line: u64,
+    pub end_line: u64,
+    pub annotation_level: String,
+    pub message: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    pub check_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct CheckFailures {
+    pub head_sha: String,
+    pub annotations: Vec<CheckAnnotation>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ReviewRequestItem {
     pub owner: String,
     pub repo: String,

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -5,7 +5,7 @@ use marrow_core::chat_history::{self, StoredChat};
 use marrow_core::config::{load_settings, resolve_github_token, save_settings_to_disk};
 use marrow_core::fetch::fetch_pr_impl;
 use marrow_core::github::GithubClient;
-use marrow_core::types::{CommitDiff, MyReviewState, PrChecksStatus, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
+use marrow_core::types::{CheckFailures, CommitDiff, MyReviewState, PrChecksStatus, PrUpdateStatus, ReviewComment, ReviewManifest, ReviewRequestItem, ReviewThread, Settings};
 use marrow_core::manifest_cache::{self, CachedPrInfo};
 use marrow_core::session::{self, SessionState};
 use marrow_core::dismissed_highlights::{self, DismissedHighlights};
@@ -445,6 +445,15 @@ pub async fn get_commit_diff(pr_ref: String, sha: String) -> Result<CommitDiff, 
     let github = github_client();
     let parsed = marrow_core::pr_parser::parse_pr_ref(&pr_ref)?;
     github.get_commit_diff(&parsed.owner, &parsed.repo, &sha).await
+}
+
+/// Inline annotations from the head commit's failed check runs, fetched on
+/// demand when the CI failures view opens.
+#[command]
+pub async fn get_check_annotations(pr_ref: String, head_sha: String) -> Result<CheckFailures, String> {
+    let github = github_client();
+    let parsed = marrow_core::pr_parser::parse_pr_ref(&pr_ref)?;
+    github.get_check_annotations(&parsed.owner, &parsed.repo, &head_sha).await
 }
 
 #[command]

--- a/app/src-tauri/src/commands.rs
+++ b/app/src-tauri/src/commands.rs
@@ -447,6 +447,15 @@ pub async fn get_commit_diff(pr_ref: String, sha: String) -> Result<CommitDiff, 
     github.get_commit_diff(&parsed.owner, &parsed.repo, &sha).await
 }
 
+/// One file's contents at a ref, fetched on demand for jump targets in files
+/// whose contents weren't part of the manifest (e.g. NOT_RELEVANT files).
+#[command]
+pub async fn get_file_content(pr_ref: String, path: String, ref_sha: String) -> Result<String, String> {
+    let github = github_client();
+    let parsed = marrow_core::pr_parser::parse_pr_ref(&pr_ref)?;
+    github.get_file_content(&parsed.owner, &parsed.repo, &path, &ref_sha).await
+}
+
 /// Inline annotations from the head commit's failed check runs, fetched on
 /// demand when the CI failures view opens.
 #[command]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -241,6 +241,7 @@ pub fn run() {
             commands::toggle_thread_resolved,
             commands::get_my_review_state,
             commands::get_commit_diff,
+            commands::get_check_annotations,
             commands::submit_review,
             commands::generate_review_body,
             commands::update_review_comment,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -242,6 +242,7 @@ pub fn run() {
             commands::get_my_review_state,
             commands::get_commit_diff,
             commands::get_check_annotations,
+            commands::get_file_content,
             commands::submit_review,
             commands::generate_review_body,
             commands::update_review_comment,

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1068,11 +1068,15 @@ function App() {
     if (!target) return;
     if (line != null && target.path === tab.selectedFile?.path) {
       // Already viewing the file — the mounted DiffViewer can jump directly.
-      diffViewerRef.current?.revealLine(line);
+      if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
       return;
     }
     pendingRevealLineRef.current = line ?? null;
     setSelectedFile(target);
+  }
+
+  function notifyLineOutsideDiff(line: number) {
+    addToast("info", `Line ${line} isn't part of this PR's changes — the annotation targets unchanged code.`);
   }
 
   /** Line to reveal once the DiffViewer for a newly-selected file mounts —
@@ -1083,7 +1087,9 @@ function App() {
     if (line == null) return;
     pendingRevealLineRef.current = null;
     // Next frame, so the fresh DiffViewer instance has attached its ref.
-    requestAnimationFrame(() => diffViewerRef.current?.revealLine(line));
+    requestAnimationFrame(() => {
+      if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
+    });
   }, [selectedFilePath]);
 
   // Set by briefMe below; consumed once the chat-open/whole-PR state it just

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -27,7 +27,7 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution, PrCommit, CommitDiff } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey } from "./utils";
 import type { ReviewSession } from "./hooks/useActivityFeed";
 
@@ -236,6 +236,28 @@ function App() {
     [searchMatches, searchCurrentIndex, selectedFilePath]
   );
 
+  // Inline CI failure annotations for the active tab, once loaded (see the
+  // fetch effect above) — grouped by path so the sidebar badge and the diff
+  // pane's inline markers are cheap lookups.
+  const annotationsByPath = useMemo(() => {
+    if (activeTab?.checkAnnotations.status !== "loaded") return null;
+    const map = new Map<string, CheckAnnotation[]>();
+    for (const a of activeTab.checkAnnotations.failures.annotations) {
+      const arr = map.get(a.path);
+      if (arr) arr.push(a); else map.set(a.path, [a]);
+    }
+    return map;
+  }, [activeTab?.checkAnnotations]);
+  const checkFailureCounts = useMemo(() => {
+    const map = new Map<string, number>();
+    if (annotationsByPath) {
+      for (const [path, anns] of annotationsByPath) map.set(path, anns.length);
+    }
+    return map;
+  }, [annotationsByPath]);
+  const selectedFileAnnotations = (selectedFilePath && annotationsByPath?.get(selectedFilePath)) || [];
+  const activeCheckFailures = activeTab?.checkAnnotations.status === "loaded" ? activeTab.checkAnnotations.failures : null;
+
   // Opening from the "Recently analyzed" cache: if the PR's head moved, the
   // backend would silently run a full AI re-analysis — surface that first.
   async function handleOpenCachedPr(prRef: string, info: CachedPrInfo) {
@@ -422,6 +444,7 @@ function App() {
       noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
+      checkAnnotations: { status: "idle" },
       commentsOpen: false,
       sidebarView: hasGroups ? "groups" : "category",
       isRefreshing: false,
@@ -448,6 +471,7 @@ function App() {
       noteResolutions: new Map(),
       chat: emptyChatState(),
       commentThreads: { status: "idle" },
+      checkAnnotations: { status: "idle" },
       commentsOpen: false,
       sidebarView: "category",
       isRefreshing: false,
@@ -1028,19 +1052,39 @@ function App() {
     updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, includeWholePr: value } }));
   }
 
-  /** Resolve a file mention from the chat (exact path, or a unique suffix
-   * match against the manifest) and select it. No absolute-line scroll API
-   * exists on DiffViewerHandle (only relative cursor movement), so this is a
-   * file-level jump only — the line number is accepted but unused. */
-  function handleChatOpenFile(path: string, _line?: number) {
+  /** Resolve a file mention (exact path, or a unique suffix match against the
+   * manifest), select it, and reveal the given head line — expanding its hunk
+   * if collapsed. Serves chat citations, top-risk rows, and check-failure rows. */
+  function handleChatOpenFile(path: string, line?: number) {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
     const files = tab.manifest.files;
-    const exact = files.find((f) => f.path === path);
-    if (exact) { setSelectedFile(exact); return; }
-    const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
-    if (suffixMatches.length === 1) setSelectedFile(suffixMatches[0]);
+    const target =
+      files.find((f) => f.path === path) ??
+      (() => {
+        const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
+        return suffixMatches.length === 1 ? suffixMatches[0] : undefined;
+      })();
+    if (!target) return;
+    if (line != null && target.path === tab.selectedFile?.path) {
+      // Already viewing the file — the mounted DiffViewer can jump directly.
+      diffViewerRef.current?.revealLine(line);
+      return;
+    }
+    pendingRevealLineRef.current = line ?? null;
+    setSelectedFile(target);
   }
+
+  /** Line to reveal once the DiffViewer for a newly-selected file mounts —
+   * the viewer remounts per file (key={path}), so the jump must wait for it. */
+  const pendingRevealLineRef = useRef<number | null>(null);
+  useEffect(() => {
+    const line = pendingRevealLineRef.current;
+    if (line == null) return;
+    pendingRevealLineRef.current = null;
+    // Next frame, so the fresh DiffViewer instance has attached its ref.
+    requestAnimationFrame(() => diffViewerRef.current?.revealLine(line));
+  }, [selectedFilePath]);
 
   // Set by briefMe below; consumed once the chat-open/whole-PR state it just
   // requested has actually committed (handleChatSend reads tabsRef, which
@@ -1269,6 +1313,9 @@ function App() {
               ? newManifest.files.find((f) => f.path === tab.selectedFile!.path) ?? null
               : newManifest.files[0] ?? null,
         commentThreads: { status: "idle" },
+        // A refresh can land on a new head_sha, invalidating any annotations
+        // fetched for the old one — re-fetch is driven by the idle-state effect.
+        checkAnnotations: { status: "idle" },
         newHighlightKeys,
       };
 
@@ -1938,6 +1985,33 @@ function App() {
     return () => clearInterval(interval);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Fetch inline CI failure annotations for the active tab once its checks are
+  // loaded with at least one failing run — GraphQL conclusions arrive UPPERCASE
+  // (see the CiChip comment in PrOverview). Guarded by tab id + head_sha so a
+  // stale resolve (tab closed, or refreshed onto a new head in the meantime)
+  // never lands on the wrong state.
+  useEffect(() => {
+    if (!activeTab?.manifest) return;
+    if (activeTab.checkAnnotations.status !== "idle") return;
+    if (!activeChecks) return;
+    const hasFailure = activeChecks.check_runs.some((c) => c.conclusion === "FAILURE");
+    if (!hasFailure) return;
+
+    const tabId = activeTab.id;
+    const prRef = activeTab.manifest.pr_url;
+    const headSha = activeTab.manifest.head_sha;
+
+    updateTab(tabId, (t) => (t.checkAnnotations.status === "idle" ? { ...t, checkAnnotations: { status: "loading" } } : t));
+
+    invoke<CheckFailures>("get_check_annotations", { prRef, headSha })
+      .then((failures) => {
+        updateTab(tabId, (t) => (t.manifest && t.manifest.head_sha === headSha ? { ...t, checkAnnotations: { status: "loaded", failures } } : t));
+      })
+      .catch((err) => {
+        updateTab(tabId, (t) => (t.manifest && t.manifest.head_sha === headSha ? { ...t, checkAnnotations: { status: "error", message: String(err) } } : t));
+      });
+  }, [activeTab?.id, activeTab?.manifest?.pr_url, activeTab?.manifest?.head_sha, activeTab?.checkAnnotations.status, activeChecks]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Floating mini-player visibility:
   //  - HIDE it whenever the MAIN window gains focus (you've engaged the app).
   //    Interacting with the floating panel focuses the panel, not the main
@@ -2312,6 +2386,7 @@ function App() {
             <PrOverview
               manifest={activeTab.manifest}
               checksStatus={activeChecks ?? null}
+              checkFailures={activeCheckFailures}
               reviewState={activeTab.myReviewState ?? null}
               viewedCount={activeTab.viewedFiles.size}
               unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
@@ -2346,6 +2421,7 @@ function App() {
             sidebarView={activeTab.sidebarView}
             onViewChange={handleViewChange}
             commentThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : []}
+            checkFailureCounts={checkFailureCounts}
             commentsOpen={activeTab.commentsOpen ?? false}
             onToggleComments={toggleThreadsView}
             onVisibleFilesChange={handleVisibleFilesChange}
@@ -2362,7 +2438,7 @@ function App() {
                 const next = nextUnviewed(order, idx, activeTab.selectedFile.path);
                 return (
                   <>
-                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} newHighlightKeys={activeTab.newHighlightKeys} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
+                    <DiffViewer ref={diffViewerRef} key={activeTab.selectedFile.path} file={activeTab.selectedFile} viewMode={viewMode} onViewModeChange={setViewMode} showHunkSignificance={showHunkSignificance} showAiNotes={showAiNotes} expandAllHunks={expandAllHunks} dismissedHighlights={activeTab.dismissedHighlights} noteResolutions={activeTab.noteResolutions} newHighlightKeys={activeTab.newHighlightKeys} onResolveHighlight={resolveHighlight} onRestoreHighlight={restoreHighlight} onCreateComment={handleCreateComment} onEditComment={handleEditComment} onReply={handleReply} onToggleResolved={handleToggleResolved} onToggleReaction={handleToggleReaction} reviewThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads : undefined} checkAnnotations={selectedFileAnnotations} searchMatches={fileSearchMatches} currentSearchMatch={currentSearchMatch} searchQuery={searchQuery} />
                     <NextFileBar
                       index={idx >= 0 ? idx : 0}
                       total={order.length}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1055,18 +1055,48 @@ function App() {
   /** Resolve a file mention (exact path, or a unique suffix match against the
    * manifest), select it, and reveal the given head line — expanding its hunk
    * if collapsed. Serves chat citations, top-risk rows, and check-failure rows. */
-  function handleChatOpenFile(path: string, line?: number) {
+  async function handleChatOpenFile(path: string, line?: number) {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
     const files = tab.manifest.files;
-    const target =
+    let target =
       files.find((f) => f.path === path) ??
       (() => {
         const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
         return suffixMatches.length === 1 ? suffixMatches[0] : undefined;
       })();
     if (!target) return;
-    if (line != null && target.path === tab.selectedFile?.path) {
+    if (line != null && !target.head_content && target.diff_type !== "removed") {
+      // Jump targets in files whose contents weren't fetched at analysis time
+      // (NOT_RELEVANT files): pull the head version on demand so the whole-file
+      // fallback in revealLine has something to show, and remember it on the
+      // manifest for the rest of the session.
+      const tabId = tab.id;
+      try {
+        const content = await invoke<string>("get_file_content", {
+          prRef: tab.manifest.pr_url,
+          path: target.path,
+          refSha: tab.manifest.head_sha,
+        });
+        const patched = { ...target, head_content: content };
+        updateTab(tabId, (t) =>
+          t.manifest
+            ? {
+                ...t,
+                manifest: {
+                  ...t.manifest,
+                  files: t.manifest.files.map((f) => (f.path === patched.path ? patched : f)),
+                },
+              }
+            : t
+        );
+        target = patched;
+      } catch {
+        // Content unavailable (deleted path, network) — fall through; the
+        // reveal will report honestly.
+      }
+    }
+    if (line != null && target.path === tab.selectedFile?.path && target.head_content === tab.selectedFile?.head_content) {
       // Already viewing the file — the mounted DiffViewer can jump directly.
       if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
       return;
@@ -1076,7 +1106,7 @@ function App() {
   }
 
   function notifyLineOutsideDiff(line: number) {
-    addToast("info", `Line ${line} isn't part of this PR's changes — the annotation targets unchanged code.`);
+    addToast("info", `Line ${line} doesn't exist in this file's current version.`);
   }
 
   /** Line to reveal once the DiffViewer for a newly-selected file mounts —

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -159,8 +159,9 @@ export interface DiffViewerHandle {
    * when the thread isn't rendered in this file (e.g. the diff hasn't
    * mounted it yet) so the caller can retry. */
   scrollToThread: (threadId: string, expandIfHidden?: boolean) => boolean;
-  /** Expand the hunk containing a head line (if collapsed) and scroll to it. */
-  revealLine: (line: number) => void;
+  /** Expand the hunk containing a head line (if collapsed) and scroll to it.
+   * Returns false when the line isn't part of the diff (unchanged code). */
+  revealLine: (line: number) => boolean;
 }
 
 /** Small keyboard-driven reply box, shown when `r` is pressed on a thread line. */
@@ -1714,8 +1715,10 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   }
 
   // Un-collapse the hunk containing `line` so it renders, then queue a scroll to
-  // it. Shared by the AI-note composer and finding navigation.
-  function revealLine(line: number) {
+  // it. Shared by the AI-note composer and finding navigation. Returns whether
+  // the line is part of the rendered diff at all — a jump target from an
+  // external source (CI annotation, chat citation) may point at unchanged code.
+  function revealLine(line: number): boolean {
     const hunk = hunks.find((h) =>
       h.lines.some((l) => l.newLineNum === line || l.oldLineNum === line),
     );
@@ -1727,6 +1730,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
       });
     }
     setPendingScroll(`diff-line-${line}`);
+    return hunk != null;
   }
 
   function handlePostHighlightAsComment(h: Highlight) {

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -159,8 +159,9 @@ export interface DiffViewerHandle {
    * when the thread isn't rendered in this file (e.g. the diff hasn't
    * mounted it yet) so the caller can retry. */
   scrollToThread: (threadId: string, expandIfHidden?: boolean) => boolean;
-  /** Expand the hunk containing a head line (if collapsed) and scroll to it.
-   * Returns false when the line isn't part of the diff (unchanged code). */
+  /** Reveal a head line: expand its hunk, or switch to the whole-file view when
+   * the line is unchanged code. Returns false when it can't be shown at all
+   * (no head content, or the line is beyond the file's current end). */
   revealLine: (line: number) => boolean;
 }
 
@@ -1715,22 +1716,32 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
   }
 
   // Un-collapse the hunk containing `line` so it renders, then queue a scroll to
-  // it. Shared by the AI-note composer and finding navigation. Returns whether
-  // the line is part of the rendered diff at all — a jump target from an
-  // external source (CI annotation, chat citation) may point at unchanged code.
+  // it. Shared by the AI-note composer and finding navigation. A jump target
+  // from an external source (CI annotation, chat citation) may point at
+  // unchanged code — fall back to the whole-file view so the line can still be
+  // shown. Returns false only when the line can't be displayed at all.
   function revealLine(line: number): boolean {
     const hunk = hunks.find((h) =>
       h.lines.some((l) => l.newLineNum === line || l.oldLineNum === line),
     );
-    if (hunk && collapsedHunks.has(hunk.index)) {
-      setCollapsedHunks((prev) => {
-        const next = new Set(prev);
-        next.delete(hunk.index);
-        return next;
-      });
+    if (hunk) {
+      if (collapsedHunks.has(hunk.index)) {
+        setCollapsedHunks((prev) => {
+          const next = new Set(prev);
+          next.delete(hunk.index);
+          return next;
+        });
+      }
+      setPendingScroll(`diff-line-${line}`);
+      return true;
     }
-    setPendingScroll(`diff-line-${line}`);
-    return hunk != null;
+    const headLines = file.head_content ? file.head_content.split("\n").length : 0;
+    if (line > 0 && line <= headLines) {
+      setFullFile(true);
+      setPendingScroll(`diff-line-${line}`);
+      return true;
+    }
+    return false;
   }
 
   function handlePostHighlightAsComment(h: Highlight) {

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -990,6 +990,13 @@ function CheckAnnotationMarker({ annotation }: { annotation: CheckAnnotation }) 
           <span className="check-annotation-name">{annotation.check_name}</span>
           <span className="check-annotation-sep">&mdash;</span>
           <span className="check-annotation-title">{subtitle}</span>
+          {annotation.end_line > annotation.start_line && (
+            // Multi-line annotations anchor once, above their last line — say
+            // which lines they actually span.
+            <span className="check-annotation-range">
+              L{annotation.start_line}&ndash;{annotation.end_line}
+            </span>
+          )}
         </div>
         <pre className={`check-annotation-message${!expanded && isLong ? " check-annotation-message-collapsed" : ""}`}>
           {annotation.message}

--- a/app/src/components/DiffViewer.tsx
+++ b/app/src/components/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import { Fragment, createContext, forwardRef, memo, useContext, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import hljs from "highlight.js";
 import "highlight.js/styles/github-dark.css";
-import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch, NoteResolution } from "../types";
+import type { FileDiff, DiffViewMode, Highlight, ReactionGroup, ReviewThread, ReviewComment, SearchMatch, NoteResolution, CheckAnnotation } from "../types";
 import { timeAgo, highlightKey } from "../utils";
 import { RichText } from "./RichText";
 
@@ -122,6 +122,8 @@ interface DiffViewerProps {
   onToggleResolved?: (threadId: string, resolve: boolean) => void;
   onToggleReaction?: (commentId: string, content: string) => void;
   reviewThreads?: ReviewThread[];
+  /** Inline CI failure annotations for this file, from a loaded CheckFailures. */
+  checkAnnotations?: CheckAnnotation[];
   searchMatches?: SearchMatch[];
   currentSearchMatch?: SearchMatch | null;
   searchQuery?: string;
@@ -157,6 +159,8 @@ export interface DiffViewerHandle {
    * when the thread isn't rendered in this file (e.g. the diff hasn't
    * mounted it yet) so the caller can retry. */
   scrollToThread: (threadId: string, expandIfHidden?: boolean) => boolean;
+  /** Expand the hunk containing a head line (if collapsed) and scroll to it. */
+  revealLine: (line: number) => void;
 }
 
 /** Small keyboard-driven reply box, shown when `r` is pressed on a thread line. */
@@ -967,6 +971,53 @@ function HighlightMarker({ highlight, isNew, onPostAsComment }: { highlight: Hig
   );
 }
 
+/** A single failing-check annotation, rendered inline above the line it
+ * anchors to. Read-only besides expand/collapse of a long message — no
+ * dismiss/resolve/comment (issue #61 is CI signal, not a reviewer note). */
+function CheckAnnotationMarker({ annotation }: { annotation: CheckAnnotation }) {
+  const [expanded, setExpanded] = useState(false);
+  const firstLine = annotation.message.split("\n")[0] ?? "";
+  const subtitle = annotation.title ?? firstLine;
+  const isLong = annotation.message.split("\n").length > 3;
+
+  return (
+    <div className="check-annotation">
+      <span className="check-annotation-icon" aria-hidden="true">&#10007;</span>
+      <div className="check-annotation-body">
+        <div className="check-annotation-header">
+          <span className="check-annotation-name">{annotation.check_name}</span>
+          <span className="check-annotation-sep">&mdash;</span>
+          <span className="check-annotation-title">{subtitle}</span>
+        </div>
+        <pre className={`check-annotation-message${!expanded && isLong ? " check-annotation-message-collapsed" : ""}`}>
+          {annotation.message}
+        </pre>
+        {isLong && (
+          <button
+            type="button"
+            className="check-annotation-toggle"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Annotations keyed by the head-side line (`end_line`) they anchor to — a
+ * line can carry more than one (e.g. two failing checks on the same line). */
+function buildAnnotationsByLine(annotations: CheckAnnotation[] | undefined): Map<number, CheckAnnotation[]> {
+  const map = new Map<number, CheckAnnotation[]>();
+  for (const a of annotations ?? []) {
+    const arr = map.get(a.end_line);
+    if (arr) arr.push(a);
+    else map.set(a.end_line, [a]);
+  }
+  return map;
+}
+
 // ── Hunk grouping ────────────────────────────────────────────────────────
 
 interface Hunk {
@@ -1046,6 +1097,7 @@ function UnifiedHunkLines({
   onSubmitComment,
   onCancelComment,
   reviewThreads,
+  checkAnnotations,
   onEditComment,
   onReply,
   onToggleResolved,
@@ -1065,6 +1117,7 @@ function UnifiedHunkLines({
   onSubmitComment?: (body: string) => void;
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
+  checkAnnotations?: CheckAnnotation[];
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved?: (threadId: string, resolve: boolean) => void;
@@ -1073,6 +1126,7 @@ function UnifiedHunkLines({
   lang?: string;
 }) {
   const threadsByLine = useMemo(() => buildThreadsByLine(reviewThreads), [reviewThreads]);
+  const annotationsByLine = useMemo(() => buildAnnotationsByLine(checkAnnotations), [checkAnnotations]);
 
   return (
     <>
@@ -1112,6 +1166,9 @@ function UnifiedHunkLines({
         const lineRange = isEndOfSelection && commentingOn && commentingOn.startLine !== commentingOn.endLine
           ? `L${commentingOn.startLine}-L${commentingOn.endLine}`
           : undefined;
+        // Annotations anchor strictly on the head line number (end_line) — a
+        // pure removal (no newLineNum) never carries one.
+        const lineAnnotations = line.newLineNum != null ? (annotationsByLine.get(line.newLineNum) ?? []) : [];
 
         return (
           <Fragment key={idx}>
@@ -1119,6 +1176,15 @@ function UnifiedHunkLines({
               <tr className="highlight-row">
                 <td colSpan={4}>
                   <HighlightMarker highlight={hlStart} isNew={newHighlights?.has(hlStart)} onPostAsComment={onPostHighlightAsComment} />
+                </td>
+              </tr>
+            )}
+            {lineAnnotations.length > 0 && (
+              <tr className="check-annotation-row">
+                <td colSpan={4}>
+                  {lineAnnotations.map((a, i) => (
+                    <CheckAnnotationMarker key={i} annotation={a} />
+                  ))}
                 </td>
               </tr>
             )}
@@ -1193,6 +1259,7 @@ function UnifiedView({
   onSubmitComment,
   onCancelComment,
   reviewThreads,
+  checkAnnotations,
   onEditComment,
   onReply,
   onToggleResolved,
@@ -1214,6 +1281,7 @@ function UnifiedView({
   onSubmitComment?: (body: string) => void;
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
+  checkAnnotations?: CheckAnnotation[];
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved?: (threadId: string, resolve: boolean) => void;
@@ -1282,13 +1350,13 @@ function UnifiedView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} checkAnnotations={checkAnnotations} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <UnifiedHunkLines lines={hunk.lines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} checkAnnotations={checkAnnotations} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -1312,6 +1380,7 @@ function SplitHunkLines({
   onSubmitComment,
   onCancelComment,
   reviewThreads,
+  checkAnnotations,
   onEditComment,
   onReply,
   onToggleResolved,
@@ -1331,6 +1400,7 @@ function SplitHunkLines({
   onSubmitComment?: (body: string) => void;
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
+  checkAnnotations?: CheckAnnotation[];
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved?: (threadId: string, resolve: boolean) => void;
@@ -1339,6 +1409,7 @@ function SplitHunkLines({
   lang?: string;
 }) {
   const threadsByLine = useMemo(() => buildThreadsByLine(reviewThreads), [reviewThreads]);
+  const annotationsByLine = useMemo(() => buildAnnotationsByLine(checkAnnotations), [checkAnnotations]);
 
   return (
     <>
@@ -1391,6 +1462,9 @@ function SplitHunkLines({
         const lineThreads = rightLine === leftLine
           ? leftThreads
           : [...leftThreads, ...rightThreads.filter(t => !leftThreads.some(lt => lt.id === t.id))];
+        // Annotations anchor strictly on the head line number (end_line) — a
+        // pure removal (no right side) never carries one.
+        const lineAnnotations = pair.right?.newLineNum != null ? (annotationsByLine.get(pair.right.newLineNum) ?? []) : [];
 
         return (
           <Fragment key={idx}>
@@ -1398,6 +1472,15 @@ function SplitHunkLines({
               <tr className="highlight-row">
                 <td colSpan={4}>
                   <HighlightMarker highlight={hlStart} isNew={newHighlights?.has(hlStart)} onPostAsComment={onPostHighlightAsComment} />
+                </td>
+              </tr>
+            )}
+            {lineAnnotations.length > 0 && (
+              <tr className="check-annotation-row">
+                <td colSpan={4}>
+                  {lineAnnotations.map((a, i) => (
+                    <CheckAnnotationMarker key={i} annotation={a} />
+                  ))}
                 </td>
               </tr>
             )}
@@ -1474,6 +1557,7 @@ function SplitView({
   onSubmitComment,
   onCancelComment,
   reviewThreads,
+  checkAnnotations,
   onEditComment,
   onReply,
   onToggleResolved,
@@ -1495,6 +1579,7 @@ function SplitView({
   onSubmitComment?: (body: string) => void;
   onCancelComment?: () => void;
   reviewThreads?: ReviewThread[];
+  checkAnnotations?: CheckAnnotation[];
   onEditComment?: (commentId: string, body: string) => void;
   onReply?: (threadId: string, commentId: string, body: string) => void;
   onToggleResolved?: (threadId: string, resolve: boolean) => void;
@@ -1566,13 +1651,13 @@ function SplitView({
                         <col />
                       </colgroup>
                       <tbody>
-                        <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                        <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} checkAnnotations={checkAnnotations} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
                       </tbody>
                     </table>
                   </td>
                 </tr>
               ) : (
-                <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
+                <SplitHunkLines splitLines={splitLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onLineMouseDown} onLineMouseEnter={onLineMouseEnter} onLineMouseUp={onLineMouseUp} onSubmitComment={onSubmitComment} onCancelComment={onCancelComment} reviewThreads={reviewThreads} checkAnnotations={checkAnnotations} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onPostHighlightAsComment} lang={lang} />
               )}
             </Fragment>
           );
@@ -1584,7 +1669,7 @@ function SplitView({
 
 // ── Main DiffViewer ──────────────────────────────────────────────────────
 
-export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, expandAllHunks, dismissedHighlights, noteResolutions, newHighlightKeys, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
+export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function DiffViewer({ file, viewMode, onViewModeChange, showHunkSignificance, showAiNotes, expandAllHunks, dismissedHighlights, noteResolutions, newHighlightKeys, onResolveHighlight, onRestoreHighlight, onCreateComment, onEditComment, onReply, onToggleResolved, onToggleReaction, reviewThreads, checkAnnotations, searchMatches, currentSearchMatch: currentMatchInFile, searchQuery }: DiffViewerProps, ref) {
   const [commentingOn, setCommentingOn] = useState<CommentingOn | null>(null);
   const [dragging, setDragging] = useState<{ anchorLine: number; side: "LEFT" | "RIGHT"; currentLine: number } | null>(null);
   // "View full file" toggle (modified files). Resets per file via the key prop.
@@ -2268,6 +2353,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
     nextHunk, prevHunk, foldAll,
     cursorMove, cursorEdge, cursorPage, nextFinding, prevFinding, foldAtCursor,
     commentAtCursor, toggleAnchor, replyAtCursor, resolveAtCursor, scrollToThread,
+    revealLine,
   }));
 
   return (
@@ -2403,6 +2489,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
               onSubmitComment={handleSubmitComment}
               onCancelComment={handleCancelComment}
               reviewThreads={fileThreads}
+              checkAnnotations={checkAnnotations}
               onEditComment={onEditComment}
               onReply={onReply}
               onToggleResolved={onToggleResolved}
@@ -2426,6 +2513,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
               onSubmitComment={handleSubmitComment}
               onCancelComment={handleCancelComment}
               reviewThreads={fileThreads}
+              checkAnnotations={checkAnnotations}
               onEditComment={onEditComment}
               onReply={onReply}
               onToggleResolved={onToggleResolved}
@@ -2443,7 +2531,7 @@ export const DiffViewer = forwardRef<DiffViewerHandle, DiffViewerProps>(function
               <col />
             </colgroup>
             <tbody>
-              <UnifiedHunkLines lines={diffLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
+              <UnifiedHunkLines lines={diffLines} highlights={highlights} newHighlights={newHighlights} commentingOn={commentingOn} dragging={dragging} onLineMouseDown={onCreateComment ? handleLineMouseDown : undefined} onLineMouseEnter={handleLineMouseEnter} onLineMouseUp={handleLineMouseUp} onSubmitComment={handleSubmitComment} onCancelComment={handleCancelComment} reviewThreads={fileThreads} checkAnnotations={checkAnnotations} onEditComment={onEditComment} onReply={onReply} onToggleResolved={onToggleResolved} onToggleReaction={onToggleReaction} onPostHighlightAsComment={onCreateComment ? handlePostHighlightAsComment : undefined} lang={lang} />
             </tbody>
           </table>
         )}

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -17,6 +17,8 @@ interface FileSidebarProps {
   onViewChange: (view: SidebarView) => void;
   /** Review threads for the whole PR, used only to size the "Comments (N)" toggle. */
   commentThreads: ReviewThread[];
+  /** Inline CI failure annotation counts by file path, from a loaded CheckFailures. */
+  checkFailureCounts?: Map<string, number>;
   commentsOpen: boolean;
   onToggleComments: () => void;
   /** Emits the visible file paths in manifest order, for keyboard file navigation. */
@@ -182,6 +184,7 @@ function FileItem({
   onSelectFile,
   onToggleViewed,
   showPathHint,
+  checkFailureCount,
 }: {
   file: FileDiff;
   selectedFile: FileDiff | null;
@@ -190,6 +193,7 @@ function FileItem({
   onSelectFile: (f: FileDiff) => void;
   onToggleViewed: (path: string) => void;
   showPathHint?: boolean;
+  checkFailureCount?: number;
 }) {
   const isCritical =
     file.risk_level === "critical" || file.risk_level === "high";
@@ -240,6 +244,14 @@ function FileItem({
             {file.highlights.length}
           </span>
         )}
+        {!!checkFailureCount && checkFailureCount > 0 && (
+          <span
+            className="file-check-failure-count"
+            title={`${checkFailureCount} failing-check annotation${checkFailureCount === 1 ? "" : "s"}`}
+          >
+            {checkFailureCount}
+          </span>
+        )}
         {showPathHint && (
           <span className="file-path-hint">
             {file.path.split("/").slice(-2, -1)[0] || ""}
@@ -263,6 +275,7 @@ function TreeFolder({
   staleViewedFiles,
   onSelectFile,
   onToggleViewed,
+  checkFailureCounts,
 }: {
   node: TreeNode;
   depth: number;
@@ -273,6 +286,7 @@ function TreeFolder({
   staleViewedFiles: Set<string>;
   onSelectFile: (f: FileDiff) => void;
   onToggleViewed: (path: string) => void;
+  checkFailureCounts?: Map<string, number>;
 }) {
   const children = sortedTreeEntries(node);
   return (
@@ -288,6 +302,7 @@ function TreeFolder({
                 isStale={staleViewedFiles.has(child.file.path)}
                 onSelectFile={onSelectFile}
                 onToggleViewed={onToggleViewed}
+                checkFailureCount={checkFailureCounts?.get(child.file.path)}
               />
             </div>
           );
@@ -320,6 +335,7 @@ function TreeFolder({
                 staleViewedFiles={staleViewedFiles}
                 onSelectFile={onSelectFile}
                 onToggleViewed={onToggleViewed}
+                checkFailureCounts={checkFailureCounts}
               />
             )}
           </div>
@@ -345,6 +361,7 @@ export function FileSidebar({
   sidebarView: view,
   onViewChange: setView,
   commentThreads,
+  checkFailureCounts,
   commentsOpen,
   onToggleComments,
   onVisibleFilesChange,
@@ -634,6 +651,7 @@ export function FileSidebar({
                       onSelectFile={onSelectFile}
                       onToggleViewed={onToggleViewed}
                       showPathHint
+                      checkFailureCount={checkFailureCounts?.get(file.path)}
                     />
                   ))}
                   </>)}
@@ -664,6 +682,7 @@ export function FileSidebar({
                       onSelectFile={onSelectFile}
                       onToggleViewed={onToggleViewed}
                       showPathHint
+                      checkFailureCount={checkFailureCounts?.get(file.path)}
                     />
                   ))}
                   </>)}
@@ -693,6 +712,7 @@ export function FileSidebar({
                     onSelectFile={onSelectFile}
                     onToggleViewed={onToggleViewed}
                     showPathHint
+                    checkFailureCount={checkFailureCounts?.get(file.path)}
                   />
                 ))}
               </div>
@@ -717,6 +737,7 @@ export function FileSidebar({
                     onSelectFile={onSelectFile}
                     onToggleViewed={onToggleViewed}
                     showPathHint
+                    checkFailureCount={checkFailureCounts?.get(file.path)}
                   />
                 ))}
               </div>
@@ -734,6 +755,7 @@ export function FileSidebar({
               staleViewedFiles={staleViewedFiles}
               onSelectFile={onSelectFile}
               onToggleViewed={onToggleViewed}
+              checkFailureCounts={checkFailureCounts}
             />
           </div>
         )}

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -3,11 +3,14 @@ import { SummaryParagraphs } from "./SummaryParagraphs";
 import { Avatar } from "./ReviewRequestList";
 import { RichText } from "./RichText";
 import { highlightKey, timeAgo } from "../utils";
-import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState, TopRisk, PrCommit } from "../types";
+import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState, TopRisk, PrCommit, CheckFailures, CheckAnnotation } from "../types";
 
 interface PrOverviewProps {
   manifest: ReviewManifest;
   checksStatus?: PrChecksStatus | null;
+  /** Inline CI failure annotations, loaded on demand once a failing check run
+   * is observed — powers the "Failing checks" card. */
+  checkFailures?: CheckFailures | null;
   reviewState: MyReviewState | null;
   viewedCount: number;
   unresolvedThreads: number | null;
@@ -213,6 +216,42 @@ function CommitsCard({
   );
 }
 
+/** Stable-sort annotations so every annotation for the same path is adjacent,
+ * in first-seen path order — a lightweight "group by path" that keeps the
+ * flat row list the card renders. */
+function groupAnnotationsByPath(annotations: CheckAnnotation[]): CheckAnnotation[] {
+  const order: string[] = [];
+  const byPath = new Map<string, CheckAnnotation[]>();
+  for (const a of annotations) {
+    if (!byPath.has(a.path)) {
+      byPath.set(a.path, []);
+      order.push(a.path);
+    }
+    byPath.get(a.path)!.push(a);
+  }
+  return order.flatMap((p) => byPath.get(p)!);
+}
+
+function CheckFailureRow({ annotation, onOpenAt }: { annotation: CheckAnnotation; onOpenAt?: (path: string, line?: number) => void }) {
+  const subtitle = annotation.title ?? annotation.message.split("\n")[0];
+  return (
+    <button
+      className="overview-check-row"
+      onClick={() => onOpenAt?.(annotation.path, annotation.start_line)}
+    >
+      <div className="overview-check-row-main">
+        <div className="overview-check-row-title">
+          <span className="risk-dot risk-dot--critical" /> {annotation.check_name}
+        </div>
+        <div className="overview-check-row-detail">{subtitle}</div>
+      </div>
+      <span className="overview-risk-file">
+        {fileName(annotation.path)}:{annotation.start_line}
+      </span>
+    </button>
+  );
+}
+
 function TopRiskRow({ risk, onOpenAt }: { risk: TopRisk; onOpenAt?: (path: string, line?: number) => void }) {
   return (
     <button
@@ -234,6 +273,7 @@ function TopRiskRow({ risk, onOpenAt }: { risk: TopRisk; onOpenAt?: (path: strin
 export function PrOverview({
   manifest,
   checksStatus,
+  checkFailures,
   reviewState,
   viewedCount,
   unresolvedThreads,
@@ -349,6 +389,17 @@ export function PrOverview({
         )}
       </div>
       <div className="overview-rail">
+        {checkFailures && checkFailures.annotations.length > 0 && (
+          <div className="overview-card overview-checks">
+            <h4>Failing checks ({checkFailures.annotations.length})</h4>
+            {groupAnnotationsByPath(checkFailures.annotations).map((a, i) => (
+              <CheckFailureRow key={i} annotation={a} onOpenAt={onOpenAt} />
+            ))}
+            {checkFailures.truncated && (
+              <div className="overview-checks-truncated">Showing the first 200 annotations</div>
+            )}
+          </div>
+        )}
         {topRisks.length > 0 && (
           <div className="overview-card overview-risks">
             <h4>What to review first</h4>

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -253,7 +253,9 @@ function CheckFailureRow({
     >
       <div className="overview-check-row-main">
         <div className="overview-check-row-title">
-          <span className="risk-dot risk-dot--critical" /> {annotation.check_name}
+          {/* Warnings get the amber dot — a red one would present them as failures. */}
+          <span className={`risk-dot ${annotation.annotation_level === "warning" ? "risk-dot--medium" : "risk-dot--critical"}`} />{" "}
+          {annotation.check_name}
         </div>
         <div className="overview-check-row-detail">{subtitle}</div>
       </div>

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -405,7 +405,18 @@ export function PrOverview({
       <div className="overview-rail">
         {checkFailures && checkFailures.annotations.length > 0 && (
           <div className="overview-card overview-checks">
-            <h4>Failing checks ({checkFailures.annotations.length})</h4>
+            {(() => {
+              // Warnings ride along in the card but shouldn't inflate the
+              // failure count in its title.
+              const failures = checkFailures.annotations.filter((a) => a.annotation_level !== "warning").length;
+              const warnings = checkFailures.annotations.length - failures;
+              return (
+                <h4>
+                  Failing checks ({failures})
+                  {warnings > 0 && <span className="overview-checks-warnings"> + {warnings} warning{warnings === 1 ? "" : "s"}</span>}
+                </h4>
+              );
+            })()}
             {groupAnnotationsByPath(checkFailures.annotations).map((a, i) => (
               <CheckFailureRow key={i} annotation={a} inDiff={byPath.has(a.path)} onOpenAt={onOpenAt} />
             ))}

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -232,12 +232,24 @@ function groupAnnotationsByPath(annotations: CheckAnnotation[]): CheckAnnotation
   return order.flatMap((p) => byPath.get(p)!);
 }
 
-function CheckFailureRow({ annotation, onOpenAt }: { annotation: CheckAnnotation; onOpenAt?: (path: string, line?: number) => void }) {
+function CheckFailureRow({
+  annotation,
+  inDiff,
+  onOpenAt,
+}: {
+  annotation: CheckAnnotation;
+  /** Whether the annotation's path is a file in this PR's diff — CI often
+   * anchors run-level failures to paths like `.github` that aren't. */
+  inDiff: boolean;
+  onOpenAt?: (path: string, line?: number) => void;
+}) {
   const subtitle = annotation.title ?? annotation.message.split("\n")[0];
   return (
     <button
-      className="overview-check-row"
-      onClick={() => onOpenAt?.(annotation.path, annotation.start_line)}
+      className={`overview-check-row${inDiff ? "" : " overview-check-row--nodiff"}`}
+      disabled={!inDiff}
+      title={inDiff ? undefined : "Not a file in this PR's diff — see the check's log on GitHub"}
+      onClick={() => inDiff && onOpenAt?.(annotation.path, annotation.start_line)}
     >
       <div className="overview-check-row-main">
         <div className="overview-check-row-title">
@@ -393,7 +405,7 @@ export function PrOverview({
           <div className="overview-card overview-checks">
             <h4>Failing checks ({checkFailures.annotations.length})</h4>
             {groupAnnotationsByPath(checkFailures.annotations).map((a, i) => (
-              <CheckFailureRow key={i} annotation={a} onOpenAt={onOpenAt} />
+              <CheckFailureRow key={i} annotation={a} inDiff={byPath.has(a.path)} onOpenAt={onOpenAt} />
             ))}
             {checkFailures.truncated && (
               <div className="overview-checks-truncated">Showing the first 200 annotations</div>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -759,14 +759,17 @@ body {
 /* Progressive disclosure: stats and note counts surface on hover/selection.
    Opacity (not display) so row layout never shifts. */
 .file-item .line-stats,
-.file-item .file-highlight-count {
+.file-item .file-highlight-count,
+.file-item .file-check-failure-count {
   opacity: 0;
   transition: opacity 0.12s;
 }
 .file-item:hover .line-stats,
 .file-item.selected .line-stats,
 .file-item:hover .file-highlight-count,
-.file-item.selected .file-highlight-count {
+.file-item.selected .file-highlight-count,
+.file-item:hover .file-check-failure-count,
+.file-item.selected .file-check-failure-count {
   opacity: 1;
 }
 
@@ -2035,6 +2038,90 @@ tr.cursor-selected td {
   flex: 1;
 }
 
+/* Inline CI failure annotations (issue #61) — same card treatment as an AI
+   note (.highlight-marker), red-accented, read-only besides expand/collapse. */
+.check-annotation-row td {
+  padding: 0;
+}
+
+.check-annotation {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: 6px var(--space-4) 6px 56px;
+  padding: 8px var(--space-3);
+  font-size: 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(182, 35, 36, 0.4);
+  border-left: 3px solid var(--sev-critical-fill);
+  background: var(--bg-secondary);
+}
+
+.check-annotation-icon {
+  flex-shrink: 0;
+  color: var(--risk-critical);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.check-annotation-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.check-annotation-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.check-annotation-name {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.check-annotation-sep {
+  color: var(--text-muted);
+}
+
+.check-annotation-title {
+  color: var(--text-secondary);
+}
+
+.check-annotation-message {
+  margin: 6px 0 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.check-annotation-message-collapsed {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.check-annotation-toggle {
+  margin-top: 4px;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.check-annotation-toggle:hover {
+  color: var(--text-primary);
+}
+
 .highlight-post-comment {
   margin-left: auto;
   flex-shrink: 0;
@@ -2253,6 +2340,23 @@ tr.cursor-selected td {
   border-radius: 8px;
   background: rgba(88, 166, 255, 0.2);
   color: var(--accent);
+  flex-shrink: 0;
+}
+
+/* Sidebar CI failure annotation count badge — same shape as the AI-note
+   count, red instead of accent-blue. */
+.file-check-failure-count {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--risk-critical-bg);
+  color: var(--risk-critical);
   flex-shrink: 0;
 }
 
@@ -4940,6 +5044,59 @@ mark.search-highlight-current {
   border-radius: var(--radius-pill);
   padding: 1px 9px;
   white-space: nowrap;
+}
+
+/* "Failing checks" card rows — a close variant of .overview-risk-row (same
+   layout), with a critical-risk dot ahead of the check name. */
+.overview-check-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 10px 4px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--chip-border);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.overview-check-row:first-of-type {
+  border-top: none;
+}
+
+.overview-check-row:hover .overview-check-row-title {
+  color: var(--accent);
+}
+
+.overview-check-row-main {
+  min-width: 0;
+}
+
+.overview-check-row-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.overview-check-row-detail {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.overview-checks-truncated {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--text-muted);
 }
 
 .overview-chip {

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -6465,3 +6465,11 @@ mark.search-highlight-current {
 .overview-check-row--nodiff:hover .overview-check-row-title {
   color: inherit;
 }
+
+.check-annotation-range {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+  white-space: nowrap;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -6473,3 +6473,8 @@ mark.search-highlight-current {
   margin-left: auto;
   white-space: nowrap;
 }
+
+.overview-checks-warnings {
+  color: var(--text-tertiary);
+  font-weight: normal;
+}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -6455,3 +6455,13 @@ mark.search-highlight-current {
   .activity-widget--dock,
   .activity-widget--pill { transition: none; }
 }
+
+/* Failing-check rows whose path isn't in the diff (run-level anchors like
+   `.github`) — visible for completeness but not clickable. */
+.overview-check-row--nodiff {
+  opacity: 0.55;
+  cursor: default;
+}
+.overview-check-row--nodiff:hover .overview-check-row-title {
+  color: inherit;
+}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -160,6 +160,12 @@ export type CommentThreadsState =
   | { status: "loaded"; threads: ReviewThread[] }
   | { status: "error"; message: string };
 
+export type CheckAnnotationsState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "loaded"; failures: CheckFailures }
+  | { status: "error"; message: string };
+
 /** One turn of the per-PR review chat. `filePath` records which file was in
  * focus when a user message was sent (for display); undefined for whole-PR scope. */
 export interface ChatMessage {
@@ -248,6 +254,9 @@ export interface Tab {
   /** Conversational diff Q&A state for this PR. */
   chat: ChatState;
   commentThreads: CommentThreadsState;
+  /** Inline CI failure annotations for this tab's PR, fetched on demand once
+   * a failing check run is observed (see the fetch effect in App.tsx). */
+  checkAnnotations: CheckAnnotationsState;
   /** Whether the right-dock comments panel is open (mutually exclusive with `chat.open`). */
   commentsOpen?: boolean;
   sidebarView: SidebarView;
@@ -336,6 +345,25 @@ export interface CheckRunInfo {
 export interface PrChecksStatus {
   overall_state: string;
   check_runs: CheckRunInfo[];
+}
+
+/** One inline annotation on a failing check run (a lint/test failure pinned
+ * to a file + line range on the head commit). */
+export interface CheckAnnotation {
+  path: string;
+  start_line: number;
+  end_line: number;
+  annotation_level: string;
+  message: string;
+  title: string | null;
+  check_name: string;
+}
+
+/** Annotations from a PR's failing checks, fetched on demand for the head SHA. */
+export interface CheckFailures {
+  head_sha: string;
+  annotations: CheckAnnotation[];
+  truncated: boolean;
 }
 
 export interface ViewedFileState {


### PR DESCRIPTION
Implements the build spec on #61 (v1: Checks-API annotations only).

## What
- **Failing checks card** at the top of the overview rail: annotations grouped by file — check name, message, `file:line` — click to jump to the exact line.
- **Inline markers**: red ✗ rows anchored above the implicated head lines in the diff, stacking per line, read-only (no dismiss/resolve semantics). Annotations on lines outside the diff appear in the card only.
- **Sidebar badges**: per-file failing-annotation counts (all sidebar views incl. tree).
- **Data**: REST `/commits/{sha}/check-runs` → one page of annotations (cap 50) per failing run, failure+warning levels, total cap 200 with a `truncated` flag. Fetch fires only when the already-polled checks report a failure — green PRs pay nothing. Keyed by the manifest's head sha, so annotations always match the diff (force-push staleness solved by construction).
- **Line jumps now real**: `DiffViewerHandle` gained `revealLine`, and `onOpenAt` finally honors its line argument — fixing the silent line-drop for chat citations and top-risk rows too.

## Verification
- `cargo test -p marrow-core` 69/69 (5 new parsing tests), `cargo check` + `bun run build` clean.
- Adversarial verifier: no confirmed defects (REST/GraphQL conclusion-casing trap, pagination/cap, stale-resolve guard, collapsed-hunk leakage, badge coverage all ruled out); its two findings (truncated flag on the >30-page cutoff, the onOpenAt line-drop) both fixed.
- **Live-tested** against fixture PR #164 (workflow-emitted file-anchored annotations): card with all 5 grouped annotations, CI chip/modal/activity intact, card-row click landed directly on README.md:214, stacked markers on 214/215, unchanged-line warning correctly card-only, badges (3/1) on both files, cross-file marker in PUBLISHING.md.

Not exercisable live with this fixture: >200 truncation, multi-line message collapse (GitHub folds workflow-command messages to one line), fetch-error state — all unit/verifier-covered.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)