### PR TITLE
feat(gui): Checks lens — CI runs and failures as the fourth PR view (#175)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1204,8 +1204,16 @@ function App() {
       }
     }
     if (line != null && target.path === tab.selectedFile?.path && target.head_content === tab.selectedFile?.head_content) {
-      // Already viewing the file — the mounted DiffViewer can jump directly.
-      if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
+      if (tab.lens === "files") {
+        // Already viewing the file — the mounted DiffViewer can jump directly.
+        if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
+      } else {
+        // Right file, wrong lens: this fast path predates the lens switcher
+        // and used to reveal into a hidden canvas. Switch to Files and let
+        // the pending-reveal effect jump once the viewer mounts.
+        pendingRevealLineRef.current = line;
+        updateTab(tab.id, (t) => ({ ...t, lens: "files" }));
+      }
       return;
     }
     pendingRevealLineRef.current = line ?? null;
@@ -1227,7 +1235,9 @@ function App() {
     requestAnimationFrame(() => {
       if (diffViewerRef.current?.revealLine(line) === false) notifyLineOutsideDiff(line);
     });
-  }, [selectedFilePath]);
+    // Lens is a dep so a reveal deferred by the same-file-wrong-lens path in
+    // handleChatOpenFile fires when the Files lens (re)mounts the viewer.
+  }, [selectedFilePath, activeTab?.lens]);
 
   // ---- Chat ```marrow-action view-control blocks (issue #166) ----
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -13,6 +13,7 @@ import { SettingsModal } from "./components/SettingsModal";
 import { ChecksBlockingModal } from "./components/ChecksBlockingModal";
 import { PrOverview } from "./components/PrOverview";
 import { CommitsLens } from "./components/CommitsLens";
+import { ChecksLens } from "./components/ChecksLens";
 import { NextFileBar } from "./components/NextFileBar";
 import { SearchBar, type SearchBarHandle } from "./components/SearchBar";
 import { KeyboardHelp } from "./components/KeyboardHelp";
@@ -29,7 +30,7 @@ import { check } from "@tauri-apps/plugin-updater";
 import { relaunch, exit } from "@tauri-apps/plugin-process";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { ReviewManifest, FileDiff, DiffViewMode, Tab, FetchProgress, HunkSignificanceFilter, SidebarView, ReviewThread, ReviewComment, SearchMatch, PrUpdateStatus, ViewedFileState, MyReviewState, PrChecksStatus, UpdateStatus, SessionState, Settings, CachedPrInfo, ChatState, ChatMessage, ChatStreamEvent, ChatAction, NoteResolution, PrCommit, CommitDiff, CheckAnnotation, CheckFailures, PrLens, ChangeGroup } from "./types";
-import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey } from "./utils";
+import { parsePrUrl, extractPrRef, canonicalPrKey, highlightKey, isFailingCheck } from "./utils";
 import type { ReviewSession } from "./hooks/useActivityFeed";
 
 /** An empty "open a PR" tab — no loaded PR, not mid-fetch, no error. */
@@ -284,7 +285,13 @@ function App() {
     return map;
   }, [annotationsByPath]);
   const selectedFileAnnotations = (selectedFilePath && annotationsByPath?.get(selectedFilePath)) || [];
-  const activeCheckFailures = activeTab?.checkAnnotations.status === "loaded" ? activeTab.checkAnnotations.failures : null;
+  // Paths in the active PR's diff — the Checks lens uses this to tell a
+  // jumpable annotation from a run-level one anchored outside the diff
+  // (e.g. `.github`), same distinction the old Overview card made via byPath.
+  const diffFilePaths = useMemo(
+    () => new Set(activeTab?.manifest?.files.map((f) => f.path) ?? []),
+    [activeTab?.manifest]
+  );
 
   // Opening from the "Recently analyzed" cache: if the PR's head moved, the
   // backend would silently run a full AI re-analysis — surface that first.
@@ -590,7 +597,7 @@ function App() {
                 }
                 // A session written before lenses existed (or a malformed
                 // value) falls back to "overview" rather than failing restore.
-                if (entry.lens === "files" || entry.lens === "commits") {
+                if (entry.lens === "files" || entry.lens === "commits" || entry.lens === "checks") {
                   tab.lens = entry.lens;
                 }
                 // Restoring straight into the Files lens without a selected
@@ -2283,15 +2290,17 @@ function App() {
 
   // Fetch inline CI failure annotations for the active tab once its checks are
   // loaded with at least one failing run — GraphQL conclusions arrive UPPERCASE
-  // (see the CiChip comment in PrOverview). Guarded by tab id + head_sha so a
-  // stale resolve (tab closed, or refreshed onto a new head in the meantime)
-  // never lands on the wrong state.
+  // (see the CiChip comment in PrOverview) — or once the user enters the
+  // Checks lens directly (issue #175), where the fetch is a cheap no-op on a
+  // green PR (empty annotations). Guarded by tab id + head_sha so a stale
+  // resolve (tab closed, or refreshed onto a new head in the meantime) never
+  // lands on the wrong state.
   useEffect(() => {
     if (!activeTab?.manifest) return;
     if (activeTab.checkAnnotations.status !== "idle") return;
     if (!activeChecks) return;
-    const hasFailure = activeChecks.check_runs.some((c) => c.conclusion === "FAILURE");
-    if (!hasFailure) return;
+    const hasFailure = activeChecks.check_runs.some(isFailingCheck);
+    if (!hasFailure && activeTab.lens !== "checks") return;
 
     const tabId = activeTab.id;
     const prRef = activeTab.manifest.pr_url;
@@ -2306,7 +2315,7 @@ function App() {
       .catch((err) => {
         updateTab(tabId, (t) => (t.manifest && t.manifest.head_sha === headSha ? { ...t, checkAnnotations: { status: "error", message: String(err) } } : t));
       });
-  }, [activeTab?.id, activeTab?.manifest?.pr_url, activeTab?.manifest?.head_sha, activeTab?.checkAnnotations.status, activeChecks]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [activeTab?.id, activeTab?.manifest?.pr_url, activeTab?.manifest?.head_sha, activeTab?.checkAnnotations.status, activeChecks, activeTab?.lens]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Floating mini-player visibility:
   //  - HIDE it whenever the MAIN window gains focus (you've engaged the app).
@@ -2551,6 +2560,7 @@ function App() {
         onSetLens={(lens) => { if (activeTabId) setLens(activeTabId, lens); }}
         filesCount={filesLensCount}
         commitsCount={commitsLensCount}
+        checksState={activeChecks ?? null}
         onSettingsClick={() => setSettingsOpen(true)}
         manifest={activeTab?.manifest ?? null}
         showHunkSignificance={showHunkSignificance}
@@ -2679,11 +2689,18 @@ function App() {
               onSelectCommit={(c) => handleViewCommit(c)}
               onViewCumulativeDiff={() => { if (activeTabId) setLens(activeTabId, "files"); }}
             />
+          ) : activeTab.lens === "checks" ? (
+            <ChecksLens
+              checks={activeChecks ?? null}
+              annotations={activeTab.checkAnnotations}
+              diffPaths={diffFilePaths}
+              headSha={activeTab.manifest.head_sha}
+              onOpenAt={handleChatOpenFile}
+            />
           ) : activeTab.lens === "overview" ? (
             <PrOverview
               manifest={activeTab.manifest}
               checksStatus={activeChecks ?? null}
-              checkFailures={activeCheckFailures}
               reviewState={activeTab.myReviewState ?? null}
               viewedCount={activeTab.viewedFiles.size}
               unresolvedThreads={activeTab.commentThreads.status === "loaded" ? activeTab.commentThreads.threads.filter((t) => !t.is_resolved).length : null}
@@ -2695,6 +2712,7 @@ function App() {
               onOpenAt={handleChatOpenFile}
               onBriefMe={briefMe}
               onViewCommit={handleViewCommit}
+              onOpenChecks={() => { if (activeTabId) setLens(activeTabId, "checks"); }}
               newHighlightKeys={
                 // Dismissing a new note removes it from the chip immediately —
                 // a dead "1 new AI note" pointing at a hidden note is worse

--- a/app/src/components/ChecksLens.tsx
+++ b/app/src/components/ChecksLens.tsx
@@ -1,0 +1,219 @@
+import { useEffect, useState } from "react";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
+import { countFailingChecks, getFileName, isFailingCheck } from "../utils";
+import type { CheckAnnotation, CheckAnnotationsState, CheckRunInfo, PrChecksStatus } from "../types";
+
+interface ChecksLensProps {
+  checks: PrChecksStatus | null;
+  annotations: CheckAnnotationsState;
+  /** Paths present in this PR's diff — CI often anchors run-level failures to
+   * paths (e.g. `.github`) that aren't, so those annotation cards can't jump. */
+  diffPaths: Set<string>;
+  /** The PR's head SHA — resets the local run-filter selection when it
+   * changes (a refresh, or switching to a different PR's tab). */
+  headSha: string;
+  onOpenAt: (path: string, line?: number) => void;
+}
+
+function runState(run: CheckRunInfo): "ok" | "fail" | "pending" {
+  if (run.status !== "COMPLETED") return "pending";
+  if (isFailingCheck(run)) return "fail";
+  return "ok";
+}
+
+/** Stable-sort annotations so every annotation for the same path is adjacent,
+ * in first-seen path order — a lightweight "group by path" that keeps the
+ * flat row list the canvas renders. Moved from PrOverview (issue #175) —
+ * the failing-checks card that used to own this now lives here. */
+function groupAnnotationsByPath(annotations: CheckAnnotation[]): CheckAnnotation[] {
+  const order: string[] = [];
+  const byPath = new Map<string, CheckAnnotation[]>();
+  for (const a of annotations) {
+    if (!byPath.has(a.path)) {
+      byPath.set(a.path, []);
+      order.push(a.path);
+    }
+    byPath.get(a.path)!.push(a);
+  }
+  return order.flatMap((p) => byPath.get(p)!);
+}
+
+function levelPillClass(level: string): string {
+  if (level === "failure") return "risk-critical";
+  if (level === "warning") return "risk-medium";
+  return "risk-low";
+}
+
+function CheckRunRow({
+  run,
+  selected,
+  onSelect,
+}: {
+  run: CheckRunInfo;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const state = runState(run);
+  const glyph = state === "ok" ? "✓" : state === "fail" ? "✗" : "●";
+  return (
+    <div className={`checks-lens-row${selected ? " selected" : ""}${state === "fail" ? " ck-row-fail" : ""}`}>
+      <button type="button" className="checks-lens-row-main" onClick={onSelect} title={run.name}>
+        <span className={`checks-lens-row-glyph ck-glyph--${state}`}>{glyph}</span>
+        <span className="checks-lens-row-name">{run.name}</span>
+      </button>
+      {run.details_url && (
+        <button
+          type="button"
+          className="github-link checks-lens-row-details"
+          onClick={() => openUrl(run.details_url!).catch(() => {})}
+        >
+          Details ↗
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CheckFailureCard({
+  annotation,
+  inDiff,
+  onOpenAt,
+}: {
+  annotation: CheckAnnotation;
+  /** Whether the annotation's path is a file in this PR's diff — CI often
+   * anchors run-level failures to paths like `.github` that aren't. */
+  inDiff: boolean;
+  onOpenAt: (path: string, line?: number) => void;
+}) {
+  const title = annotation.title ?? annotation.message.split("\n")[0];
+  return (
+    <button
+      type="button"
+      className={`ck-annotation-card${inDiff ? "" : " ck-annotation-card--nodiff"}`}
+      disabled={!inDiff}
+      title={inDiff ? undefined : "Not a file in this PR's diff — see the check's log on GitHub"}
+      onClick={() => inDiff && onOpenAt(annotation.path, annotation.start_line)}
+    >
+      <span className={`risk-badge ${levelPillClass(annotation.annotation_level)}`}>
+        {annotation.annotation_level}
+      </span>
+      <div className="ck-annotation-card-main">
+        <div className="ck-annotation-card-title">
+          {annotation.check_name} <span className="ck-annotation-card-sep">·</span> {title}
+        </div>
+        <pre className="check-annotation-message check-annotation-message-collapsed">
+          {annotation.message}
+        </pre>
+      </div>
+      <span className="overview-risk-file">
+        {getFileName(annotation.path)}:{annotation.start_line}
+      </span>
+    </button>
+  );
+}
+
+/** The Checks lens (issue #175): a rail of every check run on the PR's head
+ * commit, mirroring the Commits lens's rail grammar, with a canvas that
+ * groups failing/warning annotations by path — reusing the pieces the old
+ * Overview "Failing checks" card used to own (moved here since that card is
+ * gone). Frontend-only: `checks`/`annotations` are data the app already
+ * fetches (checksMap polling + the on-demand annotation fetch), no new Rust
+ * calls. */
+export function ChecksLens({ checks, annotations, diffPaths, headSha, onOpenAt }: ChecksLensProps) {
+  // Which run the canvas is filtered to — purely presentational to this lens
+  // (not persisted), reset whenever the PR head moves so a stale filter never
+  // survives a refresh or a switch to a different PR's tab.
+  const [selectedRun, setSelectedRun] = useState<string | null>(null);
+  useEffect(() => {
+    setSelectedRun(null);
+  }, [headSha]);
+
+  const totalRuns = checks?.check_runs.length ?? 0;
+  const failingRuns = checks ? countFailingChecks(checks) : 0;
+  // Runs still queued/in progress: without this the canvas would claim "all
+  // passing" while the header badge pulses amber for the same data.
+  const pendingRuns = checks?.check_runs.filter((r) => r.status !== "COMPLETED").length ?? 0;
+
+  function selectRun(name: string) {
+    setSelectedRun((cur) => (cur === name ? null : name));
+  }
+
+  return (
+    <>
+      <aside className="checks-lens-rail">
+        <div className="checks-lens-rail-head">
+          Checks <span className="checks-lens-rail-count">· {totalRuns} runs</span>
+        </div>
+        <div className="checks-lens-rail-list">
+          {checks?.check_runs.map((run, i) => (
+            <CheckRunRow key={`${run.name}-${i}`} run={run} selected={run.name === selectedRun} onSelect={() => selectRun(run.name)} />
+          ))}
+        </div>
+      </aside>
+      <div className="checks-lens-canvas">
+        {annotations.status === "loading" || annotations.status === "idle" ? (
+          <div className="no-file-selected">Loading checks…</div>
+        ) : annotations.status === "error" ? (
+          <div className="no-file-selected">{annotations.message}</div>
+        ) : totalRuns === 0 ? (
+          <div className="no-file-selected">No checks reported on this PR.</div>
+        ) : (
+          (() => {
+            const allAnnotations = annotations.failures.annotations;
+            const failureCount = allAnnotations.filter((a) => a.annotation_level === "failure").length;
+            const warningCount = allAnnotations.filter((a) => a.annotation_level === "warning").length;
+            const filtered = selectedRun ? allAnnotations.filter((a) => a.check_name === selectedRun) : allAnnotations;
+            const grouped = groupAnnotationsByPath(filtered);
+
+            return (
+              <>
+                <div className="checks-lens-summary">
+                  <span className="checks-lens-summary-headline">
+                    {failingRuns > 0
+                      ? `${failingRuns} ${failingRuns === 1 ? "check" : "checks"} failing`
+                      : pendingRuns > 0
+                        ? `${pendingRuns} of ${totalRuns} ${pendingRuns === 1 ? "check" : "checks"} still running`
+                        : `All ${totalRuns} checks passing`}
+                  </span>
+                  {failureCount > 0 && (
+                    <span className="risk-badge risk-critical">
+                      {failureCount} {failureCount === 1 ? "failure" : "failures"}
+                    </span>
+                  )}
+                  {warningCount > 0 && (
+                    <span className="risk-badge risk-medium">
+                      {warningCount} {warningCount === 1 ? "warning" : "warnings"}
+                    </span>
+                  )}
+                  {selectedRun && (
+                    <button type="button" className="overview-chip ck-run-filter" onClick={() => setSelectedRun(null)}>
+                      Run: {selectedRun} ✕
+                    </button>
+                  )}
+                </div>
+                {failingRuns === 0 ? (
+                  <div className="overview-card ck-all-passing">
+                    {pendingRuns > 0
+                      ? `${pendingRuns} of ${totalRuns} ${pendingRuns === 1 ? "check is" : "checks are"} still running.`
+                      : `All ${totalRuns} checks passing.`}
+                  </div>
+                ) : grouped.length === 0 ? (
+                  <div className="no-file-selected">No annotations for this run.</div>
+                ) : (
+                  <div className="overview-card ck-annotations">
+                    {grouped.map((a, i) => (
+                      <CheckFailureCard key={i} annotation={a} inDiff={diffPaths.has(a.path)} onOpenAt={onOpenAt} />
+                    ))}
+                    {annotations.failures.truncated && (
+                      <div className="overview-checks-truncated">Showing the first 200 annotations</div>
+                    )}
+                  </div>
+                )}
+              </>
+            );
+          })()
+        )}
+      </div>
+    </>
+  );
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-shell";
-import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState, PrLens } from "../types";
+import { countFailingChecks } from "../utils";
+import type { ReviewManifest, Tab, CommentThreadsState, MyReviewState, PrLens, PrChecksStatus } from "../types";
 
 function useClickOutside(
   ref: React.RefObject<HTMLElement | null>,
@@ -38,12 +39,15 @@ interface HeaderProps {
   onCloseTab: (id: string) => void;
   onNewReview: () => void;
   viewedCount: number;
-  /** Which PR lens (Overview/Files/Commits, issue #170) the switcher shows active. */
+  /** Which PR lens (Overview/Files/Commits/Checks, issue #170, #175) the switcher shows active. */
   lens: PrLens;
   onSetLens: (lens: PrLens) => void;
   /** Files segment count — relevant files, falling back to total when 0 relevant. */
   filesCount: number;
   commitsCount: number;
+  /** Checks segment status, from App's checksMap — null before the first fetch
+   * resolves (issue #175). */
+  checksState: PrChecksStatus | null;
   onSettingsClick: () => void;
   manifest: ReviewManifest | null;
   showHunkSignificance: boolean;
@@ -73,6 +77,7 @@ export function Header({
   onSetLens,
   filesCount,
   commitsCount,
+  checksState,
   onSettingsClick,
   manifest,
   showHunkSignificance,
@@ -157,7 +162,7 @@ export function Header({
                 {REVIEW_STATUS_SYMBOL.approved} Approved
               </span>
             )}
-            <LensSwitcher lens={lens} onSetLens={onSetLens} filesCount={filesCount} commitsCount={commitsCount} filesProgress={progress} />
+            <LensSwitcher lens={lens} onSetLens={onSetLens} filesCount={filesCount} commitsCount={commitsCount} filesProgress={progress} checksState={checksState} />
             {onRefresh && (
               <button
                 className={`refresh-button${isRefreshing ? " refreshing" : ""}`}
@@ -203,19 +208,35 @@ export function Header({
  * header progress bar as a hairline under its label; Overview no longer
  * disappears when you dive into a file, and the "← Overview" escape hatch
  * dissolves into this. */
+/** The Checks segment's badge: no data yet → none; any failing run wins over
+ * a still-running one; all complete and none failing → the passing check
+ * mark. Single spot this precedence is decided (issue #175). */
+function checksBadge(checksState: PrChecksStatus | null): { kind: "ok" | "pending" | "fail"; failing: number } | null {
+  if (!checksState) return null;
+  // Zero runs is "nothing reported", not "passing" — no badge, like no data.
+  if (checksState.check_runs.length === 0) return null;
+  const failing = countFailingChecks(checksState);
+  if (failing > 0) return { kind: "fail", failing };
+  if (checksState.check_runs.some((r) => r.status !== "COMPLETED")) return { kind: "pending", failing: 0 };
+  return { kind: "ok", failing: 0 };
+}
+
 function LensSwitcher({
   lens,
   onSetLens,
   filesCount,
   commitsCount,
   filesProgress,
+  checksState,
 }: {
   lens: PrLens;
   onSetLens: (lens: PrLens) => void;
   filesCount: number;
   commitsCount: number;
   filesProgress: number;
+  checksState: PrChecksStatus | null;
 }) {
+  const badge = checksBadge(checksState);
   return (
     <div className="lens-switcher">
       <button
@@ -238,6 +259,15 @@ function LensSwitcher({
         onClick={() => onSetLens("commits")}
       >
         Commits <span className="seg-count">{commitsCount}</span>
+      </button>
+      <button
+        className={`seg-item${lens === "checks" ? " active" : ""}`}
+        onClick={() => onSetLens("checks")}
+      >
+        Checks
+        {badge?.kind === "ok" && <span className="seg-count seg-ok">✓</span>}
+        {badge?.kind === "pending" && <span className="seg-count seg-pulse">●</span>}
+        {badge?.kind === "fail" && <span className="seg-count seg-fail">{badge.failing} ✗</span>}
       </button>
     </div>
   );

--- a/app/src/components/KeyboardHelp.tsx
+++ b/app/src/components/KeyboardHelp.tsx
@@ -23,6 +23,7 @@ const SECTIONS: Section[] = [
       { keys: ["1"], label: "Overview" },
       { keys: ["2"], label: "Files" },
       { keys: ["3"], label: "Commits" },
+      { keys: ["4"], label: "Checks" },
     ],
   },
   {

--- a/app/src/components/PrOverview.tsx
+++ b/app/src/components/PrOverview.tsx
@@ -2,15 +2,12 @@ import { Fragment, useEffect, useRef, useState } from "react";
 import { SummaryParagraphs } from "./SummaryParagraphs";
 import { Avatar } from "./ReviewRequestList";
 import { RichText } from "./RichText";
-import { highlightKey, timeAgo } from "../utils";
-import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState, TopRisk, PrCommit, CheckFailures, CheckAnnotation } from "../types";
+import { countFailingChecks, highlightKey, timeAgo } from "../utils";
+import type { ReviewManifest, FileDiff, ChangeGroup, PrChecksStatus, MyReviewState, TopRisk, PrCommit } from "../types";
 
 interface PrOverviewProps {
   manifest: ReviewManifest;
   checksStatus?: PrChecksStatus | null;
-  /** Inline CI failure annotations, loaded on demand once a failing check run
-   * is observed — powers the "Failing checks" card. */
-  checkFailures?: CheckFailures | null;
   reviewState: MyReviewState | null;
   viewedCount: number;
   unresolvedThreads: number | null;
@@ -29,6 +26,8 @@ interface PrOverviewProps {
   onBriefMe?: () => void;
   /** Enter commit scope for a row in the Commits card. */
   onViewCommit?: (commit: PrCommit) => void;
+  /** CI chip click — jump to the Checks lens (issue #175). */
+  onOpenChecks?: () => void;
 }
 
 /** First file (in manifest order) whose highlights include a new-note key. */
@@ -41,10 +40,12 @@ function firstNewNoteFile(manifest: ReviewManifest, newHighlightKeys: Set<string
   return null;
 }
 
-function CiChip({ checks }: { checks: PrChecksStatus }) {
+function CiChip({ checks, onOpenChecks }: { checks: PrChecksStatus; onOpenChecks?: () => void }) {
   // GitHub conclusions arrive uppercase ("FAILURE"); only overall_state is
-  // normalized to lowercase in core.
-  const failing = checks.check_runs.filter((c) => c.conclusion === "FAILURE").length;
+  // normalized to lowercase in core. Failing-count logic lives in
+  // countFailingChecks (utils.ts) — the single source of truth also reused by
+  // the header lens badge and the Checks lens (issue #175).
+  const failing = countFailingChecks(checks);
   const { dot, label } =
     checks.overall_state === "success"
       ? { dot: "risk-dot--ok", label: "CI passing" }
@@ -52,9 +53,9 @@ function CiChip({ checks }: { checks: PrChecksStatus }) {
         ? { dot: "risk-dot--critical", label: `${failing} CI ${failing === 1 ? "check" : "checks"} failing` }
         : { dot: "risk-dot--medium", label: "CI running" };
   return (
-    <span className="overview-chip overview-chip--ci">
+    <button type="button" className="overview-chip overview-chip--ci" onClick={onOpenChecks}>
       <span className={`risk-dot ${dot}`} /> {label}
-    </span>
+    </button>
   );
 }
 
@@ -218,56 +219,6 @@ function CommitsCard({
   );
 }
 
-/** Stable-sort annotations so every annotation for the same path is adjacent,
- * in first-seen path order — a lightweight "group by path" that keeps the
- * flat row list the card renders. */
-function groupAnnotationsByPath(annotations: CheckAnnotation[]): CheckAnnotation[] {
-  const order: string[] = [];
-  const byPath = new Map<string, CheckAnnotation[]>();
-  for (const a of annotations) {
-    if (!byPath.has(a.path)) {
-      byPath.set(a.path, []);
-      order.push(a.path);
-    }
-    byPath.get(a.path)!.push(a);
-  }
-  return order.flatMap((p) => byPath.get(p)!);
-}
-
-function CheckFailureRow({
-  annotation,
-  inDiff,
-  onOpenAt,
-}: {
-  annotation: CheckAnnotation;
-  /** Whether the annotation's path is a file in this PR's diff — CI often
-   * anchors run-level failures to paths like `.github` that aren't. */
-  inDiff: boolean;
-  onOpenAt?: (path: string, line?: number) => void;
-}) {
-  const subtitle = annotation.title ?? annotation.message.split("\n")[0];
-  return (
-    <button
-      className={`overview-check-row${inDiff ? "" : " overview-check-row--nodiff"}`}
-      disabled={!inDiff}
-      title={inDiff ? undefined : "Not a file in this PR's diff — see the check's log on GitHub"}
-      onClick={() => inDiff && onOpenAt?.(annotation.path, annotation.start_line)}
-    >
-      <div className="overview-check-row-main">
-        <div className="overview-check-row-title">
-          {/* Warnings get the amber dot — a red one would present them as failures. */}
-          <span className={`risk-dot ${annotation.annotation_level === "warning" ? "risk-dot--medium" : "risk-dot--critical"}`} />{" "}
-          {annotation.check_name}
-        </div>
-        <div className="overview-check-row-detail">{subtitle}</div>
-      </div>
-      <span className="overview-risk-file">
-        {fileName(annotation.path)}:{annotation.start_line}
-      </span>
-    </button>
-  );
-}
-
 function TopRiskRow({ risk, onOpenAt }: { risk: TopRisk; onOpenAt?: (path: string, line?: number) => void }) {
   return (
     <button
@@ -289,7 +240,6 @@ function TopRiskRow({ risk, onOpenAt }: { risk: TopRisk; onOpenAt?: (path: strin
 export function PrOverview({
   manifest,
   checksStatus,
-  checkFailures,
   reviewState,
   viewedCount,
   unresolvedThreads,
@@ -302,6 +252,7 @@ export function PrOverview({
   onOpenAt,
   onBriefMe,
   onViewCommit,
+  onOpenChecks,
 }: PrOverviewProps) {
   const newNoteCount = newHighlightKeys?.size ?? 0;
   const relevant = manifest.files.filter((f) => f.classification !== "NOT_RELEVANT");
@@ -339,7 +290,7 @@ export function PrOverview({
             </span>
           )}
           {draft && <span className="overview-chip overview-chip--draft">Draft</span>}
-          {checksStatus && <CiChip checks={checksStatus} />}
+          {checksStatus && <CiChip checks={checksStatus} onOpenChecks={onOpenChecks} />}
           {newNoteCount > 0 && (
             <button
               type="button"
@@ -406,28 +357,6 @@ export function PrOverview({
         )}
       </div>
       <div className="overview-rail">
-        {checkFailures && checkFailures.annotations.length > 0 && (
-          <div className="overview-card overview-checks">
-            {(() => {
-              // Warnings ride along in the card but shouldn't inflate the
-              // failure count in its title.
-              const failures = checkFailures.annotations.filter((a) => a.annotation_level !== "warning").length;
-              const warnings = checkFailures.annotations.length - failures;
-              return (
-                <h4>
-                  Failing checks ({failures})
-                  {warnings > 0 && <span className="overview-checks-warnings"> + {warnings} warning{warnings === 1 ? "" : "s"}</span>}
-                </h4>
-              );
-            })()}
-            {groupAnnotationsByPath(checkFailures.annotations).map((a, i) => (
-              <CheckFailureRow key={i} annotation={a} inDiff={byPath.has(a.path)} onOpenAt={onOpenAt} />
-            ))}
-            {checkFailures.truncated && (
-              <div className="overview-checks-truncated">Showing the first 200 annotations</div>
-            )}
-          </div>
-        )}
         {topRisks.length > 0 && (
           <div className="overview-card overview-risks">
             <h4>What to review first</h4>

--- a/app/src/hooks/useKeyboardShortcuts.ts
+++ b/app/src/hooks/useKeyboardShortcuts.ts
@@ -180,6 +180,7 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers, options: Shortc
         case "1": h.onSetLens("overview"); break;
         case "2": h.onSetLens("files"); break;
         case "3": h.onSetLens("commits"); break;
+        case "4": h.onSetLens("checks"); break;
         case "V": h.onToggleViewed(); break;
         case "T": h.onToggleThreads(); break;
         case "F5": h.onRefresh(); e.preventDefault(); break;

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -487,6 +487,36 @@ body {
   color: inherit;
 }
 
+/* Checks segment badge (issue #175) — three states layered on .seg-count:
+   passing (quiet green check), running (pulsing amber dot), failing (red
+   count, lighter-red when the segment itself is filled/active so it stays
+   readable). */
+.seg-count.seg-ok {
+  color: var(--diff-add-text);
+}
+
+.seg-count.seg-pulse {
+  color: var(--risk-medium);
+  animation: seg-pulse 1.2s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .seg-count.seg-pulse { animation: none; }
+}
+
+@keyframes seg-pulse {
+  0%, 100% { opacity: 0.45; }
+  50% { opacity: 1; }
+}
+
+.seg-count.seg-fail {
+  color: var(--diff-remove-text);
+}
+
+.seg-item.active .seg-count.seg-fail {
+  color: #ffd7d5;
+}
+
 /* Reviewed-progress hairline, absorbed from the old header progress bar. */
 .seg-progress {
   position: absolute;
@@ -1524,6 +1554,193 @@ tr.cursor-selected td {
   margin-left: auto;
   font-family: var(--font-mono);
   font-size: 10.5px;
+}
+
+/* ─── Checks lens (issue #175) — rail of every check run, mirroring the
+   Commits lens's rail grammar; the canvas groups failing/warning annotations
+   by path (the pieces the old Overview "Failing checks" card used to own,
+   moved here). ──────────────────────────────────────────────────────────── */
+.checks-lens-rail {
+  width: 360px;
+  min-width: 360px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.checks-lens-rail-head {
+  padding: var(--space-3) 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  font-weight: 650;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.checks-lens-rail-count {
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.checks-lens-rail-list {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.checks-lens-row {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-bottom: 1px solid var(--border);
+}
+
+.checks-lens-row.selected {
+  background: var(--accent-bg);
+  box-shadow: inset 2px 0 0 var(--accent-strong);
+}
+
+.checks-lens-row.ck-row-fail.selected {
+  background: rgba(248, 81, 73, 0.12);
+  box-shadow: inset 2px 0 0 var(--diff-remove-text);
+}
+
+.checks-lens-row-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.checks-lens-row-glyph {
+  flex-shrink: 0;
+  width: 14px;
+  font-weight: 700;
+  font-size: 12px;
+  text-align: center;
+}
+
+.ck-glyph--ok { color: var(--diff-add-text); }
+.ck-glyph--fail { color: var(--diff-remove-text); }
+.ck-glyph--pending { color: var(--risk-medium); }
+
+.checks-lens-row-name {
+  font-size: 13px;
+  font-weight: 550;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.checks-lens-row-details {
+  flex-shrink: 0;
+  margin-right: 16px;
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+.checks-lens-canvas {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  overflow-y: auto;
+  padding: var(--space-4);
+}
+
+.checks-lens-summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.checks-lens-summary-headline {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-right: 2px;
+}
+
+/* Reuses .sidebar-group-filter's dismissible-pill grammar for the active
+   run filter. */
+.ck-run-filter {
+  cursor: pointer;
+}
+
+.ck-run-filter:hover {
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+.ck-all-passing {
+  color: var(--text-secondary);
+  font-size: 13.5px;
+}
+
+.ck-annotations {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 4px;
+}
+
+.ck-annotation-card {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  width: 100%;
+  padding: 10px 8px;
+  background: none;
+  border: none;
+  border-top: 1px solid var(--chip-border);
+  color: inherit;
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+}
+
+.ck-annotation-card:first-child {
+  border-top: none;
+}
+
+.ck-annotation-card:hover .ck-annotation-card-title {
+  color: var(--accent);
+}
+
+.ck-annotation-card--nodiff {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.ck-annotation-card--nodiff:hover .ck-annotation-card-title {
+  color: inherit;
+}
+
+.ck-annotation-card-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.ck-annotation-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.ck-annotation-card-sep {
+  color: var(--text-muted);
+  font-weight: 400;
 }
 
 /* ─── PR Opener ─────────────────────────────────────────────────────────── */
@@ -5213,53 +5430,6 @@ mark.search-highlight-current {
   white-space: nowrap;
 }
 
-/* "Failing checks" card rows — a close variant of .overview-risk-row (same
-   layout), with a critical-risk dot ahead of the check name. */
-.overview-check-row {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  width: 100%;
-  padding: 10px 4px;
-  background: none;
-  border: none;
-  border-top: 1px solid var(--chip-border);
-  color: inherit;
-  font-family: var(--font-sans);
-  text-align: left;
-  cursor: pointer;
-}
-
-.overview-check-row:first-of-type {
-  border-top: none;
-}
-
-.overview-check-row:hover .overview-check-row-title {
-  color: var(--accent);
-}
-
-.overview-check-row-main {
-  min-width: 0;
-}
-
-.overview-check-row-title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.overview-check-row-detail {
-  font-size: 12.5px;
-  color: var(--text-secondary);
-  margin-top: 2px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .overview-checks-truncated {
   margin-top: 6px;
   font-size: 11px;
@@ -6134,10 +6304,18 @@ mark.search-highlight-current {
   margin-right: 8px;
 }
 
+/* Clickable since issue #175 (jumps to the Checks lens) — same chip-button
+   treatment as .overview-chip--new-notes. */
 .overview-chip--ci {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.overview-chip--ci:hover {
+  border-color: var(--text-muted);
 }
 
 .sidebar-progress {
@@ -6733,16 +6911,6 @@ mark.search-highlight-current {
   .activity-widget--pill { transition: none; }
 }
 
-/* Failing-check rows whose path isn't in the diff (run-level anchors like
-   `.github`) — visible for completeness but not clickable. */
-.overview-check-row--nodiff {
-  opacity: 0.55;
-  cursor: default;
-}
-.overview-check-row--nodiff:hover .overview-check-row-title {
-  color: inherit;
-}
-
 .check-annotation-range {
   font-family: var(--font-mono);
   font-size: 11px;
@@ -6751,7 +6919,3 @@ mark.search-highlight-current {
   white-space: nowrap;
 }
 
-.overview-checks-warnings {
-  color: var(--text-tertiary);
-  font-weight: normal;
-}

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -265,8 +265,9 @@ export interface NoteResolution {
 
 export type SidebarView = "groups" | "category" | "tree";
 
-/** Which of the PR view's three persistent lenses is showing (issue #170). */
-export type PrLens = "overview" | "files" | "commits";
+/** Which of the PR view's persistent lenses is showing (issue #170; Checks
+ * added in issue #175). */
+export type PrLens = "overview" | "files" | "commits" | "checks";
 
 export type DiffViewMode = "split" | "unified";
 

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -1,5 +1,27 @@
+import type { CheckRunInfo, PrChecksStatus } from "./types";
+
 export function getFileName(path: string): string {
   return path.split("/").pop() || path;
+}
+
+/** Whether a check run counts as failing. GitHub conclusions arrive
+ * uppercase (see the CiChip comment in PrOverview.tsx). Mirrors Rust's
+ * `failing_conclusion` (github.rs) — failure/timed_out/action_required,
+ * deliberately NOT cancelled (a user-initiated stop's partial annotations
+ * are noise) — so a run this badges as failing always has annotations to
+ * show, never a "N ✗" pointing at an empty Checks lens. Single source of
+ * truth reused by the overview CI chip, the header lens badge, and the
+ * Checks lens (issue #175). */
+export function isFailingCheck(check: CheckRunInfo): boolean {
+  return (
+    check.conclusion === "FAILURE" ||
+    check.conclusion === "TIMED_OUT" ||
+    check.conclusion === "ACTION_REQUIRED"
+  );
+}
+
+export function countFailingChecks(checks: PrChecksStatus): number {
+  return checks.check_runs.filter(isFailingCheck).length;
 }
 
 // djb2 string hash → unsigned base36, for compact stable keys.


### PR DESCRIPTION
Closes #175. Mockup: https://claude.ai/code/artifact/91635fde-f3a5-47e0-84c9-c018f6ef89b3

## Summary

The lens switcher from #171 gains its fourth segment. Frontend-only — every data source already existed (`PrChecksStatus` polled in `checksMap`, `CheckFailures` in `Tab.checkAnnotations`); `cargo check` passes with the Rust tree untouched.

- **Segment carries live status**: quiet `✓` when green, pulsing `●` while running (`prefers-reduced-motion` guarded), `N ✗` in failure red when failing — and **no badge at all** for zero-run PRs ("nothing reported" ≠ "passing").
- **ChecksLens**: rail of check runs (quiet-row grammar, `Details ↗` external links, click a run to filter its annotations — the `Run: <name> ✕` chip dismisses); canvas of annotations grouped by file with level pills and `path:line` jumps that land in the **Files lens**, where the #61 inline markers already render. States: loading / error / empty ("No checks reported on this PR.") / green ("All N checks passing") / **pending** ("N of M checks still running" — the canvas never claims "passing" while runs are in flight).
- **Overview slims down**: the failing-checks card moved into the lens; `CiChip` became a real button that hops to it.
- **One failing-conclusion definition**: new shared `isFailingCheck`/`countFailingChecks` matching Rust's `failing_conclusion()` (`failure/timed_out/action_required`, deliberately not `cancelled`), used by the badge, CiChip, the lens, and the annotation auto-fetch — which previously only triggered on `FAILURE` and missed timed-out/action-required PRs.
- **Keyboard**: `4` joins 1/2/3; help overlay updated. Session restore accepts `"checks"`.
- Annotations fetch on lens entry when idle (covers restoring straight into the lens; status moves off idle synchronously, so empty results can't refetch-loop).

Deviation from spec, deliberate: the spec's failing-conclusion list said `cancelled`; the implementation follows the Rust side's tested definition instead (single source of truth — a cancelled-only run would otherwise badge ✗ over a permanently empty canvas). The mockup's in-canvas "v2 ghost note" was a mockup annotation device and is not shipped.

## Test Plan

- [x] `bun run build`, `bun test`, `cargo check` (no-op — Rust untouched), `cargo test -p marrow-core` — clean
- [x] Adversarial verify: caught the pending-only "All N passing" misstatement (fixed with the pending headline/card), flagged the auto-fetch's narrow inline conclusion check (now the shared helper) and dead CSS from the deleted Overview card (removed)
- [x] Live-tested: fourth segment renders; zero-run PR shows plain "Checks" + "No checks reported" canvas; a real PR with passing CI (3 runs) shows `✓` badge, rail with Details links, and the "All 3 checks passing" canvas; per-tab badge independence; hot-reload verified the zero-run badge fix live
- [ ] Human check: a PR with actually-failing checks (rail filter, annotation jumps, `N ✗` badge) — none of this repo's open PRs fail CI; logic is unit-of-review-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)