### PR TITLE
feat: chat action blocks — the AI can drive the review view (#166 stage 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Notes:
 - **macOS-only by design**: `macOSPrivateApi`, `objc2`/`tauri-nspanel` deps under `cfg(target_os = "macos")`, Developer ID signing in `tauri.conf.json`. Don't gate desktop features on cross-platform support; the CLI is the cross-platform surface.
 - **Mini-player is fragile**: the floating window is a non-activating NSPanel driven by polling `NSApplication.isActive` (no webview focus event exists for app reactivation). Read the comments in `lib.rs` and `docs/mini-player.md` before touching show/hide logic — many past regressions here (see git log).
 - **Generated / ignored**: `app/dist/`, `app/src-tauri/target/`, `app/src-tauri/gen/`, `browser-extension/dist/`. Never edit these. `Cargo.lock` IS tracked (binary crates) — commit its changes.
+- **Chat action protocol is triplicated**: `CHAT_UI_ACTIONS` (`crates/core/src/chat.rs`), the `ChatAction` union (`app/src/types.ts`), and `isChatAction` (`app/src/components/RichText.tsx`) must stay in sync by hand — sync markers at each site.
 - **PR-ref regex is quadruplicated**: `browser-extension/content.js`, the bookmarklet in `app/src/components/SettingsModal.tsx`, `crates/core/src/pr_parser.rs`, and `app/src/utils.ts` must stay in sync — a comment in `content.js` marks this.
 - **User state lives in `~/.config/marrow/`** (config with plaintext API keys, manifest cache, viewed/dismissed state). Treat it as real user data — never clear it in tests or "cleanup".
 - Vite ignores `**/src-tauri/**` in its watcher; Rust edits are picked up by the Tauri CLI, not Vite.

--- a/app/src-tauri/crates/core/src/chat.rs
+++ b/app/src-tauri/crates/core/src/chat.rs
@@ -68,6 +68,10 @@ Guidelines:
 /// of just describing it. The frontend (RichText.tsx) recognizes a fenced
 /// code block whose language is exactly `marrow-action`, executes the JSON
 /// object once its fence completes, and renders it as a chip rather than code.
+// The action protocol is TRIPLICATED by hand: this prompt section, the
+// `ChatAction` union in app/src/types.ts, and the `isChatAction` validator in
+// app/src/components/RichText.tsx. Adding or changing an action means editing
+// all three, or the model will emit blocks the chips silently reject.
 const CHAT_UI_ACTIONS: &str = r#"You can control the review app by emitting a fenced code block with the language `marrow-action` containing exactly one JSON object. The app executes it once and renders it as a chip instead of raw JSON — never describe the JSON in prose, just emit the block.
 
 Available actions (the complete list — never invent others):

--- a/app/src-tauri/crates/core/src/chat.rs
+++ b/app/src-tauri/crates/core/src/chat.rs
@@ -63,11 +63,38 @@ Guidelines:
 - Use Markdown. Put code in fenced code blocks.
 - You are reviewing, not writing the PR — don't propose to make edits; explain, assess risk, and surface what's worth a closer look."#;
 
-/// Assemble the system prompt: the assistant instructions followed by the PR
-/// title, AI summary, and the in-scope file diffs (budget-bounded).
+/// Documents the `marrow-action` fenced-block protocol: a way for the model to
+/// drive the app's view (open a file, flip a filter, hop to a commit) instead
+/// of just describing it. The frontend (RichText.tsx) recognizes a fenced
+/// code block whose language is exactly `marrow-action`, executes the JSON
+/// object once its fence completes, and renders it as a chip rather than code.
+const CHAT_UI_ACTIONS: &str = r#"You can control the review app by emitting a fenced code block with the language `marrow-action` containing exactly one JSON object. The app executes it once and renders it as a chip instead of raw JSON — never describe the JSON in prose, just emit the block.
+
+Available actions (the complete list — never invent others):
+- {"action":"open_file","path":"<repo path>","line":<optional number>} — open a changed file, optionally at a head line
+- {"action":"open_overview"} — back to the PR overview
+- {"action":"next_file"} — the next file in review order
+- {"action":"prev_file"} — the previous file in review order
+- {"action":"open_commit","sha":"<sha or prefix>"} — open a commit in commit scope
+- {"action":"set_hunk_filter","filter":"all|high|medium"} — set the hunk significance filter
+- {"action":"set_view_mode","mode":"split|unified"} — set the diff layout
+- {"action":"show_comments","open":true|false} — open or close the comments panel
+
+Usage rules:
+- Act only when the user asks to see/navigate/show something, or it clearly helps them get there — a plain answer needs no actions.
+- At most a few actions per reply.
+- Put the action block AFTER the sentence explaining what you're doing, never instead of it.
+- Never invent a path — only use files listed under FILES IN SCOPE.
+- One JSON object per fence; use separate fences for multiple actions."#;
+
+/// Assemble the system prompt: the assistant instructions, the UI-actions
+/// protocol, then the PR title, AI summary, and the in-scope file diffs
+/// (budget-bounded).
 pub fn build_chat_system(ctx: &ChatContext) -> String {
     let mut out = String::with_capacity(4096);
     out.push_str(CHAT_SYSTEM_PREAMBLE);
+    out.push_str("\n\n--- UI ACTIONS ---\n\n");
+    out.push_str(CHAT_UI_ACTIONS);
     out.push_str("\n\n--- PR CONTEXT ---\n\n");
     out.push_str(&format!("PR Title: {}\n", ctx.pr_title));
     if !ctx.summary.trim().is_empty() {
@@ -149,6 +176,19 @@ mod tests {
     }
 
     #[test]
+    fn system_documents_ui_actions() {
+        let sys = build_chat_system(&ctx_with("@@ -1 +1 @@\n-old\n+new\n", None));
+        assert!(sys.contains("UI ACTIONS"));
+        assert!(sys.contains("marrow-action"));
+        assert!(sys.contains(r#"{"action":"open_file""#));
+        assert!(sys.contains(r#"{"action":"open_overview"}"#));
+        assert!(sys.contains(r#"{"action":"open_commit""#));
+        assert!(sys.contains(r#"{"action":"set_hunk_filter""#));
+        assert!(sys.contains(r#"{"action":"set_view_mode""#));
+        assert!(sys.contains(r#"{"action":"show_comments""#));
+    }
+
+    #[test]
     fn system_includes_title_summary_and_diff() {
         let sys = build_chat_system(&ctx_with("@@ -1 +1 @@\n-old\n+new\n", None));
         assert!(sys.contains("Test PR"));
@@ -173,8 +213,10 @@ mod tests {
                 .collect(),
         };
         let sys = build_chat_system(&ctx);
-        // Preamble + context, but bounded well under the sum of all inputs.
-        assert!(sys.chars().count() < TOTAL_CONTEXT_BUDGET + 2000);
+        // Preamble + UI-actions guide + context, but bounded well under the
+        // sum of all inputs. The fixed-overhead margin covers the constant
+        // instructional text (preamble, UI actions protocol, section labels).
+        assert!(sys.chars().count() < TOTAL_CONTEXT_BUDGET + 2500);
     }
 
     #[test]

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -21,13 +21,14 @@ import { ToastContainer, createToast, type ToastData } from "./components/Toast"
 import { CommandPalette, type PaletteCommand } from "./components/CommandPalette";
 import { WelcomeSetup } from "./components/WelcomeSetup";
 import { ChatPanel } from "./components/ChatPanel";
+import { parseChatActionFences } from "./components/RichText";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, ChatAction, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey } from "./utils";
 import type { ReviewSession } from "./hooks/useActivityFeed";
 
@@ -116,6 +117,14 @@ function App() {
   const [searchQuery, setSearchQuery] = useState("");
   const [toasts, setToasts] = useState<ToastData[]>([]);
   const [checksMap, setChecksMap] = useState<Record<string, PrChecksStatus>>({});
+  // Chat ```marrow-action chip statuses (issue #166): tabId -> message key
+  // ("msg-<index>" for a finalized message, "streaming" for the in-progress
+  // turn) -> `${blockIndex}:${JSON.stringify(action)}` -> outcome. Session-
+  // only — never persisted alongside chat history.
+  const [chatActionStatuses, setChatActionStatuses] = useState<Record<string, Record<string, Record<string, "done" | "failed">>>>({});
+  // Per-tab set of action-block keys already auto-executed during the current
+  // streaming turn, so a block that already ran isn't re-run on the next delta.
+  const chatExecutedActionsRef = useRef<Record<string, Set<string>>>({});
   const [checksDismissed, setChecksDismissed] = useState<Record<string, boolean>>({});
   const [updateStatus, setUpdateStatus] = useState<UpdateStatus>({ state: "idle" });
   const updateStatusRef = useRef(updateStatus.state);
@@ -335,8 +344,10 @@ function App() {
   }
 
   // ── Keyboard shortcuts (ported from the CLI/TUI; see useKeyboardShortcuts) ──
-  function selectAdjacentFile(delta: 1 | -1) {
-    if (!activeTab?.manifest || !activeTab.selectedFile) return;
+  // Returns whether it actually navigated, so callers that report outcomes
+  // (chat action chips) don't claim success for an edge-of-list no-op.
+  function selectAdjacentFile(delta: 1 | -1): boolean {
+    if (!activeTab?.manifest || !activeTab.selectedFile) return false;
     const order = visibleOrderRef.current.length
       ? visibleOrderRef.current
       : activeTab.manifest.files.map((f) => f.path);
@@ -345,11 +356,12 @@ function App() {
     if (i === -1) {
       // Current file is filtered out of the list — jump to the first visible one.
       const first = byPath(order[0]);
-      if (first) setSelectedFile(first);
-      return;
+      if (first) { setSelectedFile(first); return true; }
+      return false;
     }
     const next = byPath(order[Math.min(Math.max(i + delta, 0), order.length - 1)]);
-    if (next && next.path !== activeTab.selectedFile.path) setSelectedFile(next);
+    if (next && next.path !== activeTab.selectedFile.path) { setSelectedFile(next); return true; }
+    return false;
   }
 
   function selectAdjacentTab(delta: 1 | -1) {
@@ -941,6 +953,18 @@ function App() {
     const tab = tabsRef.current.find((t) => t.id === tabId);
     const messages: ChatMessage[] = [...(tab?.chat.messages ?? []), { role: "assistant", content }];
     updateTab(tabId, (t) => ({ ...t, chat: { ...t.chat, messages, status: "idle", streamingText: "", streamingStatus: null } }));
+    // The just-finished turn's action statuses were recorded under the
+    // "streaming" bucket — move them to this message's own key (its index in
+    // the now-final array) so its chips keep showing ✓/✗ after finalize.
+    const msgKey = `msg-${messages.length - 1}`;
+    setChatActionStatuses((prev) => {
+      const streaming = prev[tabId]?.streaming;
+      if (!streaming) return prev;
+      const nextForTab = { ...prev[tabId] };
+      delete nextForTab.streaming;
+      nextForTab[msgKey] = streaming;
+      return { ...prev, [tabId]: nextForTab };
+    });
     try {
       const { owner, repo, number } = parsePrUrl(prUrl);
       invoke("save_chat_history", { owner, repo, prNumber: number, state: { messages } }).catch(() => {});
@@ -967,6 +991,9 @@ function App() {
 
     chatCancelRef.current[tabId] = false;
     chatRequestIdRef.current[tabId] = requestId;
+    // A fresh turn starts a fresh action-block execution window.
+    chatExecutedActionsRef.current[tabId] = new Set();
+    setChatActionStatuses((prev) => ({ ...prev, [tabId]: { ...prev[tabId], streaming: {} } }));
     updateTab(tabId, (t) => ({
       ...t,
       chat: { ...t.chat, messages: [...t.chat.messages, userMsg], status: "streaming", streamingText: "", streamingStatus: null, error: undefined },
@@ -1022,6 +1049,12 @@ function App() {
       const requestId = chatRequestIdRef.current[tab.id];
       if (requestId) invoke("chat_cancel", { requestId }).catch(() => {});
     }
+    delete chatExecutedActionsRef.current[tab.id];
+    setChatActionStatuses((prev) => {
+      const copy = { ...prev };
+      delete copy[tab.id];
+      return copy;
+    });
     updateTab(tab.id, (t) => ({ ...t, chat: { ...t.chat, messages: [], status: "idle", streamingText: "", error: undefined } }));
     try {
       const { owner, repo, number } = parsePrUrl(tab.manifest.pr_url);
@@ -1052,19 +1085,26 @@ function App() {
     updateTab(activeTabId, (t) => ({ ...t, chat: { ...t.chat, includeWholePr: value } }));
   }
 
+  /** Resolve a file mention (exact path, or a unique suffix match) against a
+   * manifest's files — shared by handleChatOpenFile and the chat-action
+   * dispatcher so both agree on what counts as a resolvable path. */
+  function resolveManifestFile(files: FileDiff[], path: string): FileDiff | undefined {
+    return (
+      files.find((f) => f.path === path) ??
+      (() => {
+        const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
+        return suffixMatches.length === 1 ? suffixMatches[0] : undefined;
+      })()
+    );
+  }
+
   /** Resolve a file mention (exact path, or a unique suffix match against the
    * manifest), select it, and reveal the given head line — expanding its hunk
    * if collapsed. Serves chat citations, top-risk rows, and check-failure rows. */
   async function handleChatOpenFile(path: string, line?: number) {
     const tab = tabsRef.current.find((t) => t.id === activeTabId);
     if (!tab?.manifest) return;
-    const files = tab.manifest.files;
-    let target =
-      files.find((f) => f.path === path) ??
-      (() => {
-        const suffixMatches = files.filter((f) => f.path.endsWith("/" + path));
-        return suffixMatches.length === 1 ? suffixMatches[0] : undefined;
-      })();
+    let target = resolveManifestFile(tab.manifest.files, path);
     if (!target) return;
     if (line != null && !target.head_content && target.diff_type !== "removed") {
       // Jump targets in files whose contents weren't fetched at analysis time
@@ -1121,6 +1161,104 @@ function App() {
       if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
     });
   }, [selectedFilePath]);
+
+  // ---- Chat ```marrow-action view-control blocks (issue #166) ----
+
+  /** Run one chat-emitted view-control action against the active tab. No
+   * mutating actions here — everything is navigation/view state. Returns
+   * whether the action resolved (e.g. the file/commit it names actually
+   * exists) so the caller can render a done/failed chip. */
+  function executeChatAction(a: ChatAction): boolean {
+    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (!tab?.manifest) return false;
+    switch (a.action) {
+      case "open_file": {
+        if (!resolveManifestFile(tab.manifest.files, a.path)) return false;
+        handleChatOpenFile(a.path, a.line);
+        return true;
+      }
+      case "open_overview":
+        updateTab(tab.id, (t) => ({ ...t, selectedFile: null }));
+        return true;
+      case "next_file":
+        return selectAdjacentFile(1);
+      case "prev_file":
+        return selectAdjacentFile(-1);
+      case "open_commit": {
+        const commits = tab.manifest.commits;
+        const exact = commits.find((c) => c.sha === a.sha);
+        // A prefix must be unambiguous — resolving to "whichever came first"
+        // could open the wrong commit while reporting success.
+        const prefixed = commits.filter((c) => c.sha.startsWith(a.sha));
+        const match = exact ?? (prefixed.length === 1 ? prefixed[0] : undefined);
+        if (!match) return false;
+        handleViewCommit(match);
+        return true;
+      }
+      case "set_hunk_filter":
+        setHunkFilter(a.filter);
+        return true;
+      case "set_view_mode":
+        setViewMode(a.mode);
+        return true;
+      case "show_comments":
+        // Chat and Comments are mutually exclusive right-dock panels (see
+        // toggleThreadsView) — opening comments from here closes chat too.
+        updateTab(tab.id, (t) => ({
+          ...t,
+          commentsOpen: a.open,
+          chat: a.open ? { ...t.chat, open: false } : t.chat,
+        }));
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /** Execute a chat action chip's click (or the streaming auto-exec effect
+   * below), and record its done/failed status under the message it belongs
+   * to. `msgKey` is "msg-<index>" for a finalized message or "streaming" for
+   * the in-progress turn; `blockIndex` is the action's position among that
+   * message's closed marrow-action fences (see RichText's parseActionFences). */
+  function runChatAction(tabId: string, msgKey: string, a: ChatAction, blockIndex: number) {
+    const ok = executeChatAction(a);
+    const key = `${blockIndex}:${JSON.stringify(a)}`;
+    setChatActionStatuses((prev) => ({
+      ...prev,
+      [tabId]: {
+        ...prev[tabId],
+        [msgKey]: { ...prev[tabId]?.[msgKey], [key]: ok ? "done" : "failed" },
+      },
+    }));
+  }
+
+  /** Auto-execute newly-completed ```marrow-action fences as they stream in.
+   * Runs each action-block key at most once per streaming turn (tracked in
+   * chatExecutedActionsRef, cleared when a new turn starts — see
+   * handleChatSend) and records its outcome under the "streaming" bucket,
+   * which finalizeChat then migrates to the finished message's own key. */
+  useEffect(() => {
+    // Deliberately active-tab-only: actions drive the CURRENT view, so a
+    // stream finishing in a background tab must not yank the user around.
+    // Switching back mid-stream catches up (this effect re-fires); a turn that
+    // completed while backgrounded leaves its chips neutral-and-clickable,
+    // same as restored history.
+    if (!activeTab || activeTab.chat.status !== "streaming" || !activeTab.chat.streamingText) return;
+    const tabId = activeTab.id;
+    // Split on [[thought:N]] dividers before scanning, matching exactly how
+    // ChatMarkdown renders this same text (see parseChatActionFences) — so a
+    // divider landing inside a fence can't make the two sides disagree about
+    // block indices.
+    const fences = parseChatActionFences(activeTab.chat.streamingText);
+    const executed = chatExecutedActionsRef.current[tabId] ?? (chatExecutedActionsRef.current[tabId] = new Set());
+    fences.forEach((entry, blockIndex) => {
+      if (!entry.action) return;
+      const key = `${blockIndex}:${JSON.stringify(entry.action)}`;
+      if (executed.has(key)) return;
+      executed.add(key);
+      runChatAction(tabId, "streaming", entry.action, blockIndex);
+    });
+  }, [activeTab?.id, activeTab?.chat.status, activeTab?.chat.streamingText]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Set by briefMe below; consumed once the chat-open/whole-PR state it just
   // requested has actually committed (handleChatSend reads tabsRef, which
@@ -1868,6 +2006,12 @@ function App() {
       delete copy[tabId];
       return copy;
     });
+    setChatActionStatuses((prev) => {
+      const copy = { ...prev };
+      delete copy[tabId];
+      return copy;
+    });
+    delete chatExecutedActionsRef.current[tabId];
     if (next.length === 0) {
       // Closing the last *review* tab drops back to a fresh opener tab so the tab
       // bar (and a way to open a PR) is always present. But closing the last tab
@@ -2507,6 +2651,8 @@ function App() {
               onClear={handleChatClear}
               onToggleWholePr={handleChatToggleWholePr}
               onOpenFile={handleChatOpenFile}
+              onRunAction={(msgKey, a, blockIndex) => runChatAction(activeTab.id, msgKey, a, blockIndex)}
+              actionStatuses={chatActionStatuses[activeTab.id]}
             />
           )}
           {activeTab.commentsOpen && (

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -48,6 +48,10 @@ const BRIEF_ME_PROMPT =
   "Merge related changes into one line. Skip filler like 'low risk' or 'mechanical change' — silence means fine. " +
   "End with one line: where to spend my review time. If I want depth on a stop, I'll ask.";
 
+/** Ceiling on marrow-action blocks auto-executed per streaming turn — the
+ * backstop behind the prompt's "at most a few actions per reply". */
+const MAX_AUTO_ACTIONS_PER_TURN = 6;
+
 /** A fresh, closed chat panel for a new tab. */
 function emptyChatState(): ChatState {
   return { messages: [], status: "idle", streamingText: "", streamingStatus: null, includeWholePr: false, open: false };
@@ -1253,6 +1257,11 @@ function App() {
     const executed = chatExecutedActionsRef.current[tabId] ?? (chatExecutedActionsRef.current[tabId] = new Set());
     fences.forEach((entry, blockIndex) => {
       if (!entry.action) return;
+      // The prompt says "at most a few actions per reply", but the prompt
+      // isn't enforcement: cap auto-execution per turn so a runaway reply
+      // can't thrash the view. Blocks past the cap render as neutral
+      // click-to-run chips instead.
+      if (executed.size >= MAX_AUTO_ACTIONS_PER_TURN) return;
       const key = `${blockIndex}:${JSON.stringify(entry.action)}`;
       if (executed.has(key)) return;
       executed.add(key);

--- a/app/src/components/ChatPanel.tsx
+++ b/app/src/components/ChatPanel.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import type { ChatState } from "../types";
-import { RichText } from "./RichText";
+import type { ChatAction, ChatState } from "../types";
+import { RichText, parseActionFences } from "./RichText";
+
+/** A message's ```marrow-action execution statuses, keyed as RichText expects
+ * (`${blockIndex}:${JSON.stringify(action)}`). See `chatActionStatuses` in
+ * App.tsx for how the outer, per-message map is built. */
+type ActionStatusMap = Record<string, "done" | "failed">;
 
 interface ChatPanelProps {
   chat: ChatState;
@@ -15,6 +20,13 @@ interface ChatPanelProps {
   onToggleWholePr: (value: boolean) => void;
   /** Jump to a file (and, when supported, a line) mentioned in an answer. */
   onOpenFile?: (path: string, line?: number) => void;
+  /** Run a ```marrow-action chip's action; `msgKey` identifies which message
+   * (or the in-progress "streaming" turn) the chip belongs to, so the caller
+   * can record the resulting status under the right bucket. */
+  onRunAction?: (msgKey: string, a: ChatAction, blockIndex: number) => void;
+  /** Action statuses for every message + the streaming turn, keyed by msgKey
+   * ("msg-<index>" or "streaming"). */
+  actionStatuses?: Record<string, ActionStatusMap>;
 }
 
 /** A dim divider marking a gap where the AI used tools / thought between
@@ -34,18 +46,44 @@ function ThoughtDivider({ seconds }: { seconds: number }) {
  * dim "Thought for Xs" dividers) and renders the text spans between them as
  * minimal Markdown.
  */
-function ChatMarkdown({ content, filePaths, onOpenFile }: { content: string; filePaths: string[]; onOpenFile?: (path: string, line?: number) => void }) {
+function ChatMarkdown({
+  content,
+  filePaths,
+  onOpenFile,
+  onRunAction,
+  actionStatuses,
+}: {
+  content: string;
+  filePaths: string[];
+  onOpenFile?: (path: string, line?: number) => void;
+  onRunAction?: (a: ChatAction, blockIndex: number) => void;
+  actionStatuses?: ActionStatusMap;
+}) {
   // Capturing split → [text, secs, text, secs, text, …].
   const parts = content.split(/\[\[thought:(\d+)\]\]/g);
+  // Each text part gets its own RichText call, but action-block indices must
+  // stay contiguous across the whole message (App's auto-exec effect numbers
+  // blocks over the full, unsplit streamingText) — track a running offset.
+  let blockIndexOffset = 0;
   return (
     <>
-      {parts.map((part, i) =>
-        i % 2 === 1 ? (
-          <ThoughtDivider key={i} seconds={Number(part)} />
-        ) : part ? (
-          <RichText key={i} content={part} filePaths={filePaths} onOpenFile={onOpenFile} />
-        ) : null,
-      )}
+      {parts.map((part, i) => {
+        if (i % 2 === 1) return <ThoughtDivider key={i} seconds={Number(part)} />;
+        if (!part) return null;
+        const offset = blockIndexOffset;
+        blockIndexOffset += parseActionFences(part).length;
+        return (
+          <RichText
+            key={i}
+            content={part}
+            filePaths={filePaths}
+            onOpenFile={onOpenFile}
+            onRunAction={onRunAction}
+            actionStatuses={actionStatuses}
+            blockIndexOffset={offset}
+          />
+        );
+      })}
     </>
   );
 }
@@ -60,6 +98,8 @@ export function ChatPanel({
   onClear,
   onToggleWholePr,
   onOpenFile,
+  onRunAction,
+  actionStatuses,
 }: ChatPanelProps) {
   const [draft, setDraft] = useState("");
   const listRef = useRef<HTMLDivElement>(null);
@@ -149,7 +189,17 @@ export function ChatPanel({
               )}
             </div>
             <div className="chat-msg-body">
-              {m.role === "assistant" ? <ChatMarkdown content={m.content} filePaths={filePaths} onOpenFile={onOpenFile} /> : <span className="chat-user-text">{m.content}</span>}
+              {m.role === "assistant" ? (
+                <ChatMarkdown
+                  content={m.content}
+                  filePaths={filePaths}
+                  onOpenFile={onOpenFile}
+                  onRunAction={onRunAction ? (a, blockIndex) => onRunAction(`msg-${i}`, a, blockIndex) : undefined}
+                  actionStatuses={actionStatuses?.[`msg-${i}`]}
+                />
+              ) : (
+                <span className="chat-user-text">{m.content}</span>
+              )}
             </div>
           </div>
         ))}
@@ -157,7 +207,15 @@ export function ChatPanel({
           <div className="chat-msg chat-msg-assistant">
             <div className="chat-msg-role">AI</div>
             <div className="chat-msg-body">
-              {chat.streamingText && <ChatMarkdown content={chat.streamingText} filePaths={filePaths} onOpenFile={onOpenFile} />}
+              {chat.streamingText && (
+                <ChatMarkdown
+                  content={chat.streamingText}
+                  filePaths={filePaths}
+                  onOpenFile={onOpenFile}
+                  onRunAction={onRunAction ? (a, blockIndex) => onRunAction("streaming", a, blockIndex) : undefined}
+                  actionStatuses={actionStatuses?.["streaming"]}
+                />
+              )}
               {chat.streamingStatus ? (
                 <span className="chat-working"><span className="chat-working-spinner" aria-hidden="true">↻</span> {chat.streamingStatus}</span>
               ) : chat.streamingText ? (

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -280,6 +280,8 @@ function parseBlocks(segment: string): Block[] {
  * schemas documented in `CHAT_UI_ACTIONS` (crates/core/src/chat.rs). Anything
  * that doesn't match a known action renders as a plain code block instead of
  * a chip, same as unparseable JSON. */
+// Kept in sync BY HAND with CHAT_UI_ACTIONS (crates/core/src/chat.rs) and
+// the ChatAction union (types.ts) — edit all three together.
 function isChatAction(x: unknown): x is ChatAction {
   if (!x || typeof x !== "object") return false;
   const a = x as Record<string, unknown>;

--- a/app/src/components/RichText.tsx
+++ b/app/src/components/RichText.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import hljs from "highlight.js";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
+import type { ChatAction } from "../types";
 
 /** Render a fenced code block with highlight.js.
  *
@@ -196,7 +197,7 @@ type Block =
   | { kind: "quote"; lines: string[] }
   | { kind: "list"; ordered: boolean; items: { text: string; task?: "done" | "todo" }[] }
   | { kind: "hr" }
-  | { kind: "fence"; lang?: string; code: string }
+  | { kind: "fence"; lang?: string; code: string; closed: boolean }
   | { kind: "para"; lines: string[] };
 
 const HEADING_RE = /^(#{1,4})\s+(.*)$/;
@@ -223,9 +224,12 @@ function parseBlocks(segment: string): Block[] {
         code.push(lines[i]);
         i++;
       }
-      i++; // consume the closing fence (or run off the end — unterminated
-      // fences render as code anyway, which also suits streaming chat text).
-      blocks.push({ kind: "fence", lang: f[1] || undefined, code: code.join("\n") });
+      // Whether we stopped on a closing fence line or ran off the end of the
+      // text (streaming chat mid-block) — unterminated fences still render as
+      // code (or, for marrow-action, a pending pill; see RichText below).
+      const closed = i < lines.length;
+      i++; // consume the closing fence (a no-op past the end).
+      blocks.push({ kind: "fence", lang: f[1] || undefined, code: code.join("\n"), closed });
       continue;
     }
     const h = line.match(HEADING_RE);
@@ -272,6 +276,125 @@ function parseBlocks(segment: string): Block[] {
   return blocks;
 }
 
+/** Runtime shape check for a parsed ```marrow-action payload — mirrors the
+ * schemas documented in `CHAT_UI_ACTIONS` (crates/core/src/chat.rs). Anything
+ * that doesn't match a known action renders as a plain code block instead of
+ * a chip, same as unparseable JSON. */
+function isChatAction(x: unknown): x is ChatAction {
+  if (!x || typeof x !== "object") return false;
+  const a = x as Record<string, unknown>;
+  switch (a.action) {
+    case "open_file":
+      return typeof a.path === "string" && (a.line === undefined || typeof a.line === "number");
+    case "open_overview":
+    case "next_file":
+    case "prev_file":
+      return true;
+    case "open_commit":
+      return typeof a.sha === "string";
+    case "set_hunk_filter":
+      return a.filter === "all" || a.filter === "high" || a.filter === "medium";
+    case "set_view_mode":
+      return a.mode === "split" || a.mode === "unified";
+    case "show_comments":
+      return typeof a.open === "boolean";
+    default:
+      return false;
+  }
+}
+
+/** Extract every CLOSED ```marrow-action fence from `text`, in appearance
+ * order — reusing `parseBlocks` so this always segments text identically to
+ * RichText's own rendering (no separate regex to drift out of sync). This is
+ * the single source of truth for `blockIndex` assignment, shared by
+ * RichText's chip rendering and App's streaming auto-execution effect.
+ * Tolerant JSON parse: `action` is null when the block's content isn't valid
+ * JSON or isn't a recognized action — callers fall back to raw-code / no-op. */
+export function parseActionFences(text: string): { json: string; action: ChatAction | null }[] {
+  const cleaned = text.replace(/<!--[\s\S]*?-->/g, "");
+  const out: { json: string; action: ChatAction | null }[] = [];
+  for (const b of parseBlocks(cleaned)) {
+    if (b.kind !== "fence" || b.lang !== "marrow-action" || !b.closed) continue;
+    const raw = b.code.trim();
+    let action: ChatAction | null = null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (isChatAction(parsed)) action = parsed;
+    } catch {
+      // Unparseable — action stays null, block renders/counts as a miss.
+    }
+    out.push({ json: raw, action });
+  }
+  return out;
+}
+
+/** Same as `parseActionFences`, but first splits on `[[thought:N]]` dividers
+ * exactly like ChatMarkdown does before handing text to RichText — so a
+ * `marrow-action` fence numbers identically whether it's read here (App's
+ * streaming auto-exec effect, scanning the raw message) or during rendering
+ * (ChatMarkdown, which renders each split part through its own RichText
+ * call). Splitting first means a divider landing inside a fence corrupts
+ * that fence's parse the same way on both sides — instead of the two
+ * disagreeing about where blocks start, which would misalign a status key
+ * from its chip. */
+export function parseChatActionFences(text: string): { json: string; action: ChatAction | null }[] {
+  return text.split(/\[\[thought:\d+\]\]/g).flatMap(parseActionFences);
+}
+
+/** Human label for a chat-action chip. */
+function actionChipLabel(a: ChatAction): string {
+  switch (a.action) {
+    case "open_file": {
+      const base = a.path.split("/").pop() || a.path;
+      return `Open ${base}${a.line ? `:${a.line}` : ""}`;
+    }
+    case "open_overview":
+      return "Back to overview";
+    case "next_file":
+      return "Next file";
+    case "prev_file":
+      return "Previous file";
+    case "open_commit":
+      return `Open commit ${a.sha.slice(0, 7)}`;
+    case "set_hunk_filter":
+      return `Filter hunks: ${a.filter}`;
+    case "set_view_mode":
+      return `${a.mode} view`;
+    case "show_comments":
+      return a.open ? "Show comments" : "Hide comments";
+  }
+}
+
+/** A clickable chip rendered in place of a completed ```marrow-action fence.
+ * Neutral/clickable when `status` is absent (not yet run, or a restored
+ * history message); ✓/✗ once it has been executed. `blockIndex` is this
+ * fence's position among the CLOSED marrow-action fences in the containing
+ * message (see `parseActionFences`) — passed back on click so the caller can
+ * record the status under the same key it looks status up with. */
+function ActionChip({
+  action,
+  blockIndex,
+  status,
+  onRunAction,
+}: {
+  action: ChatAction;
+  blockIndex: number;
+  status?: "done" | "failed";
+  onRunAction?: (a: ChatAction, blockIndex: number) => void;
+}) {
+  const icon = status === "done" ? "✓" : status === "failed" ? "✗" : "→";
+  return (
+    <button
+      type="button"
+      className={`chat-action-chip${status ? ` chat-action-chip--${status}` : ""}`}
+      onClick={() => onRunAction?.(action, blockIndex)}
+    >
+      <span className="chat-action-chip-icon" aria-hidden="true">{icon}</span>
+      {actionChipLabel(action)}
+    </button>
+  );
+}
+
 /** Inline nodes for multiple source lines, preserving single newlines as
  * breaks (GitHub renders PR-body newlines hard, like comments). */
 function renderLines(lines: string[], filePaths: string[], onOpenFile?: (path: string, line?: number) => void): React.ReactNode[] {
@@ -282,11 +405,40 @@ function renderLines(lines: string[], filePaths: string[], onOpenFile?: (path: s
 }
 
 /** Minimal GitHub-flavored markdown: fenced code (highlighted), headings,
- * lists with task boxes, quotes, rules, links, inline code/bold. Deliberately
- * small — the project has no Markdown dep; unknown syntax degrades to text. */
-export function RichText({ content, filePaths = [], onOpenFile }: { content: string; filePaths?: string[]; onOpenFile?: (path: string, line?: number) => void }) {
+ * lists with task boxes, quotes, rules, links, inline code/bold, and
+ * ```marrow-action fences (rendered as clickable chips, see ActionChip).
+ * Deliberately small — the project has no Markdown dep; unknown syntax
+ * degrades to text. */
+export function RichText({
+  content,
+  filePaths = [],
+  onOpenFile,
+  onRunAction,
+  actionStatuses,
+  blockIndexOffset = 0,
+}: {
+  content: string;
+  filePaths?: string[];
+  onOpenFile?: (path: string, line?: number) => void;
+  /** Chip click handler for a ```marrow-action block; `blockIndex` is its
+   * position among this message's closed action fences (see ActionChip). */
+  onRunAction?: (a: ChatAction, blockIndex: number) => void;
+  /** Execution status for this message's action blocks, keyed by
+   * `${blockIndex}:${JSON.stringify(action)}`. Absent entries render neutral. */
+  actionStatuses?: Record<string, "done" | "failed">;
+  /** Added to the blockIndex assigned to each action fence in this render —
+   * lets a caller (ChatMarkdown) that splits one message into several
+   * RichText calls (around `[[thought:N]]` dividers) keep indices contiguous
+   * across the whole message instead of restarting at 0 per segment. */
+  blockIndexOffset?: number;
+}) {
   // PR templates are full of HTML comments — never render them.
   const cleaned = content.replace(/<!--[\s\S]*?-->/g, "");
+  const actionFences = useMemo(() => parseActionFences(cleaned), [cleaned]);
+  // Running pointer into actionFences, advanced once per closed marrow-action
+  // fence encountered below — parseBlocks and parseActionFences segment the
+  // same `cleaned` text identically, so this stays in lockstep.
+  let actionPtr = 0;
   // Split on fenced code blocks, keeping the fences as delimiters.
   return (
     <>
@@ -294,8 +446,34 @@ export function RichText({ content, filePaths = [], onOpenFile }: { content: str
         return parseBlocks(cleaned).map((b, j) => {
           const key = `b-${j}`;
           switch (b.kind) {
-            case "fence":
+            case "fence": {
+              if (b.lang === "marrow-action") {
+                if (!b.closed) {
+                  return (
+                    <span key={key} className="chat-action-chip chat-action-chip--pending">
+                      action…
+                    </span>
+                  );
+                }
+                const localIndex = actionPtr++;
+                const blockIndex = blockIndexOffset + localIndex;
+                const entry = actionFences[localIndex];
+                if (entry?.action) {
+                  const statusKey = `${blockIndex}:${JSON.stringify(entry.action)}`;
+                  return (
+                    <ActionChip
+                      key={key}
+                      action={entry.action}
+                      blockIndex={blockIndex}
+                      status={actionStatuses?.[statusKey]}
+                      onRunAction={onRunAction}
+                    />
+                  );
+                }
+                // Unparseable / unrecognized — fall back to a plain code block.
+              }
               return <CodeBlock key={key} lang={b.lang} code={b.code} />;
+            }
             case "heading":
               return <div key={key} className={`rt-h rt-h--${b.level}`}>{renderInline(b.text, filePaths, onOpenFile)}</div>;
             case "hr":

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -6415,6 +6415,45 @@ mark.search-highlight-current {
   white-space: nowrap;
 }
 
+/* Chat ```marrow-action chips (issue #166) — a chip replaces the JSON, one
+ * per completed action fence; neutral/clickable until run, then ✓/✗. */
+.chat-action-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--accent-bg);
+  color: var(--accent-strong);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  padding: 3px 10px;
+  margin: 2px 0;
+  cursor: pointer;
+}
+.chat-action-chip:hover {
+  color: var(--accent-strong-hover);
+  border-color: var(--accent-strong);
+}
+.chat-action-chip-icon { font-size: 11px; }
+.chat-action-chip--done {
+  background: var(--diff-add-bg);
+  color: var(--diff-add-text);
+  border-color: var(--diff-add-text);
+}
+.chat-action-chip--failed {
+  background: var(--diff-remove-bg);
+  color: var(--diff-remove-text);
+  border-color: var(--diff-remove-text);
+}
+.chat-action-chip--pending {
+  color: var(--text-muted);
+  background: var(--chip-bg);
+  border-style: dashed;
+  font-style: italic;
+  cursor: default;
+}
+
 /* ─── RichText block-level markdown (PR descriptions, chat answers) ─────── */
 .rt-h { font-weight: 600; color: var(--text-primary); margin: var(--space-3) 0 var(--space-1); line-height: 1.3; }
 .rt-h:first-child { margin-top: 0; }

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -199,6 +199,20 @@ export type ChatStreamEvent =
   | { type: "done"; content: string }
   | { type: "error"; message: string };
 
+/** A view-control action the chat model can emit as a fenced ```marrow-action
+ * JSON block (see `CHAT_UI_ACTIONS` in `crates/core/src/chat.rs`, the single
+ * source of truth for the protocol). Mirrors the schemas documented there —
+ * keep the two in sync by hand. */
+export type ChatAction =
+  | { action: "open_file"; path: string; line?: number }
+  | { action: "open_overview" }
+  | { action: "next_file" }
+  | { action: "prev_file" }
+  | { action: "open_commit"; sha: string }
+  | { action: "set_hunk_filter"; filter: "all" | "high" | "medium" }
+  | { action: "set_view_mode"; mode: DiffViewMode }
+  | { action: "show_comments"; open: boolean };
+
 export type NoteResolutionState = "fixed" | "intentional" | "noise";
 
 /** How/why an AI note was resolved. Mirrors `NoteResolution` in

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -203,6 +203,8 @@ export type ChatStreamEvent =
  * JSON block (see `CHAT_UI_ACTIONS` in `crates/core/src/chat.rs`, the single
  * source of truth for the protocol). Mirrors the schemas documented there —
  * keep the two in sync by hand. */
+// Kept in sync BY HAND with CHAT_UI_ACTIONS (crates/core/src/chat.rs) and
+// isChatAction (components/RichText.tsx) — edit all three together.
 export type ChatAction =
   | { action: "open_file"; path: string; line?: number }
   | { action: "open_overview" }


### PR DESCRIPTION
Stage 1 of the #166 discovery: the chat model can now emit fenced `marrow-action` JSON blocks that Marrow executes as **navigational** actions and renders as status chips in the transcript.

## What
- **8 actions** (documented to the model in the system prompt): open file at line, overview, next/prev file, open commit in commit scope, hunk filter, split/unified view, comments panel. No mutations — resolve/comment/submit are explicitly out of scope for v1.
- **Protocol over provider features**: fenced blocks in the markdown stream, so it works identically on Anthropic, OpenAI-compatible, and the **local `claude` CLI** — no API tool-calling required, and providers that ignore the convention just produce today's prose.
- **Execution semantics**: each block runs once when its fence completes during live streaming (active tab only — a background stream finishing must not yank the current view; its chips stay neutral and clickable). Restored history never auto-executes; chips are click-to-run. Statuses (✓/✗) are session-only, keyed per message/block, never persisted.
- Block indices are computed identically on the execute side and render side via a shared thought-marker-aware parser, so chips and outcomes can't drift.

## Verification
- `bun run build`, `cargo check`, `cargo test -p marrow-core` 71/71 (new prompt-section test).
- Two adversarial verifier passes (one during implementation, one after): fixed a thought-marker/block-index edge, false-✓ on edge-of-list next/prev, and ambiguous commit-sha prefix resolution.
- **Live-tested on the local claude CLI provider** against this repo's PR #165: "Take me to the file with the pagination logic and switch to unified view" → model replied with an explanation + two action blocks → chips rendered ✓ and the app opened `github.rs:684` in unified view.

Part of #166 (stages 2–3 tracked there; stage 3 pairs with #150).

🤖 Generated with [Claude Code](https://claude.com/claude-code)