### PR TITLE
fix(gui): neutral rail glyph for cancelled/skipped check runs (#175)

### DIFF
--- a/app/src/components/ChecksLens.tsx
+++ b/app/src/components/ChecksLens.tsx
@@ -15,9 +15,12 @@ interface ChecksLensProps {
   onOpenAt: (path: string, line?: number) => void;
 }
 
-function runState(run: CheckRunInfo): "ok" | "fail" | "pending" {
+function runState(run: CheckRunInfo): "ok" | "fail" | "pending" | "neutral" {
   if (run.status !== "COMPLETED") return "pending";
   if (isFailingCheck(run)) return "fail";
+  // Completed but not a success (cancelled, skipped, neutral): a green check
+  // would overstate — these ran to no verdict, not to "passing".
+  if (run.conclusion !== "SUCCESS") return "neutral";
   return "ok";
 }
 
@@ -54,7 +57,7 @@ function CheckRunRow({
   onSelect: () => void;
 }) {
   const state = runState(run);
-  const glyph = state === "ok" ? "✓" : state === "fail" ? "✗" : "●";
+  const glyph = state === "ok" ? "✓" : state === "fail" ? "✗" : state === "neutral" ? "–" : "●";
   return (
     <div className={`checks-lens-row${selected ? " selected" : ""}${state === "fail" ? " ck-row-fail" : ""}`}>
       <button type="button" className="checks-lens-row-main" onClick={onSelect} title={run.name}>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1632,6 +1632,7 @@ tr.cursor-selected td {
 .ck-glyph--ok { color: var(--diff-add-text); }
 .ck-glyph--fail { color: var(--diff-remove-text); }
 .ck-glyph--pending { color: var(--risk-medium); }
+.ck-glyph--neutral { color: var(--text-muted); }
 
 .checks-lens-row-name {
   font-size: 13px;


### PR DESCRIPTION
Post-merge fix-forward from #176's R2 review (3 info notes: the chip-fix description and the passing-with-warnings wording are intentional; this one deserved code): completed-but-unconcluded runs (cancelled/skipped/neutral) showed the green ✓ in the Checks rail. Now a muted `–`, matching the segment badge's honesty rules.

Two-line change + CSS token; `bun run build`/`bun test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)