### PR TITLE
feat(gui): PR views as tabbed lenses — Overview / Files / Commits (#170)

### DIFF
--- a/app/src-tauri/crates/core/src/session.rs
+++ b/app/src-tauri/crates/core/src/session.rs
@@ -12,6 +12,11 @@ pub struct SessionPrEntry {
     pub pr_url: String,
     pub selected_file: Option<String>,
     pub sidebar_view: Option<String>,
+    /// Which PR lens (overview/files/commits, issue #170) this tab was on.
+    /// `#[serde(default)]` so session.json files written before this field
+    /// existed still deserialize instead of failing the whole restore.
+    #[serde(default)]
+    pub lens: Option<String>,
     pub selected_comment_file: Option<String>,
 }
 
@@ -37,4 +42,38 @@ pub fn save_session_state(state: &SessionState) -> Result<(), String> {
         serde_json::to_string(state).map_err(|e| format!("Failed to serialize session: {}", e))?;
     fs::write(&path, json).map_err(|e| format!("Failed to write session: {}", e))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A session.json written before the `lens` field existed must still
+    /// deserialize, defaulting the missing field to `None` rather than
+    /// failing the whole restore (issue #170).
+    #[test]
+    fn deserializes_pre_lens_entry_with_lens_none() {
+        let json = r#"{
+            "pr_url": "https://github.com/o/r/pull/1",
+            "selected_file": "src/lib.rs",
+            "sidebar_view": "tree",
+            "selected_comment_file": null
+        }"#;
+        let entry: SessionPrEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.lens, None);
+    }
+
+    #[test]
+    fn round_trips_lens_field() {
+        let entry = SessionPrEntry {
+            pr_url: "https://github.com/o/r/pull/1".to_string(),
+            selected_file: None,
+            sidebar_view: None,
+            lens: Some("files".to_string()),
+            selected_comment_file: None,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let restored: SessionPrEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.lens, Some("files".to_string()));
+    }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -12,7 +12,7 @@ import { LoadingView } from "./components/LoadingView";
 import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
 import { PrOverview } from "./components/PrOverview";
-import { CommitView } from "./components/CommitView";
+import { CommitsLens } from "./components/CommitsLens";
 import { NextFileBar } from "./components/NextFileBar";
 import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
@@ -28,7 +28,7 @@ import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, ChatAction, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures } from "./types";
+import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, ChatAction, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures, PrLens, ChangeGroup } from "./types";
 import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey } from "./utils";
 import type { ReviewSession } from "./hooks/useActivityFeed";
 
@@ -84,18 +84,18 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
-  // Commit scope (issue #147): while set, CommitView replaces the sidebar +
-  // diff pane for the active tab with a single commit's file list + a
-  // read-only patch view. commitScopePath is the selected file within that
-  // commit; the diff fetch's loading/error state is tracked alongside it. A
-  // session-only cache (never invalidated — commit diffs are immutable)
-  // keyed by sha avoids refetching on reopen.
-  const [commitScope, setCommitScope] = useState<PrCommit | null>(null);
-  const [commitScopePath, setCommitScopePath] = useState<string | null>(null);
+  // Commit scope (issue #147, per-tab as of #170): which commit the Commits
+  // lens is showing lives on the tab itself (tab.selectedCommit) so it can't
+  // leak across tabs. The fetched diff, its loading/error state, and the
+  // session-only cache (never invalidated — commit diffs are immutable) keyed
+  // by sha stay App-level, shared across tabs.
   const [commitDiffLoading, setCommitDiffLoading] = useState(false);
   const [commitDiffError, setCommitDiffError] = useState<string | null>(null);
   const [commitDiff, setCommitDiff] = useState<CommitDiff | null>(null);
   const commitDiffCacheRef = useRef(new Map<string, CommitDiff>());
+  // In-flight `${tabId}:${sha}` fetches, so the resync effect (on tab switch)
+  // and an interactive commit click never both issue the same request.
+  const commitDiffFetchingRef = useRef(new Set<string>());
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [welcomeOpen, setWelcomeOpen] = useState(false);
   // Cached PR whose head moved — re-analyzing costs an AI pass, so confirm.
@@ -228,13 +228,28 @@ function App() {
   const activeChecks = activeTab ? checksMap[activeTab.id] : undefined;
   const showChecksModal = !!activeTab && !!activeTab.manifest && !!activeChecks && activeChecks.overall_state !== "success" && !checksDismissed[activeTab.manifest.pr_url];
 
-  // Commit scope is layered per-tab state, not part of Tab itself — clear it
-  // on every active-tab change (click, keyboard cycle, new/opened PR, deep
-  // link) so a commit view from one tab never carries over onto another.
+  // commitDiff/commitDiffLoading/commitDiffError are single App-level slots
+  // (not per-tab — see the state declarations above), so switching tabs must
+  // resync them to whatever the newly-active tab's Commits lens should show:
+  // serve the cached diff, kick off a fetch on a cache miss, or clear the
+  // slots so a later entry into the lens starts clean. Also fires when the
+  // active tab's own lens/selectedCommit changes (entering/leaving Commits,
+  // or picking a different commit) so it stays one code path with clicks.
   useEffect(() => {
-    setCommitScope(null);
-    setCommitScopePath(null);
-  }, [activeTabId]);
+    if (!activeTab || activeTab.lens !== "commits" || !activeTab.selectedCommit) {
+      setCommitDiff(null);
+      setCommitDiffLoading(false);
+      setCommitDiffError(null);
+      return;
+    }
+    loadCommitDiff(activeTab.id, activeTab.selectedCommit);
+  }, [activeTabId, activeTab?.lens, activeTab?.selectedCommit]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Lens switcher segment counts (issue #170). Files count mirrors the
+  // relevant/fallback-to-total rule buildChatFiles uses for whole-PR chat scope.
+  const relevantFileCount = activeTab?.manifest?.files.filter((f) => f.classification === "RELEVANT").length ?? 0;
+  const filesLensCount = activeTab?.manifest ? (relevantFileCount > 0 ? relevantFileCount : activeTab.manifest.files.length) : 0;
+  const commitsLensCount = activeTab?.manifest?.commits.length ?? 0;
 
   const selectedFilePath = activeTab?.selectedFile?.path ?? null;
   const fileSearchMatches = useMemo(
@@ -294,18 +309,21 @@ function App() {
   // The review order is the sidebar's visible order (falls back to relevant
   // files in manifest order before the sidebar reports in). The sidebar is
   // unmounted while the overview shows, so the ref can hold another tab's
-  // paths — anything not in this manifest is dropped before use.
-  function guidedOrder(): string[] {
-    if (!activeTab?.manifest) return [];
-    const inManifest = new Set(activeTab.manifest.files.map((f) => f.path));
-    const visible = visibleOrderRef.current.filter((p) => inManifest.has(p));
+  // paths — anything not in this manifest is dropped before use. Defaults to
+  // activeTab (the common case); setLens takes an explicit tab so it works
+  // correctly even when called for a tab that isn't (yet) active.
+  function guidedOrder(tab: Tab | null = activeTab): string[] {
+    if (!tab?.manifest) return [];
+    const inManifest = new Set(tab.manifest.files.map((f) => f.path));
+    // visibleOrderRef only ever reflects the mounted (active) tab's sidebar.
+    const visible = tab.id === activeTabId ? visibleOrderRef.current.filter((p) => inManifest.has(p)) : [];
     const candidates = visible.length
       ? visible
-      : activeTab.manifest.files
+      : tab.manifest.files
           .filter((f) => f.classification !== "NOT_RELEVANT")
           .map((f) => f.path);
 
-    const reviewOrder = activeTab.manifest.triage?.review_order;
+    const reviewOrder = tab.manifest.triage?.review_order;
     if (!reviewOrder?.length) return candidates;
 
     const candidateSet = new Set(candidates);
@@ -325,14 +343,14 @@ function App() {
 
   // First unviewed file after `fromIdx` in review order (wrapping), treating
   // `alsoViewed` as already reviewed — used when the current file was just
-  // marked but state hasn't committed yet.
-  function nextUnviewed(order: string[], fromIdx: number, alsoViewed?: string): FileDiff | null {
-    if (!activeTab?.manifest || order.length === 0) return null;
-    const viewed = activeTab.viewedFiles;
+  // marked but state hasn't committed yet. Defaults to activeTab; see guidedOrder.
+  function nextUnviewed(order: string[], fromIdx: number, alsoViewed?: string, tab: Tab | null = activeTab): FileDiff | null {
+    if (!tab?.manifest || order.length === 0) return null;
+    const viewed = tab.viewedFiles;
     for (let step = 1; step <= order.length; step++) {
       const p = order[(fromIdx + step + order.length) % order.length];
       if (!viewed.has(p) && p !== alsoViewed) {
-        return activeTab.manifest.files.find((f) => f.path === p) ?? null;
+        return tab.manifest.files.find((f) => f.path === p) ?? null;
       }
     }
     return null;
@@ -409,7 +427,7 @@ function App() {
       onRefresh: () => { if (activeTab?.manifest) handleRefreshPr(); },
       onOpenSearch: () => searchRef.current?.open("local"),
       onToggleHelp: () => setHelpOpen((o) => !o),
-      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); setPaletteOpen(false); setCommitScope(null); },
+      onCloseOverlays: () => { setHelpOpen(false); setReviewPickerOpen(false); setPaletteOpen(false); },
       // Not during first-run setup — the palette would open invisibly under
       // the welcome card and pop up when setup closes.
       onTogglePalette: () => { if (!welcomeOpen) setPaletteOpen((v) => !v); },
@@ -438,10 +456,11 @@ function App() {
       onResolve: () => diffViewerRef.current?.resolveAtCursor(),
       onReviewPicker: () => { if (activeTab?.manifest) setReviewPickerOpen(true); },
       onToggleChat: () => { if (!welcomeOpen) toggleChatOpen(); },
+      onSetLens: (lens) => { if (activeTabId) setLens(activeTabId, lens); },
     },
     {
       enabled: !!activeTab?.manifest,
-      overlayOpen: helpOpen || settingsOpen || searchOpen || showChecksModal || reviewPickerOpen || paletteOpen || !!commitScope,
+      overlayOpen: helpOpen || settingsOpen || searchOpen || showChecksModal || reviewPickerOpen || paletteOpen,
     },
   );
 
@@ -454,6 +473,9 @@ function App() {
       // Land on the overview (summary + change groups), not a file — the
       // "Start review" CTA and sidebar are the ways in.
       selectedFile: null,
+      lens: "overview",
+      selectedCommit: null,
+      groupFilter: null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
@@ -481,6 +503,9 @@ function App() {
       loading: null,
       error: null,
       selectedFile: null,
+      lens: "overview",
+      selectedCommit: null,
+      groupFilter: null,
       viewedFiles: new Set(),
       staleViewedFiles: new Set(),
       dismissedHighlights: new Set(),
@@ -562,6 +587,22 @@ function App() {
                   } else {
                     tab.sidebarView = entry.sidebar_view as SidebarView;
                   }
+                }
+                // A session written before lenses existed (or a malformed
+                // value) falls back to "overview" rather than failing restore.
+                if (entry.lens === "files" || entry.lens === "commits") {
+                  tab.lens = entry.lens;
+                }
+                // Restoring straight into the Files lens without a selected
+                // file (no persisted selection, or it no longer exists) skips
+                // setLens entirely — auto-select guided-first here the same
+                // way, scoped to THIS tab rather than activeTab (guidedOrder/
+                // nextUnviewed both accept an explicit tab for exactly this).
+                if (tab.lens === "files" && !tab.selectedFile) {
+                  const order = guidedOrder(tab);
+                  const firstPath = nextUnviewed(order, -1, undefined, tab)?.path ?? order[0];
+                  const first = firstPath ? manifest.files.find((f) => f.path === firstPath) : undefined;
+                  if (first) tab.selectedFile = first;
                 }
                 return tab;
               } catch {
@@ -1197,7 +1238,8 @@ function App() {
         return true;
       }
       case "open_overview":
-        updateTab(tab.id, (t) => ({ ...t, selectedFile: null }));
+        // selectedFile is left as-is (Files lens returns to where it was).
+        setLens(tab.id, "overview");
         return true;
       case "next_file":
         return selectAdjacentFile(1);
@@ -1211,7 +1253,7 @@ function App() {
         const prefixed = commits.filter((c) => c.sha.startsWith(a.sha));
         const match = exact ?? (prefixed.length === 1 ? prefixed[0] : undefined);
         if (!match) return false;
-        handleViewCommit(match);
+        handleViewCommit(match, tab.id);
         return true;
       }
       case "set_hunk_filter":
@@ -1445,6 +1487,32 @@ function App() {
     setTabs((prev) => prev.map((t) => (t.id === tabId ? updater(t) : t)));
   }
 
+  /** Switch `tabId` to `lens`. The single place lens transitions happen —
+   * switcher clicks, keyboard 1/2/3, deep links, and chat actions all route
+   * through this (or through setSelectedFile/handleViewCommit, which set
+   * their matching lens directly since they already know the target).
+   * Entering Files with nothing selected auto-picks the first unviewed file
+   * in guided order (falling back to the first file); entering Commits with
+   * no commit scoped auto-picks the most recent commit and kicks off its
+   * diff fetch via handleViewCommit. */
+  function setLens(tabId: string, lens: PrLens) {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    if (!tab?.manifest) return;
+    if (lens === "files" && !tab.selectedFile) {
+      const order = guidedOrder(tab);
+      const firstPath = nextUnviewed(order, -1, undefined, tab)?.path ?? order[0];
+      const first = firstPath ? tab.manifest.files.find((f) => f.path === firstPath) : undefined;
+      updateTab(tabId, (t) => ({ ...t, lens, selectedFile: first ?? t.selectedFile }));
+      return;
+    }
+    if (lens === "commits" && !tab.selectedCommit) {
+      const commits = tab.manifest.commits;
+      const first = commits[commits.length - 1];
+      if (first) { handleViewCommit(first, tabId); return; }
+    }
+    updateTab(tabId, (t) => ({ ...t, lens }));
+  }
+
   async function handleRefreshPr(tabId?: string) {
     const targetId = tabId ?? activeTabId;
     const tab = tabsRef.current.find((t) => t.id === targetId);
@@ -1515,6 +1583,13 @@ function App() {
         // fetched for the old one — re-fetch is driven by the idle-state effect.
         checkAnnotations: { status: "idle" },
         newHighlightKeys,
+        // A change-group filter naming a group the re-analysis dropped would
+        // otherwise linger invisibly and silently reapply if a same-labeled
+        // group ever came back — clear it rather than carry a dangling scope.
+        groupFilter:
+          tab.groupFilter && (newManifest.change_groups ?? []).some((g) => g.label === tab.groupFilter)
+            ? tab.groupFilter
+            : null,
       };
 
       updateTab(tab.id, () => refreshedTab);
@@ -1567,8 +1642,19 @@ function App() {
     }
   }
 
+  // The single low-level "select a file" primitive — every open-file path
+  // (sidebar clicks, search, chat citations, top-risk rows, next/prev,
+  // guided review) routes through this, so always landing in the Files lens
+  // needs no per-callsite changes (issue #170).
   function setSelectedFile(file: FileDiff) {
-    updateTab(activeTabId,(t) => ({ ...t, selectedFile: file }));
+    updateTab(activeTabId, (t) => ({ ...t, selectedFile: file, lens: "files" }));
+  }
+
+  /** A change-group row on the Overview — scopes the Files sidebar to the
+   * group and opens it at the group's first file (issue #170). */
+  function openGroup(group: ChangeGroup, files: FileDiff[]) {
+    if (!activeTabId || files.length === 0) return;
+    updateTab(activeTabId, (t) => ({ ...t, groupFilter: group.label, lens: "files", selectedFile: files[0] }));
   }
 
   function toggleViewed(filePath: string) {
@@ -1665,62 +1751,68 @@ function App() {
     }
   }
 
-  /** Commit row click in the Commits card (or a Newer/Older nav in CommitView)
-   * — enters/moves commit scope, serving from the session cache when this sha
-   * was already fetched. */
-  async function handleViewCommit(commit: PrCommit) {
-    setCommitScope(commit);
+  /** Load `commit`'s diff for `tabId` into the shared App-level slots —
+   * serving the cache when it hits, and fetching on a miss. The single fetch
+   * path for both an interactive commit click (handleViewCommit) and the
+   * tab-switch resync effect above, so they can't diverge. Only ever writes
+   * the *visible* slots (setCommitDiff/Loading/Error) when `tabId` is still
+   * the active tab at the time — cache writes are unconditional (shas are
+   * immutable, so a background-tab fetch resolving late is still good data
+   * for whenever that tab becomes active again). `commitDiffFetchingRef`
+   * dedupes a request already in flight for this exact tab+sha (the resync
+   * effect and a click can both ask for the same thing in the same tick). */
+  async function loadCommitDiff(tabId: string, commit: PrCommit) {
+    const key = `${tabId}:${commit.sha}`;
     const cached = commitDiffCacheRef.current.get(commit.sha);
     if (cached) {
-      setCommitDiff(cached);
-      setCommitDiffError(null);
-      setCommitDiffLoading(false);
-      setCommitScopePath(cached.files[0]?.path ?? null);
+      if (activeTabIdRef.current === tabId) {
+        setCommitDiff(cached);
+        setCommitDiffError(null);
+        setCommitDiffLoading(false);
+      }
       return;
     }
-    const tab = tabsRef.current.find((t) => t.id === activeTabId);
+    if (activeTabIdRef.current === tabId) {
+      setCommitDiff(null);
+      setCommitDiffError(null);
+      setCommitDiffLoading(true);
+    }
+    if (commitDiffFetchingRef.current.has(key)) return;
+    const tab = tabsRef.current.find((t) => t.id === tabId);
     if (!tab?.manifest) return;
-    setCommitDiff(null);
-    setCommitDiffError(null);
-    setCommitScopePath(null);
-    setCommitDiffLoading(true);
+    commitDiffFetchingRef.current.add(key);
     try {
       const diff = await invoke<CommitDiff>("get_commit_diff", {
         prRef: tab.manifest.pr_url,
         sha: commit.sha,
       });
       commitDiffCacheRef.current.set(commit.sha, diff);
-      // A late resolve after the user switched to another commit (or exited
-      // the scope) must not clobber whatever's now showing.
-      setCommitScope((current) => {
-        if (current?.sha === commit.sha) {
-          setCommitDiff(diff);
-          setCommitDiffLoading(false);
-          setCommitScopePath(diff.files[0]?.path ?? null);
-        }
-        return current;
-      });
+      // A late resolve after the user switched to another commit, or away
+      // from this tab entirely, must not clobber whatever's now showing.
+      const current = tabsRef.current.find((t) => t.id === tabId);
+      if (activeTabIdRef.current === tabId && current?.selectedCommit?.sha === commit.sha) {
+        setCommitDiff(diff);
+        setCommitDiffLoading(false);
+      }
     } catch (err) {
-      setCommitScope((current) => {
-        if (current?.sha === commit.sha) {
-          setCommitDiffError(String(err));
-          setCommitDiffLoading(false);
-        }
-        return current;
-      });
+      const current = tabsRef.current.find((t) => t.id === tabId);
+      if (activeTabIdRef.current === tabId && current?.selectedCommit?.sha === commit.sha) {
+        setCommitDiffError(String(err));
+        setCommitDiffLoading(false);
+      }
+    } finally {
+      commitDiffFetchingRef.current.delete(key);
     }
   }
 
-  /** The commit adjacent to `commit` in `manifest.commits` (oldest-first) —
-   * "newer" walks toward the end of that array, "older" toward the start.
-   * The Commits card displays newest-first (reversed), so this is the
-   * inverse of index adjacency in the card's own render order. */
-  function commitNeighbor(commit: PrCommit, direction: "newer" | "older"): PrCommit | null {
-    const commits = activeTab?.manifest?.commits;
-    if (!commits) return null;
-    const idx = commits.findIndex((c) => c.sha === commit.sha);
-    if (idx === -1) return null;
-    return commits[direction === "newer" ? idx + 1 : idx - 1] ?? null;
+  /** Commit row click (Commits card, Commits lens rail, or a Newer/Older nav)
+   * — enters/moves commit scope on `tabId` (defaulting to the active tab) and
+   * switches it to the Commits lens. Per-tab as of #170: `selectedCommit`
+   * lives on the tab so it can't leak onto another tab's canvas; the fetched
+   * diff itself stays a single App-level slot (see loadCommitDiff above). */
+  function handleViewCommit(commit: PrCommit, tabId: string = activeTabId!) {
+    updateTab(tabId, (t) => ({ ...t, selectedCommit: commit, lens: "commits" }));
+    loadCommitDiff(tabId, commit);
   }
 
   /** File-group header click in the comments panel — jump to the file, no thread scroll. */
@@ -2288,6 +2380,7 @@ function App() {
             pr_url: t.manifest!.pr_url,
             selected_file: t.selectedFile?.path ?? null,
             sidebar_view: t.sidebarView,
+            lens: t.lens,
             // Retired with the comments panel (#144) — kept on the wire type
             // for schema stability, always written null now.
             selected_comment_file: null,
@@ -2360,7 +2453,7 @@ function App() {
   if (activeTab?.manifest) {
     const m = activeTab.manifest;
     paletteCommands.push(
-      { id: "overview", section: "Review", title: "Back to overview", run: () => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, selectedFile: null })); } },
+      { id: "overview", section: "Review", title: "Back to overview", run: () => { if (activeTabId) setLens(activeTabId, "overview"); } },
       { id: "next-file", section: "Review", title: "Next file", keys: "]", run: () => selectAdjacentFile(1) },
       { id: "prev-file", section: "Review", title: "Previous file", keys: "[", run: () => selectAdjacentFile(-1) },
       { id: "mark-viewed", section: "Review", title: "Mark file reviewed", keys: "V", run: () => { const p = activeTab.selectedFile?.path; if (p) toggleViewed(p); } },
@@ -2454,7 +2547,10 @@ function App() {
         onCloseTab={closeTab}
         onNewReview={handleNewReview}
         viewedCount={activeTab?.viewedFiles.size ?? 0}
-        staleCount={activeTab?.staleViewedFiles.size ?? 0}
+        lens={activeTab?.lens ?? "overview"}
+        onSetLens={(lens) => { if (activeTabId) setLens(activeTabId, lens); }}
+        filesCount={filesLensCount}
+        commitsCount={commitsLensCount}
         onSettingsClick={() => setSettingsOpen(true)}
         manifest={activeTab?.manifest ?? null}
         showHunkSignificance={showHunkSignificance}
@@ -2571,22 +2667,19 @@ function App() {
           onOpenChange={setSearchOpen}
         />
         <div className="main-content">
-          {commitScope ? (
-            <CommitView
-              commit={commitScope}
+          {activeTab.lens === "commits" ? (
+            <CommitsLens
+              commits={activeTab.manifest.commits}
+              selectedCommit={activeTab.selectedCommit}
               diff={commitDiff}
               loading={commitDiffLoading}
               error={commitDiffError}
-              selectedPath={commitScopePath}
-              onSelectFile={setCommitScopePath}
+              commitDiffCache={commitDiffCacheRef.current}
               repoBaseUrl={repoBaseUrl(activeTab.manifest.pr_url)}
-              onBack={() => setCommitScope(null)}
-              onNewer={() => { const n = commitNeighbor(commitScope, "newer"); if (n) handleViewCommit(n); }}
-              onOlder={() => { const n = commitNeighbor(commitScope, "older"); if (n) handleViewCommit(n); }}
-              hasNewer={commitNeighbor(commitScope, "newer") !== null}
-              hasOlder={commitNeighbor(commitScope, "older") !== null}
+              onSelectCommit={(c) => handleViewCommit(c)}
+              onViewCumulativeDiff={() => { if (activeTabId) setLens(activeTabId, "files"); }}
             />
-          ) : !activeTab.selectedFile ? (
+          ) : activeTab.lens === "overview" ? (
             <PrOverview
               manifest={activeTab.manifest}
               checksStatus={activeChecks ?? null}
@@ -2598,6 +2691,7 @@ function App() {
               startTarget={nextUnviewed(guidedOrder(), -1)}
               onStartReview={() => { const t = nextUnviewed(guidedOrder(), -1); if (t) setSelectedFile(t); }}
               onSelectFile={setSelectedFile}
+              onOpenGroup={openGroup}
               onOpenAt={handleChatOpenFile}
               onBriefMe={briefMe}
               onViewCommit={handleViewCommit}
@@ -2629,7 +2723,8 @@ function App() {
             commentsOpen={activeTab.commentsOpen ?? false}
             onToggleComments={toggleThreadsView}
             onVisibleFilesChange={handleVisibleFilesChange}
-            onShowOverview={() => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, selectedFile: null })); }}
+            groupFilter={activeTab.groupFilter}
+            onClearGroupFilter={() => { if (activeTabId) updateTab(activeTabId, (t) => ({ ...t, groupFilter: null })); }}
           />
           <div className="diff-pane">
             {activeTab.selectedFile ? (

--- a/app/src/components/CommitView.tsx
+++ b/app/src/components/CommitView.tsx
@@ -11,11 +11,13 @@ interface CommitViewProps {
   selectedPath: string | null;
   onSelectFile: (path: string) => void;
   repoBaseUrl: string;
-  onBack: () => void;
   onNewer: () => void;
   onOlder: () => void;
   hasNewer: boolean;
   hasOlder: boolean;
+  /** "View cumulative diff" chip in the meta row — hops to the Files lens
+   * (issue #170; this scope no longer has a "back" exit of its own). */
+  onViewCumulativeDiff: () => void;
 }
 
 /** Classifies a raw patch line by its leading character, mapping onto the
@@ -109,11 +111,11 @@ export function CommitView({
   selectedPath,
   onSelectFile,
   repoBaseUrl,
-  onBack,
   onNewer,
   onOlder,
   hasNewer,
   hasOlder,
+  onViewCumulativeDiff,
 }: CommitViewProps) {
   const commitUrl = `${repoBaseUrl}/commit/${commit.sha}`;
   const selectedFile = diff?.files.find((f) => f.path === selectedPath) ?? null;
@@ -121,9 +123,6 @@ export function CommitView({
   return (
     <>
       <aside className="file-sidebar commit-view-sidebar">
-        <button className="sidebar-overview-link" onClick={onBack}>
-          ← Back to review
-        </button>
         <div className="commit-view-identity">
           <div className="commit-view-nav">
             <button className="commit-view-nav-btn" onClick={onNewer} disabled={!hasNewer}>
@@ -136,6 +135,10 @@ export function CommitView({
           <span className="commit-view-sha">{commit.sha.slice(0, 7)}</span>
           <p className="commit-view-headline">{commit.message_headline}</p>
           <div className="commit-view-meta">
+            <span className="scope-pill">◉ This commit only</span>
+            <button type="button" className="overview-chip commit-view-cumulative" onClick={onViewCumulativeDiff}>
+              View cumulative diff
+            </button>
             {commit.author_login && (
               <span className="commit-view-author">
                 <Avatar login={commit.author_login} size={16} /> {commit.author_login}

--- a/app/src/components/CommitsLens.tsx
+++ b/app/src/components/CommitsLens.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import { CommitView } from "./CommitView";
+import { timeAgo } from "../utils";
+import type { CommitDiff, PrCommit } from "../types";
+
+interface CommitsLensProps {
+  /** This PR's commits, oldest first (same order/data as the overview card). */
+  commits: PrCommit[];
+  /** The commit the right pane is scoped to; null only transiently (e.g. a
+   * session restored straight into this lens before the auto-select effect
+   * below runs). */
+  selectedCommit: PrCommit | null;
+  diff: CommitDiff | null;
+  loading: boolean;
+  error: string | null;
+  /** Session cache of already-fetched commit diffs (App-level, keyed by sha)
+   * — read opportunistically for the rail's +/− stats, which PrCommit itself
+   * doesn't carry. A row shows no stats until its diff has been fetched once. */
+  commitDiffCache: Map<string, CommitDiff>;
+  repoBaseUrl: string;
+  onSelectCommit: (commit: PrCommit) => void;
+  onViewCumulativeDiff: () => void;
+}
+
+/** Sum of +/− across a fetched commit diff's files, or null when the diff
+ * hasn't been fetched (and so isn't in the cache) yet. */
+function cachedStats(cache: Map<string, CommitDiff>, sha: string): { additions: number; deletions: number } | null {
+  const diff = cache.get(sha);
+  if (!diff) return null;
+  return diff.files.reduce(
+    (acc, f) => ({ additions: acc.additions + f.additions, deletions: acc.deletions + f.deletions }),
+    { additions: 0, deletions: 0 },
+  );
+}
+
+function CommitRow({
+  commit,
+  selected,
+  stats,
+  onSelect,
+}: {
+  commit: PrCommit;
+  selected: boolean;
+  stats: { additions: number; deletions: number } | null;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`commits-lens-row${selected ? " selected" : ""}`}
+      onClick={onSelect}
+      title={commit.message_headline}
+    >
+      <span className="commits-lens-row-msg">{commit.message_headline}</span>
+      <span className="commits-lens-row-meta">
+        <span className="commits-lens-row-sha">{commit.sha.slice(0, 7)}</span>
+        {commit.author_login && <span>{commit.author_login}</span>}
+        <span>{timeAgo(commit.committed_at, true)}</span>
+        {stats && (
+          <span className="commits-lens-row-stats">
+            <span className="line-stat-add">+{stats.additions}</span>{" "}
+            <span className="line-stat-del">−{stats.deletions}</span>
+          </span>
+        )}
+      </span>
+    </button>
+  );
+}
+
+/** The Commits lens (issue #170): a rail of every commit in the PR (the
+ * sidebar's quiet-row grammar) driving the existing per-commit CommitView as
+ * its main pane. Replaces the old "commit scope" that dropped in over the
+ * sidebar + diff pane — this is a persistent, first-class lens instead. */
+export function CommitsLens({
+  commits,
+  selectedCommit,
+  diff,
+  loading,
+  error,
+  commitDiffCache,
+  repoBaseUrl,
+  onSelectCommit,
+  onViewCumulativeDiff,
+}: CommitsLensProps) {
+  // Which file within the selected commit's diff the main pane shows — purely
+  // presentational to this lens, so it lives here rather than on Tab or App.
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSelectedPath(diff?.files[0]?.path ?? null);
+  }, [diff]);
+
+  // Land on a commit even if this lens was entered without one selected yet
+  // (e.g. a restored session) — mirrors setLens's auto-select for a fresh switch.
+  useEffect(() => {
+    if (!selectedCommit && commits.length > 0) {
+      onSelectCommit(commits[commits.length - 1]);
+    }
+  }, [selectedCommit, commits, onSelectCommit]);
+
+  return (
+    <>
+      <aside className="commits-lens-rail">
+        <div className="commits-lens-rail-head">
+          Commits <span className="commits-lens-rail-count">· {commits.length}</span>
+        </div>
+        <div className="commits-lens-rail-list">
+          {commits.map((commit) => (
+            <CommitRow
+              key={commit.sha}
+              commit={commit}
+              selected={commit.sha === selectedCommit?.sha}
+              stats={cachedStats(commitDiffCache, commit.sha)}
+              onSelect={() => onSelectCommit(commit)}
+            />
+          ))}
+        </div>
+      </aside>
+      {selectedCommit && (
+        <CommitView
+          commit={selectedCommit}
+          diff={diff}
+          loading={loading}
+          error={error}
+          selectedPath={selectedPath}
+          onSelectFile={setSelectedPath}
+          repoBaseUrl={repoBaseUrl}
+          onNewer={() => {
+            const idx = commits.findIndex((c) => c.sha === selectedCommit.sha);
+            const n = commits[idx + 1];
+            if (n) onSelectCommit(n);
+          }}
+          onOlder={() => {
+            const idx = commits.findIndex((c) => c.sha === selectedCommit.sha);
+            const o = commits[idx - 1];
+            if (o) onSelectCommit(o);
+          }}
+          hasNewer={commits.findIndex((c) => c.sha === selectedCommit.sha) < commits.length - 1}
+          hasOlder={commits.findIndex((c) => c.sha === selectedCommit.sha) > 0}
+          onViewCumulativeDiff={onViewCumulativeDiff}
+        />
+      )}
+      {!selectedCommit && (
+        <div className="diff-pane commit-view-pane">
+          <div className="no-file-selected">No commits fetched for this PR.</div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -23,7 +23,10 @@ interface FileSidebarProps {
   onToggleComments: () => void;
   /** Emits the visible file paths in manifest order, for keyboard file navigation. */
   onVisibleFilesChange?: (paths: string[]) => void;
-  onShowOverview?: () => void;
+  /** Change-group name scoping the file list (a change-group deep link from
+   * the Overview), or null for the full list. */
+  groupFilter?: string | null;
+  onClearGroupFilter?: () => void;
 }
 
 function getMaxHunkSignificance(file: FileDiff): string {
@@ -348,7 +351,7 @@ function TreeFolder({
 /* ─── Main component ────────────────────────────────────────────────────── */
 
 export function FileSidebar({
-  files,
+  files: allFiles,
   changeGroups,
   selectedFile,
   onSelectFile,
@@ -365,8 +368,15 @@ export function FileSidebar({
   commentsOpen,
   onToggleComments,
   onVisibleFilesChange,
-  onShowOverview,
+  groupFilter,
+  onClearGroupFilter,
 }: FileSidebarProps) {
+  // A change-group deep link (issue #170) scopes every view mode to that
+  // group's files — everything below derives from `files`, not the raw prop,
+  // so Groups/Category/Tree and the guided [ / ] order all narrow together.
+  const activeGroup = groupFilter ? changeGroups.find((g) => g.label === groupFilter) : undefined;
+  const files = activeGroup ? allFiles.filter((f) => activeGroup.file_paths.includes(f.path)) : allFiles;
+
   const hasGroups = changeGroups.length > 0;
   const prevHasGroups = useRef(hasGroups);
 
@@ -532,13 +542,9 @@ export function FileSidebar({
 
   return (
     <aside className="file-sidebar">
-      {onShowOverview && (
-        <button
-          className={`sidebar-overview-link${selectedFile === null ? " active" : ""}`}
-          onClick={onShowOverview}
-          title="Back to the PR summary and change groups"
-        >
-          ← Overview
+      {activeGroup && onClearGroupFilter && (
+        <button type="button" className="overview-chip sidebar-group-filter" onClick={onClearGroupFilter}>
+          Group: {activeGroup.label} ✕
         </button>
       )}
       <div className="sidebar-header">

--- a/app/src/components/FileSidebar.tsx
+++ b/app/src/components/FileSidebar.tsx
@@ -532,8 +532,10 @@ export function FileSidebar({
     onVisibleFilesChange?.(navigableOrder);
   }, [navigableOrder, onVisibleFilesChange]);
 
-  const viewedCount = viewedFiles.size;
-  const staleCount = staleViewedFiles.size;
+  // Scope the counts to the (possibly group-filtered) list, not the whole PR —
+  // otherwise "N/M viewed" can exceed M while a group filter is active.
+  const viewedCount = files.reduce((n, f) => n + (viewedFiles.has(f.path) ? 1 : 0), 0);
+  const staleCount = files.reduce((n, f) => n + (staleViewedFiles.has(f.path) ? 1 : 0), 0);
   const totalCount = files.length;
   const unresolvedCommentCount = useMemo(
     () => commentThreads.filter((t) => !t.is_resolved).length,

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
-import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState } from "../types";
+import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState, PrLens } from "../types";
 
 function useClickOutside(
   ref: React.RefObject<HTMLElement | null>,
@@ -38,7 +38,12 @@ interface HeaderProps {
   onCloseTab: (id: string) => void;
   onNewReview: () => void;
   viewedCount: number;
-  staleCount: number;
+  /** Which PR lens (Overview/Files/Commits, issue #170) the switcher shows active. */
+  lens: PrLens;
+  onSetLens: (lens: PrLens) => void;
+  /** Files segment count — relevant files, falling back to total when 0 relevant. */
+  filesCount: number;
+  commitsCount: number;
   onSettingsClick: () => void;
   manifest: ReviewManifest | null;
   showHunkSignificance: boolean;
@@ -64,7 +69,10 @@ export function Header({
   onCloseTab,
   onNewReview,
   viewedCount,
-  staleCount,
+  lens,
+  onSetLens,
+  filesCount,
+  commitsCount,
   onSettingsClick,
   manifest,
   showHunkSignificance,
@@ -133,12 +141,6 @@ export function Header({
       {manifest && (
         <div className="header-toolbar">
           <div className="header-left">
-            <span className="file-count">
-              {viewedCount}/{totalCount} reviewed
-              {staleCount > 0 && (
-                <span className="stale-badge">{staleCount} changed</span>
-              )}
-            </span>
             {(myReviewState ? myReviewState.draft : manifest.draft) && !myReviewState?.is_merged && (
               <span className="pr-badge pr-badge--draft" title="This PR is a draft">Draft</span>
             )}
@@ -155,9 +157,7 @@ export function Header({
                 {REVIEW_STATUS_SYMBOL.approved} Approved
               </span>
             )}
-            <div className="progress-bar">
-              <div className="progress-fill" style={{ width: `${progress}%` }} />
-            </div>
+            <LensSwitcher lens={lens} onSetLens={onSetLens} filesCount={filesCount} commitsCount={commitsCount} filesProgress={progress} />
             {onRefresh && (
               <button
                 className={`refresh-button${isRefreshing ? " refreshing" : ""}`}
@@ -195,6 +195,51 @@ export function Header({
         </div>
       )}
     </header>
+  );
+}
+
+/** The PR-view lens switcher (issue #170) — same segmented-control grammar as
+ * the Split/Unified toggle, sized for the header. Files absorbs the old
+ * header progress bar as a hairline under its label; Overview no longer
+ * disappears when you dive into a file, and the "← Overview" escape hatch
+ * dissolves into this. */
+function LensSwitcher({
+  lens,
+  onSetLens,
+  filesCount,
+  commitsCount,
+  filesProgress,
+}: {
+  lens: PrLens;
+  onSetLens: (lens: PrLens) => void;
+  filesCount: number;
+  commitsCount: number;
+  filesProgress: number;
+}) {
+  return (
+    <div className="lens-switcher">
+      <button
+        className={`seg-item${lens === "overview" ? " active" : ""}`}
+        onClick={() => onSetLens("overview")}
+      >
+        Overview
+      </button>
+      <button
+        className={`seg-item${lens === "files" ? " active" : ""}`}
+        onClick={() => onSetLens("files")}
+      >
+        Files <span className="seg-count">{filesCount}</span>
+        <span className="seg-progress">
+          <span className="seg-progress-fill" style={{ width: `${filesProgress}%` }} />
+        </span>
+      </button>
+      <button
+        className={`seg-item${lens === "commits" ? " active" : ""}`}
+        onClick={() => onSetLens("commits")}
+      >
+        Commits <span className="seg-count">{commitsCount}</span>
+      </button>
+    </div>
   );
 }
 

--- a/app/src/components/KeyboardHelp.tsx
+++ b/app/src/components/KeyboardHelp.tsx
@@ -18,6 +18,14 @@ interface Section {
 // bindings that actually work — don't advertise TUI keys the GUI doesn't honor yet.
 const SECTIONS: Section[] = [
   {
+    title: "Views",
+    bindings: [
+      { keys: ["1"], label: "Overview" },
+      { keys: ["2"], label: "Files" },
+      { keys: ["3"], label: "Commits" },
+    ],
+  },
+  {
     title: "Navigation",
     bindings: [
       { keys: ["]"], label: "Next file" },

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -18,6 +18,8 @@ interface PrOverviewProps {
   startTarget: FileDiff | null;
   onStartReview: () => void;
   onSelectFile: (f: FileDiff) => void;
+  /** Change-group row click — scopes the Files lens to that group (issue #170). */
+  onOpenGroup: (group: ChangeGroup, files: FileDiff[]) => void;
   /** Keys (see highlightKey) of AI highlights introduced by the most recent
    * refresh's re-analysis — surfaced as a "new AI notes" chip when non-empty. */
   newHighlightKeys?: Set<string>;
@@ -92,11 +94,11 @@ function DescriptionCard({ body }: { body: string }) {
 function GroupRow({
   group,
   files,
-  onSelectFile,
+  onOpenGroup,
 }: {
   group: ChangeGroup;
   files: FileDiff[];
-  onSelectFile: (f: FileDiff) => void;
+  onOpenGroup: (group: ChangeGroup, files: FileDiff[]) => void;
 }) {
   if (files.length === 0) return null;
   const criticalNotes = files.reduce(
@@ -107,7 +109,7 @@ function GroupRow({
     (f) => f.risk_level === "critical" || f.risk_level === "high"
   ).length;
   return (
-    <button className="overview-group" onClick={() => onSelectFile(files[0])}>
+    <button className="overview-group" onClick={() => onOpenGroup(group, files)}>
       <div className="overview-group-main">
         <div className="overview-group-name">{group.label}</div>
         {group.description && (
@@ -295,6 +297,7 @@ export function PrOverview({
   startTarget,
   onStartReview,
   onSelectFile,
+  onOpenGroup,
   newHighlightKeys,
   onOpenAt,
   onBriefMe,
@@ -386,7 +389,7 @@ export function PrOverview({
                 files={g.file_paths
                   .map((p) => byPath.get(p))
                   .filter((f): f is FileDiff => !!f)}
-                onSelectFile={onSelectFile}
+                onOpenGroup={onOpenGroup}
               />
             ))}
           </div>

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import type { PrLens } from "../types";
 
 /**
  * Global keyboard shortcuts for the review GUI, ported from the CLI/TUI
@@ -49,6 +50,8 @@ export interface ShortcutHandlers {
   onTogglePalette: () => void;
   /** Toggle the conversational diff Q&A panel (Cmd/Ctrl+J). */
   onToggleChat: () => void;
+  /** Switch the PR view lens (1/2/3 — issue #170). */
+  onSetLens: (lens: PrLens) => void;
 }
 
 export interface ShortcutOptions {
@@ -173,6 +176,10 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
       switch (e.key) {
         case "]": h.onNextFile(); break;
         case "[": h.onPrevFile(); break;
+        // PR view lenses (issue #170) — spatial order left to right.
+        case "1": h.onSetLens("overview"); break;
+        case "2": h.onSetLens("files"); break;
+        case "3": h.onSetLens("commits"); break;
         case "V": h.onToggleViewed(); break;
         case "T": h.onToggleThreads(); break;
         case "F5": h.onRefresh(); e.preventDefault(); break;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -310,31 +310,6 @@ body {
   min-width: 0;
 }
 
-.file-count {
-  font-size: 12px;
-  color: var(--text-secondary);
-  background: var(--bg-tertiary);
-  padding: 2px 8px;
-  border-radius: 10px;
-  flex-shrink: 0;
-}
-
-.progress-bar {
-  width: 80px;
-  height: 4px;
-  background: var(--bg-tertiary);
-  border-radius: 2px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.progress-fill {
-  height: 100%;
-  background: var(--diff-add-text);
-  border-radius: 2px;
-  transition: width 0.3s ease;
-}
-
 .header-right {
   display: flex;
   align-items: center;
@@ -458,6 +433,78 @@ body {
   color: var(--text-primary);
 }
 
+/* ─── PR view lens switcher (issue #170) ─────────────────────────────────
+   Same segmented-control grammar as .view-toggle, sized for the header —
+   pill container, filled active segment. Class names/values match the
+   design mockup verbatim (.seg-item, .seg-count, .seg-progress). */
+.lens-switcher {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 3px;
+}
+
+.seg-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 14px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: none;
+  color: var(--text-secondary);
+  font-weight: 500;
+  font-size: 12.5px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.seg-item:hover:not(.active) {
+  color: var(--text-primary);
+}
+
+.seg-item.active {
+  background: var(--accent-strong);
+  color: var(--white);
+}
+
+.seg-count {
+  font: 500 11px/1 var(--font-mono);
+  background: var(--chip-bg);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  padding: 3px 7px;
+}
+
+.seg-item.active .seg-count {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: transparent;
+  color: inherit;
+}
+
+/* Reviewed-progress hairline, absorbed from the old header progress bar. */
+.seg-progress {
+  position: absolute;
+  left: 14px;
+  right: 14px;
+  bottom: 2px;
+  height: 2px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.seg-progress-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--white);
+}
+
 .github-link {
   color: var(--accent);
   text-decoration: none;
@@ -478,6 +525,20 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* Change-group deep link scope (issue #170) — reuses .overview-chip's
+   grammar for a dismissible pill above the file list. */
+.sidebar-group-filter {
+  display: flex;
+  width: calc(100% - 24px);
+  margin: 10px 12px 0;
+  cursor: pointer;
+}
+
+.sidebar-group-filter:hover {
+  border-color: var(--text-muted);
+  color: var(--text-primary);
 }
 
 .sidebar-header {
@@ -1270,8 +1331,9 @@ tr.cursor-selected td {
 
 .commit-view-meta {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   margin-top: 6px;
   font-size: 11.5px;
   color: var(--text-secondary);
@@ -1357,6 +1419,111 @@ tr.cursor-selected td {
 
 .commit-view-patch > div {
   padding: 0 12px;
+}
+
+.commit-view-cumulative {
+  cursor: pointer;
+}
+
+/* Static scope indicator in CommitView's meta row ("◉ This commit only"),
+   issue #170 — accent-tinted like .overview-chip--new-notes, but never
+   clickable (that's what the adjacent "View cumulative diff" chip is for). */
+.scope-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-bg);
+  color: var(--accent);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+/* ─── Commits lens (issue #170) — rail of every commit, mirroring the file
+   sidebar's quiet-row + selected grammar; CommitView (above) is its main
+   pane. ──────────────────────────────────────────────────────────────── */
+.commits-lens-rail {
+  width: 360px;
+  min-width: 360px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.commits-lens-rail-head {
+  padding: var(--space-3) 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  font-weight: 650;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.commits-lens-rail-count {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.commits-lens-rail-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.commits-lens-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.commits-lens-row:hover {
+  background: var(--bg-tertiary);
+}
+
+.commits-lens-row.selected {
+  background: var(--accent-bg);
+  box-shadow: inset 2px 0 0 var(--accent-strong);
+}
+
+.commits-lens-row-msg {
+  font-weight: 550;
+  font-size: 13px;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.commits-lens-row-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+
+.commits-lens-row-sha {
+  font-family: var(--font-mono);
+  color: var(--accent);
+  font-size: 11px;
+}
+
+.commits-lens-row-stats {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
 }
 
 /* ─── PR Opener ─────────────────────────────────────────────────────────── */
@@ -5401,30 +5568,6 @@ mark.search-highlight-current {
 .next-bar-finish--ready:hover {
   background: var(--accent-strong-hover);
   border-color: transparent;
-}
-
-.sidebar-overview-link {
-  display: block;
-  width: 100%;
-  text-align: left;
-  padding: 8px 16px;
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-secondary);
-  font-size: 12.5px;
-  font-weight: 500;
-  font-family: var(--font-sans);
-  cursor: pointer;
-}
-
-.sidebar-overview-link:hover {
-  color: var(--text-primary);
-  background: var(--bg-tertiary);
-}
-
-.sidebar-overview-link.active {
-  color: var(--accent);
 }
 
 /* ─── Review queue home (opener tab) ──────────────────────────────────── */

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -265,6 +265,9 @@ export interface NoteResolution {
 
 export type SidebarView = "groups" | "category" | "tree";
 
+/** Which of the PR view's three persistent lenses is showing (issue #170). */
+export type PrLens = "overview" | "files" | "commits";
+
 export type DiffViewMode = "split" | "unified";
 
 export type HunkSignificanceFilter = "all" | "high" | "medium" | "low";
@@ -289,6 +292,15 @@ export interface Tab {
   /** last PR ref this tab tried to fetch — lets a failed fetch offer Retry */
   lastPrRef?: string | null;
   selectedFile: FileDiff | null;
+  /** Which of Overview/Files/Commits this tab is showing — persistent per tab
+   * (issue #170), not a global mode. */
+  lens: PrLens;
+  /** The commit shown in the Commits lens, if any. Per-tab so switching tabs
+   * can't leak one PR's commit scope onto another's canvas. */
+  selectedCommit: PrCommit | null;
+  /** Change-group name scoping the Files sidebar (the "Group: <name> ✕" pill),
+   * from a change-group deep link. Null = no filter. */
+  groupFilter: string | null;
   viewedFiles: Set<string>;
   staleViewedFiles: Set<string>;
   /** Keys (see highlightKey) of AI highlights the user has dismissed for this PR. */
@@ -459,6 +471,10 @@ export interface SessionPrEntry {
   selected_file: string | null;
   sidebar_view: SidebarView | null;
   selected_comment_file: string | null;
+  /** Mirrors Rust's `Option<String>` — hand-validated against `PrLens` on
+   * restore rather than typed as `PrLens | null` here (an old session file, or
+   * a future value, could carry anything). */
+  lens?: string | null;
 }
 
 export interface SessionState {


### PR DESCRIPTION
Closes #170. Mockups: https://claude.ai/code/artifact/4f978f81-b3f9-41a1-ae37-dd735a95d691

## Summary

A PR is now three stable **lenses** — Overview, Files, Commits — behind a segmented switcher in the header, replacing replace-and-back navigation. You always know where you are; every view is one click or one keystroke away.

- **Switcher, not a second tab row**: uses the app's Split/Unified segmented grammar (filled `--accent-strong` active) so it never competes with the app-level "which PR" tabs. Files carries the relevant-file count and absorbs the reviewed-progress bar as a hairline; Commits carries the commit count. The header's old `n/m reviewed` bar and the sidebar's "← Overview" link are deleted.
- **Deep links hop lenses**: change-group rows open Files **scoped to the group** (dismissible `Group: <name> ✕` pill; sidebar filtering narrows all three view modes AND the guided/keyboard order); top-risk rows open Files at the line; the chat's `open_commit` lands in Commits with the commit selected; every `selectedFile` write routes through helpers that imply the Files lens. `marrow-action` protocol untouched.
- **Commits becomes a place**: rail of commits (sidebar quiet-row grammar) + the existing commit-scoped diff as canvas, with a "◉ This commit only" scope pill and a "View cumulative diff" chip that hops to Files. Empty state for PRs with no fetched commits.
- **Commit scope is per-tab now** — it was top-level App state, so two tabs couldn't hold commit scope and the singleton diff slots could show one tab's commit header over another's diff body. `selectedCommit` lives on the tab; visible diff state resyncs (cache-first) on every tab switch; async fetch completions are guarded by tab identity + sha so an in-flight background fetch can't write into the active view.
- **Keyboard**: `1`/`2`/`3` switch lenses (post-typing-guard single-key tier); `[` `]` `V` unchanged; help overlay updated.
- **Persistence**: `SessionPrEntry.lens` (serde-defaulted; old session.json files load clean — tested) through the hand-mirrored Rust/TS session types; unknown values fall back to Overview.

### Deferred (deliberate)
Checks as a fourth segment, ↑/↓ commit-walking in the rail, and an "Overview regenerated" refresh dot.

## Test Plan

- [x] `bun run build`, `bun test`, `cargo check`, `cargo test -p marrow-core` (94 tests incl. new session round-trips) — clean
- [x] Adversarial verify pass; it caught a real cross-tab commit-diff leak in the first cut (singleton diff slots not resynced on tab switch) — fixed with the resync effect + guarded async completions, re-verified
- [x] Live-tested in the dev app: switcher + counts + hairline; all three lenses; session restore straight into a Commits lens with its diff; group deep link → filtered sidebar + pill → ✕ restores; guided "file 1 of 1" respects the scope; commits rail + merged meta row + scope pill; empty-commits state; a second tab's empty Commits lens shows the empty state, not the first tab's loaded diff
- [ ] Human keypress check: `1`/`2`/`3` (synthetic keys can't reach the WKWebView), and an A→B→A commit-lens round trip re-serving A's diff from cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)